### PR TITLE
fix: ping_expiry panics with VaultNotFound for non-existent vaults

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -507,7 +507,8 @@ impl TtlVaultContract {
     /// # Returns
     /// The remaining TTL in seconds (0 if expired)
     pub fn ping_expiry(env: Env, vault_id: u64) -> u64 {
-        let ttl = Self::get_ttl_remaining(env.clone(), vault_id).unwrap_or(0);
+        let ttl = Self::get_ttl_remaining(env.clone(), vault_id)
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::VaultNotFound));
         if ttl < EXPIRY_WARNING_THRESHOLD {
             env.events().publish((PING_EXPIRY_TOPIC, vault_id), ttl);
         }

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -320,6 +320,13 @@ fn test_ping_expiry_returns_zero_when_expired() {
     assert_eq!(ttl, 0u64);
 }
 
+#[test]
+#[should_panic]
+fn test_ping_expiry_panics_for_nonexistent_vault() {
+    let (_, _, _, _, _, client) = setup();
+    client.ping_expiry(&9999u64);
+}
+
 // ---- Task 2: partial_release tests ----
 
 #[test]


### PR DESCRIPTION
Fix: ping_expiry panics with VaultNotFound for non-existent vaults

Problem

ping_expiry called get_ttl_remaining which returns None for non-existent vault IDs. The unwrap_or(0) silently treated missing vaults as expired, causing a
spurious ping_exp event to be emitted with TTL=0 — misleading callers into thinking a real vault had expired.

Changes

- contracts/ttl_vault/src/lib.rs: Replace unwrap_or(0) with unwrap_or_else(|| panic_with_error!(&env, ContractError::VaultNotFound)) in ping_expiry, so 
callers get a clear error instead of silent bad data.
- contracts/ttl_vault/src/test.rs: Add test_ping_expiry_panics_for_nonexistent_vault — verifies the function panics when called with a vault ID that doesn
't exist.

Testing

test_ping_expiry_panics_for_nonexistent_vault  ← new
test_ping_expiry_emits_event_when_near_expiry  ← existing, unaffected
test_ping_expiry_no_event_when_far_from_expiry ← existing, unaffected
test_ping_expiry_returns_zero_when_expired     ← existing, unaffected


Closes #110