### PR TITLE
feat: beneficiary index, upgrade, min/max interval enforcement

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, panic_with_error, symbol_short, token, Address, Env,
-    String, Vec,
+    contract, contracterror, contractimpl, panic_with_error, symbol_short, token, Address,
+    BytesN, Env, String, Vec,
 };
 
 mod types;
@@ -33,12 +33,11 @@ pub enum ContractError {
     InsufficientBalance = 8,
     NotAdmin = 9,
     Paused = 10,
-feat/ttl-vault-admin-transfer
     NoPendingAdmin = 11,
-
-    InvalidBps = 11,
-    NotExpiringSoon = 12,
- main
+    InvalidBps = 12,
+    NotExpiringSoon = 13,
+    IntervalTooLow = 14,
+    IntervalTooHigh = 15,
 }
 
 #[contract]
@@ -71,6 +70,36 @@ impl TtlVaultContract {
         env.storage().instance().set(&DataKey::Paused, &false);
     }
 
+    pub fn set_min_check_in_interval(env: Env, min_interval: u64) {
+        Self::require_admin(&env);
+        if min_interval == 0 {
+            panic_with_error!(&env, ContractError::InvalidInterval);
+        }
+        env.storage().instance().set(&DataKey::MinCheckInInterval, &min_interval);
+    }
+
+    pub fn set_max_check_in_interval(env: Env, max_interval: u64) {
+        Self::require_admin(&env);
+        if max_interval == 0 {
+            panic_with_error!(&env, ContractError::InvalidInterval);
+        }
+        env.storage().instance().set(&DataKey::MaxCheckInInterval, &max_interval);
+    }
+
+    pub fn get_min_check_in_interval(env: Env) -> Option<u64> {
+        env.storage().instance().get(&DataKey::MinCheckInInterval)
+    }
+
+    pub fn get_max_check_in_interval(env: Env) -> Option<u64> {
+        env.storage().instance().get(&DataKey::MaxCheckInInterval)
+    }
+
+    /// Admin-only. Upgrades the contract to a new WASM hash.
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) {
+        Self::require_admin(&env);
+        env.deployer().update_current_contract_wasm(new_wasm_hash);
+    }
+
     pub fn is_paused(env: Env) -> bool {
         Self::load_paused(&env)
     }
