### PR TITLE
feat:fix: emit deposit and withdraw events with vault_id, amount, new_balance

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -8,7 +8,7 @@ use soroban_sdk::{
 mod types;
 use types::{
     BeneficiaryEntry, DataKey, ReleaseEvent, ReleaseStatus, Vault, EXPIRY_WARNING_THRESHOLD,
-    PING_EXPIRY_TOPIC, RELEASE_TOPIC, VAULT_CREATED_TOPIC,
+    DEPOSIT_TOPIC, WITHDRAW_TOPIC, PING_EXPIRY_TOPIC, RELEASE_TOPIC, VAULT_CREATED_TOPIC,
 };
 
 #[cfg(test)]
@@ -187,6 +187,10 @@ impl TtlVaultContract {
         xlm.transfer(&from, &env.current_contract_address(), &amount);
         vault.balance += amount;
         Self::save_vault(&env, vault_id, &vault);
+        env.events().publish(
+            (DEPOSIT_TOPIC, vault_id),
+            (amount, vault.balance),
+        );
     }
 
  feat/batch-deposit
@@ -250,6 +254,10 @@ impl TtlVaultContract {
         xlm.transfer(&env.current_contract_address(), &vault.owner, &amount);
         vault.balance -= amount;
         Self::save_vault(&env, vault_id, &vault);
+        env.events().publish(
+            (WITHDRAW_TOPIC, vault_id),
+            (amount, vault.balance),
+        );
         Ok(())
     }
 

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -206,3 +206,49 @@ fn test_deposit_into_expired_vault_is_rejected() {
     env.ledger().with_mut(|l| l.timestamp += 200);
     client.deposit(&vault_id, &owner, &500i128);
 }
+
+#[test]
+fn test_deposit_emits_event() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+
+    env.mock_all_auths();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+
+    client.deposit(&vault_id, &owner, &300i128);
+
+    let events = env.events().all();
+    // find the deposit event: topic[0] == "deposit", topic[1] == vault_id
+    let deposit_event = events.iter().find(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
+        if topics.len() < 2 {
+            return false;
+        }
+        let topic0: Result<soroban_sdk::Symbol, _> = topics.get(0).unwrap().try_into_val(&env);
+        topic0.map(|s| s == soroban_sdk::symbol_short!("deposit")).unwrap_or(false)
+    });
+
+    assert!(deposit_event.is_some(), "deposit event not emitted");
+}
+
+#[test]
+fn test_withdraw_emits_event() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+
+    env.mock_all_auths();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+    client.deposit(&vault_id, &owner, &500i128);
+
+    client.withdraw(&vault_id, &100i128);
+
+    let events = env.events().all();
+    let withdraw_event = events.iter().find(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
+        if topics.len() < 2 {
+            return false;
+        }
+        let topic0: Result<soroban_sdk::Symbol, _> = topics.get(0).unwrap().try_into_val(&env);
+        topic0.map(|s| s == soroban_sdk::symbol_short!("withdraw")).unwrap_or(false)
+    });
+
+    assert!(withdraw_event.is_some(), "withdraw event not emitted");
+}

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -3,6 +3,8 @@ use soroban_sdk::{contracttype, symbol_short, Address, String, Symbol, Vec};
 pub const RELEASE_TOPIC: Symbol = symbol_short!("release");
 pub const VAULT_CREATED_TOPIC: Symbol = symbol_short!("v_created");
 pub const PING_EXPIRY_TOPIC: Symbol = symbol_short!("ping_exp");
+pub const DEPOSIT_TOPIC: Symbol = symbol_short!("deposit");
+pub const WITHDRAW_TOPIC: Symbol = symbol_short!("withdraw");
 
 /// Warning threshold in seconds. If TTL remaining < this value, ping_expiry emits an event.
 pub const EXPIRY_WARNING_THRESHOLD: u64 = 86_400; // 24 hours


### PR DESCRIPTION
Body:
Category: Smart Contract - Bug
Priority: Medium
Estimated Time: 1 hour

Description:
deposit and withdraw do not emit on-chain events. Balance changes are invisible to off-chain listeners.

Tasks:

Add env.events().publish in deposit and withdraw
Define event topics and data (vault_id, amount, new_balance)
Add tests asserting events are emitted
closes #17 