### PR TITLE
feat: add pagination, event topic constants, and missing events

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -8,7 +8,8 @@ use soroban_sdk::{
 mod types;
 use types::{
     BeneficiaryEntry, DataKey, ReleaseEvent, ReleaseStatus, Vault, EXPIRY_WARNING_THRESHOLD,
-    DEPOSIT_TOPIC, WITHDRAW_TOPIC, PING_EXPIRY_TOPIC, RELEASE_TOPIC, VAULT_CREATED_TOPIC,
+    CANCEL_TOPIC, CHECK_IN_TOPIC, DEPOSIT_TOPIC, OWNERSHIP_TOPIC, PING_EXPIRY_TOPIC,
+    RELEASE_TOPIC, VAULT_CREATED_TOPIC, WITHDRAW_TOPIC,
 };
 
 #[cfg(test)]
@@ -304,7 +305,7 @@ impl TtlVaultContract {
         }
         vault.last_check_in = env.ledger().timestamp();
         Self::save_vault(&env, vault_id, &vault);
-        env.events().publish((symbol_short!("check_in"), vault_id), vault.last_check_in);
+        env.events().publish((CHECK_IN_TOPIC, vault_id), vault.last_check_in);
         Ok(())
     }
 
@@ -693,28 +694,34 @@ impl TtlVaultContract {
         Self::try_load_vault(&env, vault_id).is_some()
     }
 
-    /// Returns all vault IDs owned by a specific address.
+    /// Returns a paginated slice of vault IDs owned by a specific address.
     ///
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `owner` - The owner address
+    /// * `page` - Zero-based page index
+    /// * `page_size` - Number of items per page
     ///
     /// # Returns
