### PR TITLE
fix: use VaultExpired error when depositing into an expired vault

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -41,6 +41,7 @@ pub enum ContractError {
     NotExpired = 16,
     InvalidBeneficiary = 11,
     BalanceOverflow = 12,
+    VaultExpired = 17,
 }
 
 #[contract]
@@ -320,7 +321,7 @@ impl TtlVaultContract {
 
         let now = env.ledger().timestamp();
         if now >= vault.last_check_in + vault.check_in_interval {
-            panic_with_error!(&env, ContractError::AlreadyReleased);
+            panic_with_error!(&env, ContractError::VaultExpired);
         }
 
         let xlm = token::Client::new(&env, &Self::load_token(&env));

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -348,17 +348,12 @@ fn test_update_beneficiary_rejects_owner_as_beneficiary() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #7)")]
+#[should_panic(expected = "Error(Contract, #17)")]
 fn test_deposit_into_expired_vault_is_rejected() {
     let (env, owner, beneficiary, _, _, client) = setup();
     let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
     env.ledger().with_mut(|l| l.timestamp += 200);
     client.deposit(&vault_id, &owner, &500i128);
-    env.ledger().with_mut(|l| l.timestamp += 200);
-    client.trigger_release(&vault_id);
-
-    let label = soroban_sdk::String::from_str(&env, "too late");
-    assert!(client.try_update_metadata(&vault_id, &label).is_err());
 }
 
 #[test]


### PR DESCRIPTION
Fix: deposit uses VaultExpired instead of AlreadyReleased for expired vaults

Problem

When a vault's check-in interval lapses but trigger_release hasn't been called yet, deposit was panicking with ContractError::AlreadyReleased (#7). This 
is semantically wrong — the vault is expired (owner missed check-in) but not yet released (funds haven't moved). Callers relying on the error code to 
distinguish these two states would misinterpret the situation.

Changes

- contracts/ttl_vault/src/lib.rs:
  - Add ContractError::VaultExpired = 17 to the error enum
  - Replace AlreadyReleased with VaultExpired in the deposit expiry guard
- contracts/ttl_vault/src/test.rs:
  - Update test_deposit_into_expired_vault_is_rejected to assert Error(Contract, #17)
  - Remove the dead post-panic assertions that could never execute

Why = 17

The existing enum has duplicate discriminants (11 and 12 appear twice). 17 is the next clean unused value.

Closes #111