### PR TITLE
fix: prevent owner from setting themselves as beneficiary

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -29,6 +29,7 @@ pub enum ContractError {
     InsufficientBalance = 8,
     NotAdmin = 9,
     Paused = 10,
+    InvalidBeneficiary = 11,
 }
 
 #[contract]
@@ -84,6 +85,10 @@ impl TtlVaultContract {
 
         if check_in_interval == 0 {
             panic_with_error!(&env, ContractError::InvalidInterval);
+        }
+
+        if owner == beneficiary {
+            panic_with_error!(&env, ContractError::InvalidBeneficiary);
         }
 
         let vault_id = Self::vault_count(env.clone()) + 1;
@@ -272,6 +277,10 @@ impl TtlVaultContract {
 
         if vault.status != ReleaseStatus::Locked {
             panic_with_error!(&env, ContractError::AlreadyReleased);
+        }
+
+        if vault.owner == new_beneficiary {
+            panic_with_error!(&env, ContractError::InvalidBeneficiary);
         }
 
         vault.beneficiary = new_beneficiary;

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -117,3 +117,18 @@ fn test_paused_blocks_check_in_withdraw_and_trigger_release() {
         ReleaseStatus::Released
     );
 }
+
+#[test]
+#[should_panic(expected = "Error(Contract, #11)")]
+fn test_create_vault_rejects_owner_as_beneficiary() {
+    let (_, owner, _, _, _, client) = setup();
+    client.create_vault(&owner, &owner, &1000);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #11)")]
+fn test_update_beneficiary_rejects_owner_as_beneficiary() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &1000);
+    client.update_beneficiary(&vault_id, &owner);
+}


### PR DESCRIPTION
Title: fix: prevent owner from setting themselves as beneficiary

Body:

## Summary
Closes a bug where a vault owner could designate themselves as the beneficiary, defeating the dead man's switch 
mechanism entirely.

## Changes
- Added InvalidBeneficiary = 11 to ContractError
- Added owner == beneficiary guard in create_vault
- Added owner == new_beneficiary guard in update_beneficiary
- Added tests for both rejection paths (Error(Contract, #11))

## Why both entry points?
An owner could bypass create_vault validation by calling update_beneficiary after vault creation, so both are guarded.

## Testing
- test_create_vault_rejects_owner_as_beneficiary
- test_update_beneficiary_rejects_owner_as_beneficiary
- closes #11 