-    /// A vector of vault IDs
-    pub fn get_vaults_by_owner(env: Env, owner: Address) -> Vec<u64> {
-        Self::load_owner_vault_ids(&env, &owner)
+    /// A vector of vault IDs for the requested page
+    pub fn get_vaults_by_owner(env: Env, owner: Address, page: u32, page_size: u32) -> Vec<u64> {
+        let all = Self::load_owner_vault_ids(&env, &owner);
+        Self::paginate(&env, all, page, page_size)
     }
 
-    /// Returns all vault IDs where a specific address is the beneficiary.
+    /// Returns a paginated slice of vault IDs where a specific address is the beneficiary.
     ///
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `beneficiary` - The beneficiary address
+    /// * `page` - Zero-based page index
+    /// * `page_size` - Number of items per page
     ///
     /// # Returns
-    /// A vector of vault IDs
-    pub fn get_vaults_by_beneficiary(env: Env, beneficiary: Address) -> Vec<u64> {
-        Self::load_beneficiary_vault_ids(&env, &beneficiary)
+    /// A vector of vault IDs for the requested page
+    pub fn get_vaults_by_beneficiary(env: Env, beneficiary: Address, page: u32, page_size: u32) -> Vec<u64> {
+        let all = Self::load_beneficiary_vault_ids(&env, &beneficiary);
+        Self::paginate(&env, all, page, page_size)
     }
 
     /// Returns the remaining time-to-live (TTL) for a vault in seconds.
@@ -876,6 +883,7 @@ impl TtlVaultContract {
         vault.balance = 0;
         vault.status = ReleaseStatus::Cancelled;
         Self::save_vault(&env, vault_id, &vault);
+        env.events().publish((CANCEL_TOPIC, vault_id), (vault.owner, refund_amount));
         Ok(())
     }
 
@@ -914,12 +922,28 @@ impl TtlVaultContract {
             Self::remove_owner_vault_id(&env, &old_owner, vault_id);
             Self::add_owner_vault_id(&env, &new_owner, vault_id);
         }
-        vault.owner = new_owner;
+        vault.owner = new_owner.clone();
         Self::save_vault(&env, vault_id, &vault);
+        env.events().publish((OWNERSHIP_TOPIC, vault_id), (old_owner, new_owner));
         Ok(())
     }
 
     // --- helpers ---
+
+    fn paginate(env: &Env, all: Vec<u64>, page: u32, page_size: u32) -> Vec<u64> {
+        if page_size == 0 {
+            return Vec::new(env);
+        }
+        let start = (page as u64).saturating_mul(page_size as u64);
+        let len = all.len() as u64;
+        let mut result = Vec::new(env);
+        let mut i = start;
+        while i < len && i < start + page_size as u64 {
+            result.push_back(all.get(i as u32).unwrap());
+            i += 1;
+        }
+        result
+    }
 
     fn assert_not_paused(env: &Env) {
         if Self::load_paused(env) {

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -191,7 +191,7 @@ fn test_get_vaults_by_owner_tracks_multiple_vaults() {
     let vault_id_2 = client.create_vault(&owner, &beneficiary, &200u64);
 
     assert_eq!(
-        client.get_vaults_by_owner(&owner),
+        client.get_vaults_by_owner(&owner, &0u32, &10u32),
         vec![&env, vault_id_1, vault_id_2]
     );
 }
@@ -214,14 +214,14 @@ fn test_transfer_ownership_updates_owner_and_owner_index() {
     let new_owner = Address::generate(&env);
 
     let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
-    assert_eq!(client.get_vaults_by_owner(&owner), vec![&env, vault_id]);
-    assert_eq!(client.get_vaults_by_owner(&new_owner), vec![&env]);
+    assert_eq!(client.get_vaults_by_owner(&owner, &0u32, &10u32), vec![&env, vault_id]);
+    assert_eq!(client.get_vaults_by_owner(&new_owner, &0u32, &10u32), vec![&env]);
 
     client.transfer_ownership(&vault_id, &new_owner);
 
     assert_eq!(client.get_vault(&vault_id).owner, new_owner);
-    assert_eq!(client.get_vaults_by_owner(&owner), vec![&env]);
-    assert_eq!(client.get_vaults_by_owner(&new_owner), vec![&env, vault_id]);
+    assert_eq!(client.get_vaults_by_owner(&owner, &0u32, &10u32), vec![&env]);
+    assert_eq!(client.get_vaults_by_owner(&new_owner, &0u32, &10u32), vec![&env, vault_id]);
 }
 
 #[test]
@@ -419,18 +419,18 @@ fn test_get_vaults_by_beneficiary_tracks_vaults() {
     let (env, owner, beneficiary, _, _, client) = setup();
     let other_beneficiary = Address::generate(&env);
 
-    assert_eq!(client.get_vaults_by_beneficiary(&beneficiary), vec![&env]);
+    assert_eq!(client.get_vaults_by_beneficiary(&beneficiary, &0u32, &10u32), vec![&env]);
 
     let vault_id_1 = client.create_vault(&owner, &beneficiary, &100u64);
     let vault_id_2 = client.create_vault(&owner, &beneficiary, &200u64);
     let _vault_id_3 = client.create_vault(&owner, &other_beneficiary, &300u64);
 
     assert_eq!(
-        client.get_vaults_by_beneficiary(&beneficiary),
+        client.get_vaults_by_beneficiary(&beneficiary, &0u32, &10u32),
         vec![&env, vault_id_1, vault_id_2]
     );
     assert_eq!(
-        client.get_vaults_by_beneficiary(&other_beneficiary),
+        client.get_vaults_by_beneficiary(&other_beneficiary, &0u32, &10u32),
         vec![&env, _vault_id_3]
     );
 }
@@ -439,7 +439,7 @@ fn test_get_vaults_by_beneficiary_tracks_vaults() {
 fn test_get_vaults_by_beneficiary_empty_for_unknown() {
     let (env, _, _, _, _, client) = setup();
     let stranger = Address::generate(&env);
-    assert_eq!(client.get_vaults_by_beneficiary(&stranger), vec![&env]);
+    assert_eq!(client.get_vaults_by_beneficiary(&stranger, &0u32, &10u32), vec![&env]);
 }
 
 // ---- Issue 2: upgrade ----
@@ -646,4 +646,103 @@ fn test_deposit_rejects_balance_overflow() {
     let result = client.try_deposit(&vault_id, &owner, &1i128);
 
     assert!(result.is_err(), "expected overflow error on deposit exceeding i128::MAX");
+}
+
+// ---- Pagination tests ----
+
+#[test]
+fn test_get_vaults_by_owner_pagination() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+
+    let id1 = client.create_vault(&owner, &beneficiary, &100u64);
+    let id2 = client.create_vault(&owner, &beneficiary, &200u64);
+    let id3 = client.create_vault(&owner, &beneficiary, &300u64);
+
+    // page 0, size 2 => [id1, id2]
+    assert_eq!(client.get_vaults_by_owner(&owner, &0u32, &2u32), vec![&env, id1, id2]);
+    // page 1, size 2 => [id3]
+    assert_eq!(client.get_vaults_by_owner(&owner, &1u32, &2u32), vec![&env, id3]);
+    // page 2, size 2 => []
+    assert_eq!(client.get_vaults_by_owner(&owner, &2u32, &2u32), vec![&env]);
+    // page_size 0 => []
+    assert_eq!(client.get_vaults_by_owner(&owner, &0u32, &0u32), vec![&env]);
+}
+
+#[test]
+fn test_get_vaults_by_beneficiary_pagination() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+
+    let id1 = client.create_vault(&owner, &beneficiary, &100u64);
+    let id2 = client.create_vault(&owner, &beneficiary, &200u64);
+    let id3 = client.create_vault(&owner, &beneficiary, &300u64);
+
+    assert_eq!(client.get_vaults_by_beneficiary(&beneficiary, &0u32, &2u32), vec![&env, id1, id2]);
+    assert_eq!(client.get_vaults_by_beneficiary(&beneficiary, &1u32, &2u32), vec![&env, id3]);
+    assert_eq!(client.get_vaults_by_beneficiary(&beneficiary, &2u32, &2u32), vec![&env]);
+}
+
+// ---- check_in event topic constant test ----
+
+#[test]
+fn test_check_in_emits_event_with_check_in_topic() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+
+    client.check_in(&vault_id, &owner);
+
+    let events = env.events().all();
+    let found = events.iter().any(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
+        if topics.len() < 1 {
+            return false;
+        }
+        let topic0: Result<soroban_sdk::Symbol, _> = topics.get(0).unwrap().try_into_val(&env);
+        topic0.map(|s| s == types::CHECK_IN_TOPIC).unwrap_or(false)
+    });
+    assert!(found, "check_in event with CHECK_IN_TOPIC not emitted");
+}
+
+// ---- cancel_vault event test ----
+
+#[test]
+fn test_cancel_vault_emits_cancel_event() {
+    let (env, owner, beneficiary, _, token_address, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+    client.deposit(&vault_id, &owner, &500i128);
+
+    client.cancel_vault(&vault_id);
+
+    let events = env.events().all();
+    let found = events.iter().any(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
+        if topics.len() < 1 {
+            return false;
+        }
+        let topic0: Result<soroban_sdk::Symbol, _> = topics.get(0).unwrap().try_into_val(&env);
+        topic0.map(|s| s == types::CANCEL_TOPIC).unwrap_or(false)
+    });
+    assert!(found, "cancel event not emitted");
+    let _ = token_address;
+}
+
+// ---- transfer_ownership event test ----
+
+#[test]
+fn test_transfer_ownership_emits_ownership_event() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_owner = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+
+    client.transfer_ownership(&vault_id, &new_owner);
+
+    let events = env.events().all();
+    let found = events.iter().any(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
+        if topics.len() < 1 {
+            return false;
+        }
+        let topic0: Result<soroban_sdk::Symbol, _> = topics.get(0).unwrap().try_into_val(&env);
+        topic0.map(|s| s == types::OWNERSHIP_TOPIC).unwrap_or(false)
+    });
+    assert!(found, "ownership transfer event not emitted");
 }

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -5,6 +5,9 @@ pub const VAULT_CREATED_TOPIC: Symbol = symbol_short!("v_created");
 pub const PING_EXPIRY_TOPIC: Symbol = symbol_short!("ping_exp");
 pub const DEPOSIT_TOPIC: Symbol = symbol_short!("deposit");
 pub const WITHDRAW_TOPIC: Symbol = symbol_short!("withdraw");
