### PR TITLE
docs: reference issue #279 in trigger_release NotExpired test

### DIFF
--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -856,7 +856,7 @@ fn test_trigger_release_emits_event_with_zero_balance() {
     client.trigger_release(&vault_id);
 }
 
-// Regression test for #97: trigger_release must return structured error code 16
+// Regression test for #97 / #279: trigger_release must return structured error code 16
 // (ContractError::NotExpired) when the vault TTL has not yet lapsed, instead of
 // panicking with a raw string.
 #[test]


### PR DESCRIPTION
## Summary
This PR addresses issue #279 by documenting that the fix was already implemented in PR #267 (issue #97).

## Changes
- Updated regression test comment to cross-reference both #97 and #279
- No functional changes — the fix (using `panic_with_error!` with `ContractError::NotExpired`) is already present

## Context
Issue #279 requested:
1. ✅ Add `NotExpired` variant to `ContractError` (already exists as variant 16)
2. ✅ Replace `panic!` with `panic_with_error!` in `trigger_release` (already done)
3. ✅ Add test asserting correct error code (already exists)

All requirements were satisfied by PR #267. This PR ensures both issues are tracked in the test documentation.

Closes #279