### PR TITLE
fix: derive vault persistent TTL dynamically from check_in_interval

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -19,6 +19,21 @@ pub const VAULT_TTL_LEDGERS: u32 = 200_000;
 pub const INSTANCE_TTL_THRESHOLD: u32 = 1000;
 pub const INSTANCE_TTL_LEDGERS: u32 = 200_000;
 
+/// Approximate ledger close time in seconds (Stellar mainnet ~5s).
+const LEDGER_SECOND: u32 = 5;
+/// Soroban maximum persistent entry TTL in ledgers (~180 days at 5s/ledger).
+const MAX_PERSISTENT_TTL: u32 = 3_110_400;
+
+/// Compute a persistent storage TTL (in ledgers) for a vault with the given
+/// check-in interval. Applies a 2× safety buffer so storage outlives the
+/// interval, capped at the Soroban maximum.
+fn vault_ttl_ledgers(check_in_interval: u64) -> u32 {
+    let ledgers = (check_in_interval as u32)
+        .saturating_mul(2)
+        .saturating_div(LEDGER_SECOND);
+    ledgers.max(VAULT_TTL_LEDGERS).min(MAX_PERSISTENT_TTL)
+}
+
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -984,8 +999,9 @@ impl TtlVaultContract {
 
     fn save_vault(env: &Env, vault_id: u64, vault: &Vault) {
         let key = DataKey::Vault(vault_id);
+        let ttl = vault_ttl_ledgers(vault.check_in_interval);
         env.storage().persistent().set(&key, vault);
-        env.storage().persistent().extend_ttl(&key, VAULT_TTL_THRESHOLD, VAULT_TTL_LEDGERS);
+        env.storage().persistent().extend_ttl(&key, VAULT_TTL_THRESHOLD, ttl);
     }
 
     fn load_beneficiary_vault_ids(env: &Env, beneficiary: &Address) -> Vec<u64> {

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -389,6 +389,19 @@ fn test_create_vault_zero_interval_fails() {
     assert!(result.is_err());
 }
 
+#[test]
+fn test_create_vault_long_interval_remains_accessible() {
+    // 30-day check-in interval: vault storage TTL must outlive the interval.
+    // vault_ttl_ledgers(2_592_000) = 2_592_000 * 2 / 5 = 1_036_800 ledgers (~60 days).
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let thirty_days: u64 = 30 * 24 * 3600; // 2_592_000 seconds
+    let vault_id = client.create_vault(&owner, &beneficiary, &thirty_days);
+    // Advance just under the interval — vault must still be readable.
+    env.ledger().with_mut(|l| l.timestamp += thirty_days - 1);
+    let vault = client.get_vault(&vault_id);
+    assert_eq!(vault.check_in_interval, thirty_days);
+}
+
 // ---- Issue 1: get_vaults_by_beneficiary ----
 
 #[test]


### PR DESCRIPTION
Fix: derive vault persistent TTL dynamically from check_in_interval

Problem

VAULT_TTL_LEDGERS = 200_000 (~11 days at 5s/ledger) was applied unconditionally to every vault's persistent storage entry. A vault configured with a 30-
day check-in interval would have its storage archived before the owner's next check-in was even due, causing VaultNotFound panics on what should be a 
perfectly healthy vault.

Changes

- lib.rs: Add vault_ttl_ledgers(check_in_interval: u64) -> u32 — converts the interval from seconds to ledgers (interval * 2 / 5), applying a 2× safety 
buffer so storage always outlives the interval. Floored at the existing VAULT_TTL_LEDGERS (200,000) for short-interval vaults, capped at 
MAX_PERSISTENT_TTL (3,110,400 ledgers ≈ 180 days, Soroban's persistent entry maximum).
- save_vault: use vault_ttl_ledgers(vault.check_in_interval) instead of the fixed constant.
- test.rs: add test_create_vault_long_interval_remains_accessible — creates a vault with a 30-day interval, advances the ledger to just before expiry, and
asserts the vault is still readable.

TTL examples

| Interval | Storage TTL (ledgers) | ~Days |
|---|---|---|
| 100s (default test) | 200,000 (floor) | ~11 |
| 30 days | 1,036,800 | ~60 |
| 90 days | 3,110,400 (cap) | ~180 |

Closes #113