+pub const CHECK_IN_TOPIC: Symbol = symbol_short!("check_in");
+pub const CANCEL_TOPIC: Symbol = symbol_short!("cancel");
+pub const OWNERSHIP_TOPIC: Symbol = symbol_short!("own_xfer");
 
 /// Warning threshold in seconds. If TTL remaining < this value, ping_expiry emits an event.
 pub const EXPIRY_WARNING_THRESHOLD: u64 = 86_400; // 24 hours


### PR DESCRIPTION
feat(contract): pagination for vault queries, named event topic constants, and missing events
closes #118 
closes #119 
closes #120 
closes #121 

## Motivation
Four medium-priority issues were identified in the smart contract:

1. `get_vaults_by_owner` and `get_vaults_by_beneficiary` returned the full
   Vec<u64> with no upper bound, risking ledger read-limit violations for
   owners with many vaults.

2. `check_in` emitted its event using an inline `symbol_short!("check_in")`
   rather than a named constant, making the topic inconsistent with every
   other event in the contract and harder to reference from off-chain indexers.

3. `cancel_vault` changed vault status and refunded the owner but emitted no
   on-chain event, making cancellations invisible to indexers without polling
   storage.

4. `transfer_ownership` silently updated the vault owner with no on-chain
   event, giving the old owner no verifiable record of the transfer.

