### PR TITLE
Fix/161 162 163 164

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -794,14 +794,28 @@ impl TtlVaultContract {
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `owner` - The owner address
+    /// * `status_filter` - Optional status filter (None returns all vaults, Some(status) returns only vaults with that status)
     /// * `page` - Zero-based page index
     /// * `page_size` - Number of items per page
     ///
     /// # Returns
     /// A vector of vault IDs for the requested page
-    pub fn get_vaults_by_owner(env: Env, owner: Address, page: u32, page_size: u32) -> Vec<u64> {
+    pub fn get_vaults_by_owner(env: Env, owner: Address, status_filter: Option<ReleaseStatus>, page: u32, page_size: u32) -> Vec<u64> {
         let all = Self::load_owner_vault_ids(&env, &owner);
-        Self::paginate(&env, all, page, page_size)
+        let filtered = if let Some(status) = status_filter {
+            let mut result = Vec::new(&env);
+            for vault_id in all.iter() {
+                if let Some(vault) = Self::try_load_vault(&env, vault_id) {
+                    if vault.status == status {
+                        result.push_back(vault_id);
+                    }
+                }
+            }
+            result
+        } else {
+            all
+        };
+        Self::paginate(&env, filtered, page, page_size)
     }
 
     /// Returns a paginated slice of vault IDs where a specific address is the beneficiary.
@@ -809,14 +823,28 @@ impl TtlVaultContract {
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `beneficiary` - The beneficiary address
+    /// * `status_filter` - Optional status filter (None returns all vaults, Some(status) returns only vaults with that status)
     /// * `page` - Zero-based page index
     /// * `page_size` - Number of items per page
     ///
     /// # Returns
     /// A vector of vault IDs for the requested page
-    pub fn get_vaults_by_beneficiary(env: Env, beneficiary: Address, page: u32, page_size: u32) -> Vec<u64> {
+    pub fn get_vaults_by_beneficiary(env: Env, beneficiary: Address, status_filter: Option<ReleaseStatus>, page: u32, page_size: u32) -> Vec<u64> {
         let all = Self::load_beneficiary_vault_ids(&env, &beneficiary);
-        Self::paginate(&env, all, page, page_size)
+        let filtered = if let Some(status) = status_filter {
+            let mut result = Vec::new(&env);
+            for vault_id in all.iter() {
+                if let Some(vault) = Self::try_load_vault(&env, vault_id) {
+                    if vault.status == status {
+                        result.push_back(vault_id);
+                    }
+                }
+            }
+            result
+        } else {
+            all
+        };
+        Self::paginate(&env, filtered, page, page_size)
     }
 
     /// Returns the remaining time-to-live (TTL) for a vault in seconds.

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -202,7 +202,7 @@ fn test_get_vaults_by_owner_tracks_multiple_vaults() {
     let vault_id_2 = client.create_vault(&owner, &beneficiary, &200u64);
 
     assert_eq!(
-        client.get_vaults_by_owner(&owner, &0u32, &10u32),
+        client.get_vaults_by_owner(&owner, &None, &0u32, &10u32),
         vec![&env, vault_id_1, vault_id_2]
     );
 }
@@ -251,14 +251,14 @@ fn test_transfer_ownership_updates_owner_and_owner_index() {
     let new_owner = Address::generate(&env);
 
     let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
-    assert_eq!(client.get_vaults_by_owner(&owner, &0u32, &10u32), vec![&env, vault_id]);
-    assert_eq!(client.get_vaults_by_owner(&new_owner, &0u32, &10u32), vec![&env]);
+    assert_eq!(client.get_vaults_by_owner(&owner, &None, &0u32, &10u32), vec![&env, vault_id]);
+    assert_eq!(client.get_vaults_by_owner(&new_owner, &None, &0u32, &10u32), vec![&env]);
 
     client.transfer_ownership(&vault_id, &owner, &new_owner);
 
     assert_eq!(client.get_vault(&vault_id).owner, new_owner);
-    assert_eq!(client.get_vaults_by_owner(&owner, &0u32, &10u32), vec![&env]);
-    assert_eq!(client.get_vaults_by_owner(&new_owner, &0u32, &10u32), vec![&env, vault_id]);
+    assert_eq!(client.get_vaults_by_owner(&owner, &None, &0u32, &10u32), vec![&env]);
+    assert_eq!(client.get_vaults_by_owner(&new_owner, &None, &0u32, &10u32), vec![&env, vault_id]);
 }
 
 /// Invariant: owner and beneficiary must always be distinct.
@@ -286,13 +286,13 @@ fn test_transfer_ownership_preserves_beneficiary_index() {
     let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
 
     // beneficiary index contains the vault before transfer
-    assert_eq!(client.get_vaults_by_beneficiary(&beneficiary, &0u32, &10u32), vec![&env, vault_id]);
+    assert_eq!(client.get_vaults_by_beneficiary(&beneficiary, &None, &0u32, &10u32), vec![&env, vault_id]);
 
     client.transfer_ownership(&vault_id, &owner, &new_owner);
 
     // vault.beneficiary is unchanged — index must still be intact
     assert_eq!(client.get_vault(&vault_id).beneficiary, beneficiary);
-    assert_eq!(client.get_vaults_by_beneficiary(&beneficiary, &0u32, &10u32), vec![&env, vault_id]);
+    assert_eq!(client.get_vaults_by_beneficiary(&beneficiary, &None, &0u32, &10u32), vec![&env, vault_id]);
 }
 
 #[test]
@@ -508,18 +508,18 @@ fn test_get_vaults_by_beneficiary_tracks_vaults() {
     let (env, owner, beneficiary, _, _, client) = setup();
     let other_beneficiary = Address::generate(&env);
 
-    assert_eq!(client.get_vaults_by_beneficiary(&beneficiary, &0u32, &10u32), vec![&env]);
+    assert_eq!(client.get_vaults_by_beneficiary(&beneficiary, &None, &0u32, &10u32), vec![&env]);
 
     let vault_id_1 = client.create_vault(&owner, &beneficiary, &100u64);
     let vault_id_2 = client.create_vault(&owner, &beneficiary, &200u64);
     let _vault_id_3 = client.create_vault(&owner, &other_beneficiary, &300u64);
 
     assert_eq!(
-        client.get_vaults_by_beneficiary(&beneficiary, &0u32, &10u32),
+        client.get_vaults_by_beneficiary(&beneficiary, &None, &0u32, &10u32),
         vec![&env, vault_id_1, vault_id_2]
     );
     assert_eq!(
-        client.get_vaults_by_beneficiary(&other_beneficiary, &0u32, &10u32),
+        client.get_vaults_by_beneficiary(&other_beneficiary, &None, &0u32, &10u32),
         vec![&env, _vault_id_3]
     );
 }
@@ -528,7 +528,7 @@ fn test_get_vaults_by_beneficiary_tracks_vaults() {
 fn test_get_vaults_by_beneficiary_empty_for_unknown() {
     let (env, _, _, _, _, client) = setup();
     let stranger = Address::generate(&env);
-    assert_eq!(client.get_vaults_by_beneficiary(&stranger, &0u32, &10u32), vec![&env]);
+    assert_eq!(client.get_vaults_by_beneficiary(&stranger, &None, &0u32, &10u32), vec![&env]);
 }
 
 // ---- Issue 2: upgrade ----
@@ -846,15 +846,15 @@ fn test_update_beneficiary_updates_index() {
     let vault_id = client.create_vault(&owner, &old_beneficiary, &100u64);
 
     // old beneficiary sees the vault, new one does not
-    assert_eq!(client.get_vaults_by_beneficiary(&old_beneficiary, &0u32, &10u32), vec![&env, vault_id]);
-    assert_eq!(client.get_vaults_by_beneficiary(&new_beneficiary, &0u32, &10u32), vec![&env]);
+    assert_eq!(client.get_vaults_by_beneficiary(&old_beneficiary, &None, &0u32, &10u32), vec![&env, vault_id]);
+    assert_eq!(client.get_vaults_by_beneficiary(&new_beneficiary, &None, &0u32, &10u32), vec![&env]);
 
     client.update_beneficiary(&vault_id, &new_beneficiary);
 
     // old beneficiary no longer sees the vault
-    assert_eq!(client.get_vaults_by_beneficiary(&old_beneficiary, &0u32, &10u32), vec![&env]);
+    assert_eq!(client.get_vaults_by_beneficiary(&old_beneficiary, &None, &0u32, &10u32), vec![&env]);
     // new beneficiary now sees the vault
-    assert_eq!(client.get_vaults_by_beneficiary(&new_beneficiary, &0u32, &10u32), vec![&env, vault_id]);
+    assert_eq!(client.get_vaults_by_beneficiary(&new_beneficiary, &None, &0u32, &10u32), vec![&env, vault_id]);
 }
 
 
@@ -932,4 +932,92 @@ fn test_ping_expiry_no_event_for_cancelled_vault() {
     // No new ping_expiry event should be emitted
     assert_eq!(ttl, 0);
     assert_eq!(events_before.len(), events_after.len());
+}
+
+
+#[test]
+fn test_get_vaults_by_owner_with_status_filter() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+
+    let vault_id_1 = client.create_vault(&owner, &beneficiary, &100u64);
+    let vault_id_2 = client.create_vault(&owner, &beneficiary, &200u64);
+    
+    client.deposit(&vault_id_1, &owner, &500i128);
+    env.ledger().with_mut(|l| l.timestamp += 200);
+    client.trigger_release(&vault_id_1);
+    
+    // All vaults (no filter)
+    assert_eq!(
+        client.get_vaults_by_owner(&owner, &None, &0u32, &10u32),
+        vec![&env, vault_id_1, vault_id_2]
+    );
+    
+    // Only locked vaults
+    assert_eq!(
+        client.get_vaults_by_owner(&owner, &Some(ReleaseStatus::Locked), &0u32, &10u32),
+        vec![&env, vault_id_2]
+    );
+    
+    // Only released vaults
+    assert_eq!(
+        client.get_vaults_by_owner(&owner, &Some(ReleaseStatus::Released), &0u32, &10u32),
+        vec![&env, vault_id_1]
+    );
+    
+    // No cancelled vaults
+    assert_eq!(
+        client.get_vaults_by_owner(&owner, &Some(ReleaseStatus::Cancelled), &0u32, &10u32),
+        vec![&env]
+    );
+}
+
+#[test]
+fn test_get_vaults_by_beneficiary_with_status_filter() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+
+    let vault_id_1 = client.create_vault(&owner, &beneficiary, &100u64);
+    let vault_id_2 = client.create_vault(&owner, &beneficiary, &200u64);
+    
+    client.deposit(&vault_id_1, &owner, &500i128);
+    env.ledger().with_mut(|l| l.timestamp += 200);
+    client.trigger_release(&vault_id_1);
+    
+    // All vaults (no filter)
+    assert_eq!(
+        client.get_vaults_by_beneficiary(&beneficiary, &None, &0u32, &10u32),
+        vec![&env, vault_id_1, vault_id_2]
+    );
+    
+    // Only locked vaults
+    assert_eq!(
+        client.get_vaults_by_beneficiary(&beneficiary, &Some(ReleaseStatus::Locked), &0u32, &10u32),
+        vec![&env, vault_id_2]
+    );
+    
+    // Only released vaults
+    assert_eq!(
+        client.get_vaults_by_beneficiary(&beneficiary, &Some(ReleaseStatus::Released), &0u32, &10u32),
+        vec![&env, vault_id_1]
+    );
+}
+
+#[test]
+fn test_get_vaults_by_owner_with_cancelled_status_filter() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+    client.deposit(&vault_id, &owner, &500i128);
+    client.cancel_vault(&vault_id);
+    
+    // Only cancelled vaults
+    assert_eq!(
+        client.get_vaults_by_owner(&owner, &Some(ReleaseStatus::Cancelled), &0u32, &10u32),
+        vec![&env, vault_id]
+    );
+    
+    // No locked vaults
+    assert_eq!(
+        client.get_vaults_by_owner(&owner, &Some(ReleaseStatus::Locked), &0u32, &10u32),
+        vec![&env]
+    );
 }


### PR DESCRIPTION
## Fix: Storage and Error Handling Issues (#161-164)

### Changes

**#161**: Move VaultCount to persistent storage to survive instance TTL expiry and prevent vault ID collisions.

**#162**: Add `ContractError::NotInitialized` and replace `.expect()` calls in `load_admin` and `load_token` with structured error handling.

**#163**: Fix `ping_expiry` to not emit events for Released or Cancelled vaults.

**#164**: Add optional `status_filter` parameter to `get_vaults_by_owner` and `get_vaults_by_beneficiary` for efficient status-based filtering.

Closes #161
Closes #162
Closes #163
Closes #164