### PR TITLE
feat:fix: emit release event for zero-balance vault in trigger_release

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -263,14 +263,13 @@ impl TtlVaultContract {
         if !Self::is_expired(env.clone(), vault_id) {
             panic!("vault not yet expired");
         }
-        if vault.balance == 0 {
-            panic_with_error!(&env, ContractError::EmptyVault);
-        }
         let total = vault.balance;
         let xlm = token::Client::new(&env, &Self::load_token(&env));
 
         if vault.beneficiaries.is_empty() {
-            xlm.transfer(&env.current_contract_address(), &vault.beneficiary, &total);
+            if total > 0 {
+                xlm.transfer(&env.current_contract_address(), &vault.beneficiary, &total);
+            }
             env.events().publish(
                 (RELEASE_TOPIC,),
                 ReleaseEvent { vault_id, beneficiary: vault.beneficiary.clone(), amount: total },
@@ -284,7 +283,9 @@ impl TtlVaultContract {
                 } else {
                     total * (entry.bps as i128) / 10_000
                 };
-                xlm.transfer(&env.current_contract_address(), &entry.address, &share);
+                if share > 0 {
+                    xlm.transfer(&env.current_contract_address(), &entry.address, &share);
+                }
                 distributed += share;
                 env.events().publish(
                     (RELEASE_TOPIC,),

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -206,3 +206,29 @@ fn test_deposit_into_expired_vault_is_rejected() {
     env.ledger().with_mut(|l| l.timestamp += 200);
     client.deposit(&vault_id, &owner, &500i128);
 }
+
+#[test]
+fn test_trigger_release_emits_event_with_zero_balance() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+
+    // create vault but never deposit — balance stays 0
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+    env.ledger().with_mut(|l| l.timestamp += 200);
+
+    // should succeed and emit a release event with amount: 0
+    client.trigger_release(&vault_id);
+
+    assert_eq!(client.get_release_status(&vault_id), ReleaseStatus::Released);
+
+    let events = env.events().all();
+    let release_event = events.iter().find(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
+        if topics.len() < 1 {
+            return false;
+        }
+        let topic0: Result<soroban_sdk::Symbol, _> = topics.get(0).unwrap().try_into_val(&env);
+        topic0.map(|s| s == soroban_sdk::symbol_short!("release")).unwrap_or(false)
+    });
+
+    assert!(release_event.is_some(), "release event not emitted for zero-balance vault");
+}


### PR DESCRIPTION
Body:
Category: Smart Contract - Bug
Priority: Low
Estimated Time: 30 minutes

Description:
When vault.balance == 0, trigger_release skips the token transfer but still marks the vault as Released. No event is emitted in either case.

Tasks:

Emit release event regardless of balance
Include amount: 0 in event data for zero-balance releases
Add test
closes #20 