## Changes

### types.rs
- Add `CHECK_IN_TOPIC: Symbol = symbol_short!("check_in")`
- Add `CANCEL_TOPIC: Symbol = symbol_short!("cancel")`
- Add `OWNERSHIP_TOPIC: Symbol = symbol_short!("own_xfer")`

### lib.rs
- Import the three new topic constants
- `check_in`: replace inline `symbol_short!("check_in")` with `CHECK_IN_TOPIC`
- `cancel_vault`: emit `(CANCEL_TOPIC, vault_id) → (owner, refund_amount)`
  after saving the cancelled vault
- `transfer_ownership`: clone `new_owner` before moving into vault; emit
  `(OWNERSHIP_TOPIC, vault_id) → (old_owner, new_owner)` after saving
- `get_vaults_by_owner`: add `page: u32, page_size: u32` parameters; delegate
  to new `paginate` helper
- `get_vaults_by_beneficiary`: same pagination parameters
- Add private `paginate(env, all, page, page_size) -> Vec<u64>` helper that
  computes `start = page * page_size`, iterates up to `page_size` items, and
  returns an empty Vec for out-of-range pages or `page_size == 0`

### test.rs
- Update all existing `get_vaults_by_owner` / `get_vaults_by_beneficiary`
  call sites to pass `page=0, page_size=10` (preserves existing assertions)
- `test_get_vaults_by_owner_pagination`: verifies page 0/1/2 slicing and
  the `page_size=0` edge case across 3 vaults
- `test_get_vaults_by_beneficiary_pagination`: same coverage for the
  beneficiary index
- `test_check_in_emits_event_with_check_in_topic`: asserts the emitted event
  topic matches `CHECK_IN_TOPIC`
- `test_cancel_vault_emits_cancel_event`: asserts `CANCEL_TOPIC` is present
  in emitted events after cancellation
- `test_transfer_ownership_emits_ownership_event`: asserts `OWNERSHIP_TOPIC`
  is present in emitted events after ownership transfer


To replace the existing commit message:

bash
git commit --amend -m "<paste above>"
git push --force-with-lease
