### PR TITLE
fix(#99): add IntervalTooLow=14 and IntervalTooHigh=15 to ContractEror; add regression tests

### DIFF
--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -853,3 +853,30 @@ fn test_update_beneficiary_updates_index() {
     // new beneficiary now sees the vault
     assert_eq!(client.get_vaults_by_beneficiary(&new_beneficiary), vec![&env, vault_id]);
 }
+
+// Regression tests for #99: assert_interval_in_bounds must return structured
+// error codes 14 (IntervalTooLow) and 15 (IntervalTooHigh) instead of failing
+// to compile due to missing ContractError variants.
+#[test]
+fn test_create_vault_returns_interval_too_low_error() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    client.set_min_check_in_interval(&3_600u64);
+
+    let err = client
+        .try_create_vault(&owner, &beneficiary, &100u64)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(14));
+}
+
+#[test]
+fn test_create_vault_returns_interval_too_high_error() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    client.set_max_check_in_interval(&1_000u64);
+
+    let err = client
+        .try_create_vault(&owner, &beneficiary, &2_000u64)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(15));
+}


### PR DESCRIPTION

assert_interval_in_bounds called panic_with_error!(env, ContractError::IntervalTooLow) and panic_with_error!(env, ContractError::IntervalTooHigh) but neither variant existed in ContractError, causing a compile error.

Changes:
- ContractError::IntervalTooLow = 14 and ContractError::IntervalTooHigh = 15 are present in lib.rs (already on main; this commit documents the fix and guards against regression).
- assert_interval_in_bounds correctly references both variants when the supplied interval falls outside the configured min/max bounds.
- Added test_create_vault_returns_interval_too_low_error: sets a min interval of 3_600, attempts to create a vault with interval 100, and asserts the returned error is exactly contract error code 14 (IntervalTooLow).
- Added test_create_vault_returns_interval_too_high_error: sets a max interval of 1_000, attempts to create a vault with interval 2_000, and asserts the returned error is exactly contract error code 15 (IntervalTooHigh).

Closes #99