### PR TITLE
Add test: non-owner cannot call check_in (#48)

### DIFF
--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -644,3 +644,18 @@ fn test_min_and_max_both_enforced() {
     let vault_id = client.create_vault(&owner, &beneficiary, &1_800u64);
     assert_eq!(client.get_vault(&vault_id).check_in_interval, 1_800u64);
 }
+
+// ---- Issue 48: non-owner cannot call check_in ----
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_non_owner_cannot_call_check_in() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let non_owner = Address::generate(&env);
+
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+
+    // Call check_in from non-owner address - should panic with NotOwner error
+    client.with_source_address(&non_owner).check_in(&vault_id, &non_owner);
+    let _ = env;
+}


### PR DESCRIPTION
## Summary
Add test to verify that a non-owner address cannot successfully call `check_in`.

## Tasks Completed
- Create vault with owner A
- Call check_in from address B (non-owner)
- Assert auth error (NotOwner = #6)

## Test Details
- **File modified**: `contracts/ttl_vault/src/test.rs`
- **Test function**: `test_non_owner_cannot_call_check_in`
- **Expected behavior**: Panics with `Error(Contract, #6)` (NotOwner error) when a non-owner attempts to call check_in

## Category
Smart Contract - Testing
closes #48 