### PR TITLE
feat:fix: add zero-amount withdrawal guard and rejection tests

### DIFF
--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -206,3 +206,27 @@ fn test_deposit_into_expired_vault_is_rejected() {
     env.ledger().with_mut(|l| l.timestamp += 200);
     client.deposit(&vault_id, &owner, &500i128);
 }
+
+#[test]
+fn test_withdraw_rejects_zero_amount() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+    client.deposit(&vault_id, &owner, &500i128);
+
+    // zero amount should return InvalidAmount (#5)
+    let result = client.try_withdraw(&vault_id, &0i128);
+    assert!(result.is_err(), "expected error for zero-amount withdrawal");
+}
+
+#[test]
+fn test_withdraw_rejects_negative_amount() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+    client.deposit(&vault_id, &owner, &500i128);
+
+    // negative amount should also return InvalidAmount (#5)
+    let result = client.try_withdraw(&vault_id, &-1i128);
+    assert!(result.is_err(), "expected error for negative-amount withdrawal");
+}


### PR DESCRIPTION
Body:
Category: Smart Contract - Bug
Priority: Medium
Estimated Time: 30 minutes

Description:
withdraw has no guard against amount <= 0. A zero-amount withdrawal passes all checks and executes a no-op token transfer.

Tasks:

Add assert!(amount > 0, "amount must be positive") guard
Add test for zero-amount withdrawal rejection
closes #18 