### PR TITLE
feat: fix: use checked_add for vault balance to prevent i128 overflow

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -34,6 +34,7 @@ pub enum ContractError {
     NotAdmin = 9,
     Paused = 10,
     InvalidBeneficiary = 11,
+    BalanceOverflow = 12,
 }
 
 #[contract]
@@ -185,7 +186,9 @@ impl TtlVaultContract {
 
         let xlm = token::Client::new(&env, &Self::load_token(&env));
         xlm.transfer(&from, &env.current_contract_address(), &amount);
-        vault.balance += amount;
+        vault.balance = vault.balance
+            .checked_add(amount)
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::BalanceOverflow));
         Self::save_vault(&env, vault_id, &vault);
     }
 
@@ -224,7 +227,9 @@ impl TtlVaultContract {
 
         for validated_deposit in validated.iter() {
             let (vault_id, mut vault, amount) = validated_deposit;
-            vault.balance += amount;
+            vault.balance = vault.balance
+                .checked_add(amount)
+                .unwrap_or_else(|| panic_with_error!(&env, ContractError::BalanceOverflow));
             Self::save_vault(&env, vault_id, &vault);
         }
     }

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -206,3 +206,22 @@ fn test_deposit_into_expired_vault_is_rejected() {
     env.ledger().with_mut(|l| l.timestamp += 200);
     client.deposit(&vault_id, &owner, &500i128);
 }
+
+#[test]
+fn test_deposit_rejects_balance_overflow() {
+    let (env, owner, beneficiary, _, token_address, client) = setup();
+
+    // mint enough tokens to attempt the overflow deposit
+    StellarAssetClient::new(&env, &token_address).mint(&owner, &i128::MAX);
+
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+
+    // first deposit fills balance to i128::MAX
+    client.deposit(&vault_id, &owner, &i128::MAX);
+
+    // mint 1 more token and attempt to push balance past i128::MAX
+    StellarAssetClient::new(&env, &token_address).mint(&owner, &1i128);
+    let result = client.try_deposit(&vault_id, &owner, &1i128);
+
+    assert!(result.is_err(), "expected overflow error on deposit exceeding i128::MAX");
+}


### PR DESCRIPTION
Body:
Category: Smart Contract - Bug
Priority: Medium
Estimated Time: 1 hour

Description:
vault.balance += amount uses unchecked addition. Repeated large deposits could overflow i128.

Tasks:

Use checked addition for vault.balance += amount
Panic with structured error on overflow
Add test for overflow scenario
close #19 