### PR TITLE
fix: validate xlm_token != admin in initialize (#108) and remove dupl…

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -57,6 +57,7 @@ pub enum ContractError {
     InvalidBeneficiary = 11,
     BalanceOverflow = 12,
     VaultExpired = 17,
+    InvalidAdmin = 18,
 }
 
 #[contract]
@@ -83,6 +84,9 @@ impl TtlVaultContract {
             || env.storage().instance().has(&DataKey::Admin)
         {
             panic_with_error!(&env, ContractError::AlreadyInitialized);
+        }
+        if xlm_token == admin {
+            panic_with_error!(&env, ContractError::InvalidAdmin);
         }
         admin.require_auth();
         env.storage().instance().set(&DataKey::TokenAddress, &xlm_token);
@@ -249,8 +253,6 @@ impl TtlVaultContract {
         }
 
         let vault_id = Self::vault_count(env.clone()) + 1;
-
-        let vault_id = Self::vault_count(env.clone()) + 1;
         let vault = Vault {
             owner: owner.clone(),
             beneficiary: beneficiary.clone(),
@@ -264,6 +266,9 @@ impl TtlVaultContract {
         Self::save_vault(&env, vault_id, &vault);
         Self::add_owner_vault_id(&env, &owner, vault_id);
         Self::add_beneficiary_vault_id(&env, &beneficiary, vault_id);
+        // VaultCount is updated only after all vault data is written. If any
+        // prior storage call panics, the count is not advanced, keeping it
+        // consistent with the number of successfully persisted vaults.
         env.storage().instance().set(&DataKey::VaultCount, &vault_id);
         env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
         env.events().publish(

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -55,6 +55,17 @@ fn test_initialize_guard_against_double_init() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #18)")]
+fn test_initialize_rejects_same_xlm_token_and_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let addr = Address::generate(&env);
+    let contract_address = env.register_contract(None, TtlVaultContract);
+    let client = TtlVaultContractClient::new(&env, &contract_address);
+    client.initialize(&addr, &addr);
+}
+
+#[test]
 fn test_vault_count_view() {
     let (_, owner, beneficiary, _, _, client) = setup();
 
@@ -265,6 +276,15 @@ fn test_admin_transfer_full_flow() {
 fn test_create_vault_rejects_owner_as_beneficiary() {
     let (_, owner, _, _, _, client) = setup();
     client.create_vault(&owner, &owner, &1000);
+}
+
+#[test]
+fn test_vault_count_consistent_after_creation() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    assert_eq!(client.vault_count(), 0);
+    let id = client.create_vault(&owner, &beneficiary, &1000);
+    assert_eq!(id, 1);
+    assert_eq!(client.vault_count(), 1);
 }
 
 #[test]


### PR DESCRIPTION
closes #108 
closes #109 

Fix: initialize address validation & vault count ordering (#108, #109)

#108 — initialize rejects identical xlm_token and admin addresses

Passing the same address for both parameters was silently accepted, which would cause the admin 
address to be treated as a token contract. Added an explicit guard that panics with InvalidAdmin 
(#18) if the two addresses are equal.

Changes:
- Added InvalidAdmin = 18 to ContractError
- Added xlm_token != admin assertion in initialize before require_auth()
- Added test_initialize_rejects_same_xlm_token_and_admin

#109 — Remove duplicate vault_id assignment in create_vault

A duplicate let vault_id = ... line existed in create_vault. Removed the redundant line and added
a comment documenting the intentional ordering: VaultCount is written last so that a panic in 
any prior storage call leaves the count consistent with the number of successfully persisted 
vaults.

Changes:
- Removed duplicate let vault_id = Self::vault_count(env.clone()) + 1
- Added ordering comment above VaultCount set
- Added test_vault_count_consistent_after_creation