@@ -94,6 +123,7 @@ impl TtlVaultContract {
         if check_in_interval == 0 {
             panic_with_error!(&env, ContractError::InvalidInterval);
         }
+        Self::assert_interval_in_bounds(&env, check_in_interval);
         let vault_id = Self::vault_count(env.clone()) + 1;
         let vault = Vault {
             owner: owner.clone(),
@@ -107,6 +137,7 @@ impl TtlVaultContract {
         };
         Self::save_vault(&env, vault_id, &vault);
         Self::add_owner_vault_id(&env, &owner, vault_id);
+        Self::add_beneficiary_vault_id(&env, &beneficiary, vault_id);
         env.storage().instance().set(&DataKey::VaultCount, &vault_id);
         env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
         env.events().publish(
@@ -353,6 +384,10 @@ impl TtlVaultContract {
         Self::load_owner_vault_ids(&env, &owner)
     }
 
+    pub fn get_vaults_by_beneficiary(env: Env, beneficiary: Address) -> Vec<u64> {
+        Self::load_beneficiary_vault_ids(&env, &beneficiary)
+    }
+
     pub fn get_ttl_remaining(env: Env, vault_id: u64) -> Option<u64> {
         let vault: Vault = env.storage().persistent().get(&DataKey::Vault(vault_id))?;
         let deadline = vault.last_check_in + vault.check_in_interval;
@@ -393,6 +428,7 @@ impl TtlVaultContract {
         if new_interval == 0 {
             return Err(ContractError::InvalidInterval);
         }
+        Self::assert_interval_in_bounds(&env, new_interval);
         let mut vault = Self::load_vault(&env, vault_id);
         vault.owner.require_auth();
         if vault.status != ReleaseStatus::Locked {
@@ -516,5 +552,37 @@ impl TtlVaultContract {
         let key = DataKey::Vault(vault_id);
         env.storage().persistent().set(&key, vault);
         env.storage().persistent().extend_ttl(&key, VAULT_TTL_THRESHOLD, VAULT_TTL_LEDGERS);
+    }
+
+    fn load_beneficiary_vault_ids(env: &Env, beneficiary: &Address) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::BeneficiaryVaults(beneficiary.clone()))
+            .unwrap_or(Vec::new(env))
+    }
+
+    fn save_beneficiary_vault_ids(env: &Env, beneficiary: &Address, vault_ids: &Vec<u64>) {
+        let key = DataKey::BeneficiaryVaults(beneficiary.clone());
+        env.storage().persistent().set(&key, vault_ids);
+        env.storage().persistent().extend_ttl(&key, VAULT_TTL_THRESHOLD, VAULT_TTL_LEDGERS);
+    }
+
+    fn add_beneficiary_vault_id(env: &Env, beneficiary: &Address, vault_id: u64) {
+        let mut vault_ids = Self::load_beneficiary_vault_ids(env, beneficiary);
+        vault_ids.push_back(vault_id);
+        Self::save_beneficiary_vault_ids(env, beneficiary, &vault_ids);
+    }
+
+    fn assert_interval_in_bounds(env: &Env, interval: u64) {
+        if let Some(min) = env.storage().instance().get::<DataKey, u64>(&DataKey::MinCheckInInterval) {
+            if interval < min {
+                panic_with_error!(env, ContractError::IntervalTooLow);
+            }
+        }
+        if let Some(max) = env.storage().instance().get::<DataKey, u64>(&DataKey::MaxCheckInInterval) {
+            if interval > max {
+                panic_with_error!(env, ContractError::IntervalTooHigh);
+            }
+        }
     }
 }

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -4,7 +4,7 @@ use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     token::{self, StellarAssetClient},
-    vec, Address, Env,
+    vec, Address, BytesN, Env,
 };
 
 fn setup() -> (
@@ -522,4 +522,125 @@ fn test_create_vault_zero_interval_fails() {
 
     let result = client.try_create_vault(&owner, &beneficiary, &0u64);
     assert!(result.is_err());
+}
+
+// ---- Issue 1: get_vaults_by_beneficiary ----
+
+#[test]
+fn test_get_vaults_by_beneficiary_tracks_vaults() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let other_beneficiary = Address::generate(&env);
+
+    assert_eq!(client.get_vaults_by_beneficiary(&beneficiary), vec![&env]);
+
+    let vault_id_1 = client.create_vault(&owner, &beneficiary, &100u64);
+    let vault_id_2 = client.create_vault(&owner, &beneficiary, &200u64);
+    let _vault_id_3 = client.create_vault(&owner, &other_beneficiary, &300u64);
+
+    assert_eq!(
+        client.get_vaults_by_beneficiary(&beneficiary),
+        vec![&env, vault_id_1, vault_id_2]
+    );
+    assert_eq!(
+        client.get_vaults_by_beneficiary(&other_beneficiary),
+        vec![&env, _vault_id_3]
+    );
+}
+
+#[test]
+fn test_get_vaults_by_beneficiary_empty_for_unknown() {
+    let (env, _, _, _, _, client) = setup();
+    let stranger = Address::generate(&env);
+    assert_eq!(client.get_vaults_by_beneficiary(&stranger), vec![&env]);
+}
+
+// ---- Issue 2: upgrade ----
+
+#[test]
+#[should_panic]
+fn test_upgrade_fails_for_non_admin() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let _vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+    // Use a zero hash — this will fail auth before even reaching deployer
+    let fake_hash = BytesN::from_array(&env, &[0u8; 32]);
+    // Call upgrade as owner (not admin) — should panic with NotAdmin
+    client.with_source_address(&owner).upgrade(&fake_hash);
+}
+
+// ---- Issue 3: max_check_in_interval ----
+
+#[test]
+fn test_set_and_get_max_check_in_interval() {
+    let (_, _, _, _, _, client) = setup();
+    assert_eq!(client.get_max_check_in_interval(), None);
+    client.set_max_check_in_interval(&86_400u64);
+    assert_eq!(client.get_max_check_in_interval(), Some(86_400u64));
+}
+
+#[test]
+fn test_create_vault_fails_when_interval_exceeds_max() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    client.set_max_check_in_interval(&1_000u64);
+    assert!(client.try_create_vault(&owner, &beneficiary, &2_000u64).is_err());
+}
+
+#[test]
+fn test_create_vault_succeeds_at_max_boundary() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    client.set_max_check_in_interval(&1_000u64);
+    let vault_id = client.create_vault(&owner, &beneficiary, &1_000u64);
+    assert_eq!(client.get_vault(&vault_id).check_in_interval, 1_000u64);
+}
+
+#[test]
+fn test_update_check_in_interval_fails_when_exceeds_max() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+    client.set_max_check_in_interval(&500u64);
+    assert!(client.try_update_check_in_interval(&vault_id, &600u64).is_err());
+}
+
+// ---- Issue 4: min_check_in_interval ----
+
+#[test]
+fn test_set_and_get_min_check_in_interval() {
+    let (_, _, _, _, _, client) = setup();
+    assert_eq!(client.get_min_check_in_interval(), None);
+    client.set_min_check_in_interval(&60u64);
+    assert_eq!(client.get_min_check_in_interval(), Some(60u64));
+}
+
+#[test]
+fn test_create_vault_fails_when_interval_below_min() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    client.set_min_check_in_interval(&3_600u64);
+    assert!(client.try_create_vault(&owner, &beneficiary, &100u64).is_err());
+}
+
+#[test]
+fn test_create_vault_succeeds_at_min_boundary() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    client.set_min_check_in_interval(&3_600u64);
+    let vault_id = client.create_vault(&owner, &beneficiary, &3_600u64);
+    assert_eq!(client.get_vault(&vault_id).check_in_interval, 3_600u64);
+}
+
+#[test]
+fn test_update_check_in_interval_fails_when_below_min() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    client.set_min_check_in_interval(&3_600u64);
+    let vault_id = client.create_vault(&owner, &beneficiary, &3_600u64);
+    assert!(client.try_update_check_in_interval(&vault_id, &100u64).is_err());
+}
+
+#[test]
+fn test_min_and_max_both_enforced() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    client.set_min_check_in_interval(&60u64);
+    client.set_max_check_in_interval(&3_600u64);
+
+    assert!(client.try_create_vault(&owner, &beneficiary, &30u64).is_err());
+    assert!(client.try_create_vault(&owner, &beneficiary, &7_200u64).is_err());
+    let vault_id = client.create_vault(&owner, &beneficiary, &1_800u64);
+    assert_eq!(client.get_vault(&vault_id).check_in_interval, 1_800u64);
 }

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -12,11 +12,14 @@ pub const EXPIRY_WARNING_THRESHOLD: u64 = 86_400; // 24 hours
 pub enum DataKey {
     Vault(u64),
     OwnerVaults(Address),
+    BeneficiaryVaults(Address),
     VaultCount,
     TokenAddress,
     Admin,
     Paused,
     PendingAdmin,
+    MinCheckInInterval,
+    MaxCheckInInterval,
 }
 
 #[contracttype]


### PR DESCRIPTION
Issue 1 - get_vaults_by_beneficiary:
- Added BeneficiaryVaults(Address) key to DataKey enum
- Track beneficiary -> vault IDs on create_vault
- Added get_vaults_by_beneficiary(beneficiary) view
- Added load/save/add beneficiary vault ID helpers
- Added tests: tracks multiple vaults, empty for unknown address

Issue 2 - Contract upgrade mechanism:
- Added upgrade(new_wasm_hash: BytesN<32>) admin-only function
- Uses env.deployer().update_current_contract_wasm()
- Added test: non-admin cannot call upgrade

Issue 3 - Max check-in interval:
- Added MaxCheckInInterval key to DataKey enum
- Added set_max_check_in_interval(max) admin-only function
- Added get_max_check_in_interval() view
- Enforced in create_vault and update_check_in_interval via assert_interval_in_bounds
- Added tests: set/get, create fails above max, succeeds at boundary, update fails above max

Issue 4 - Min check-in interval:
- Added MinCheckInInterval key to DataKey enum
- Added set_min_check_in_interval(min) admin-only function
- Added get_min_check_in_interval() view
- Enforced in create_vault and update_check_in_interval via assert_interval_in_bounds
- Added tests: set/get, create fails below min, succeeds at boundary, update fails below min, both bounds enforced together

Also fixed duplicate ContractError discriminant (NoPendingAdmin and InvalidBps both had value 11)
- NoPendingAdmin = 11, InvalidBps = 12, NotExpiringSoon = 13
- Added IntervalTooLow = 14, IntervalTooHigh = 15

closes #29 
closes #30 
closes #31 
closes #32 