### PR TITLE
fix: dynamic vault TTL and batch_deposit instance TTL (#295, #296)

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -333,8 +333,8 @@ impl TtlVaultContract {
             metadata: String::from_str(&env, ""),
         };
         Self::save_vault(&env, vault_id, &vault);
-        Self::add_owner_vault_id(&env, &owner, vault_id);
-        Self::add_beneficiary_vault_id(&env, &beneficiary, vault_id);
+        Self::add_owner_vault_id(&env, &owner, vault_id, check_in_interval);
+        Self::add_beneficiary_vault_id(&env, &beneficiary, vault_id, check_in_interval);
         // VaultCount is an incrementing generation ID and must be updated
         // only after the vault and its owner/beneficiary indexes are persisted.
         //
@@ -388,7 +388,7 @@ impl TtlVaultContract {
         vault.last_check_in = env.ledger().timestamp();
         Self::save_vault(&env, vault_id, &vault);
         let owner_ids = Self::load_owner_vault_ids(&env, &vault.owner);
-        Self::save_owner_vault_ids(&env, &vault.owner, &owner_ids);
+        Self::save_owner_vault_ids(&env, &vault.owner, &owner_ids, vault.check_in_interval);
         env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
         env.events().publish((CHECK_IN_TOPIC, vault_id), vault.last_check_in);
         Ok(())
@@ -1025,8 +1025,8 @@ impl TtlVaultContract {
         Self::save_vault(&env, vault_id, &vault);
 
         if old_beneficiary != new_beneficiary {
-            Self::remove_beneficiary_vault_id(&env, &old_beneficiary, vault_id);
-            Self::add_beneficiary_vault_id(&env, &new_beneficiary, vault_id);
+            Self::remove_beneficiary_vault_id(&env, &old_beneficiary, vault_id, vault.check_in_interval);
+            Self::add_beneficiary_vault_id(&env, &new_beneficiary, vault_id, vault.check_in_interval);
         }
         env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
         Ok(())
@@ -1120,8 +1120,8 @@ impl TtlVaultContract {
         vault.balance = 0;
         vault.status = ReleaseStatus::Cancelled;
         Self::save_vault(&env, vault_id, &vault);
-        Self::remove_owner_vault_id(&env, &vault.owner, vault_id);
-        Self::remove_beneficiary_vault_id(&env, &vault.beneficiary, vault_id);
+        Self::remove_owner_vault_id(&env, &vault.owner, vault_id, vault.check_in_interval);
+        Self::remove_beneficiary_vault_id(&env, &vault.beneficiary, vault_id, vault.check_in_interval);
         env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
         env.events().publish((CANCEL_TOPIC, vault_id), (vault.owner, refund_amount));
         Ok(())
@@ -1171,8 +1171,8 @@ impl TtlVaultContract {
                 return Err(ContractError::InvalidBeneficiary);
             }
             if old_owner != new_owner {
-                Self::remove_owner_vault_id(&env, &old_owner, vault_id);
-                Self::add_owner_vault_id(&env, &new_owner, vault_id);
+                Self::remove_owner_vault_id(&env, &old_owner, vault_id, vault.check_in_interval);
+                Self::add_owner_vault_id(&env, &new_owner, vault_id, vault.check_in_interval);
             }
             vault.owner = new_owner.clone();
             Self::save_vault(&env, vault_id, &vault);
@@ -1261,19 +1261,20 @@ impl TtlVaultContract {
             .unwrap_or(Vec::new(env))
     }
 
-    fn save_owner_vault_ids(env: &Env, owner: &Address, vault_ids: &Vec<u64>) {
+    fn save_owner_vault_ids(env: &Env, owner: &Address, vault_ids: &Vec<u64>, check_in_interval: u64) {
         let key = DataKey::OwnerVaults(owner.clone());
+        let ttl = vault_ttl_ledgers(check_in_interval);
         env.storage().persistent().set(&key, vault_ids);
-        env.storage().persistent().extend_ttl(&key, VAULT_TTL_THRESHOLD, VAULT_TTL_LEDGERS);
+        env.storage().persistent().extend_ttl(&key, VAULT_TTL_THRESHOLD, ttl);
     }
 
-    fn add_owner_vault_id(env: &Env, owner: &Address, vault_id: u64) {
+    fn add_owner_vault_id(env: &Env, owner: &Address, vault_id: u64, check_in_interval: u64) {
         let mut vault_ids = Self::load_owner_vault_ids(env, owner);
         vault_ids.push_back(vault_id);
-        Self::save_owner_vault_ids(env, owner, &vault_ids);
+        Self::save_owner_vault_ids(env, owner, &vault_ids, check_in_interval);
     }
 
-    fn remove_owner_vault_id(env: &Env, owner: &Address, vault_id: u64) {
+    fn remove_owner_vault_id(env: &Env, owner: &Address, vault_id: u64, check_in_interval: u64) {
         let vault_ids = Self::load_owner_vault_ids(env, owner);
         let mut next_ids = Vec::new(env);
         for id in vault_ids.iter() {
@@ -1286,7 +1287,7 @@ impl TtlVaultContract {
             let key = DataKey::OwnerVaults(owner.clone());
             env.storage().persistent().remove(&key);
         } else {
-            Self::save_owner_vault_ids(env, owner, &next_ids);
+            Self::save_owner_vault_ids(env, owner, &next_ids, check_in_interval);
         }
     }
 
@@ -1304,19 +1305,20 @@ impl TtlVaultContract {
             .unwrap_or(Vec::new(env))
     }
 
-    fn save_beneficiary_vault_ids(env: &Env, beneficiary: &Address, vault_ids: &Vec<u64>) {
+    fn save_beneficiary_vault_ids(env: &Env, beneficiary: &Address, vault_ids: &Vec<u64>, check_in_interval: u64) {
         let key = DataKey::BeneficiaryVaults(beneficiary.clone());
+        let ttl = vault_ttl_ledgers(check_in_interval);
         env.storage().persistent().set(&key, vault_ids);
-        env.storage().persistent().extend_ttl(&key, VAULT_TTL_THRESHOLD, VAULT_TTL_LEDGERS);
+        env.storage().persistent().extend_ttl(&key, VAULT_TTL_THRESHOLD, ttl);
     }
 
-    fn add_beneficiary_vault_id(env: &Env, beneficiary: &Address, vault_id: u64) {
+    fn add_beneficiary_vault_id(env: &Env, beneficiary: &Address, vault_id: u64, check_in_interval: u64) {
         let mut vault_ids = Self::load_beneficiary_vault_ids(env, beneficiary);
         vault_ids.push_back(vault_id);
-        Self::save_beneficiary_vault_ids(env, beneficiary, &vault_ids);
+        Self::save_beneficiary_vault_ids(env, beneficiary, &vault_ids, check_in_interval);
     }
 
-    fn remove_beneficiary_vault_id(env: &Env, beneficiary: &Address, vault_id: u64) {
+    fn remove_beneficiary_vault_id(env: &Env, beneficiary: &Address, vault_id: u64, check_in_interval: u64) {
         let vault_ids = Self::load_beneficiary_vault_ids(env, beneficiary);
         let mut next_ids = Vec::new(env);
         for id in vault_ids.iter() {
@@ -1329,7 +1331,7 @@ impl TtlVaultContract {
             let key = DataKey::BeneficiaryVaults(beneficiary.clone());
             env.storage().persistent().remove(&key);
         } else {
-            Self::save_beneficiary_vault_ids(env, beneficiary, &next_ids);
+            Self::save_beneficiary_vault_ids(env, beneficiary, &next_ids, check_in_interval);
         }
     }
 

--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -485,6 +485,7 @@ impl TtlVaultContract {
         }
 
         if total_amount == 0 {
+            env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
             return;
         }
 

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -653,10 +653,13 @@ fn test_create_vault_long_interval_remains_accessible() {
     let (env, owner, beneficiary, _, _, client) = setup();
     let thirty_days: u64 = 30 * 24 * 3600; // 2_592_000 seconds
     let vault_id = client.create_vault(&owner, &beneficiary, &thirty_days);
-    // Advance just under the interval — vault must still be readable.
+    // Advance just under the interval — vault and its indexes must still be readable.
     env.ledger().with_mut(|l| l.timestamp += thirty_days - 1);
     let vault = client.get_vault(&vault_id);
     assert_eq!(vault.check_in_interval, thirty_days);
+    // Owner and beneficiary index entries must also survive the long interval.
+    assert_eq!(client.get_vaults_by_owner(&owner, &None, &0u32, &10u32), vec![&env, vault_id]);
+    assert_eq!(client.get_vaults_by_beneficiary(&beneficiary, &None, &0u32, &10u32), vec![&env, vault_id]);
 }
 
 // ---- Issue 1: get_vaults_by_beneficiary ----


### PR DESCRIPTION
## Summary

Closes #295
Closes #296
Closes #298 
---

### #295 — Derive index TTL dynamically from `check_in_interval`

**Problem:** `save_owner_vault_ids`, `save_beneficiary_vault_ids`, and their `remove_*` counterparts used the fixed `VAULT_TTL_LEDGERS` (200k ledgers ≈ 11 days) for persistent index entries. A vault with a 30-day `check_in_interval` would have its owner/beneficiary indexes expire before the next check-in, causing `VaultNotFound` panics.

**Fix:**
- Added `check_in_interval: u64` parameter to `save_owner_vault_ids`, `save_beneficiary_vault_ids`, `remove_owner_vault_id`, and `remove_beneficiary_vault_id`
- They now call `vault_ttl_ledgers(check_in_interval)` (2× safety buffer, capped at Soroban max) instead of the fixed constant
- Updated all call sites: `create_vault`, `check_in`, `cancel_vault`, `update_beneficiary`, `transfer_ownership`
- Extended `test_create_vault_long_interval_remains_accessible` to also assert owner and beneficiary index entries survive a 30-day interval

---

### #296 — Extend instance TTL on `batch_deposit` early-return path

**Problem:** The `total_amount == 0` early return in `batch_deposit` bypassed the `extend_ttl` call at the bottom of the function. All other state-mutating functions already had `extend_ttl` on their success paths.

**Fix:** Added `env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS)` before the early `return` in `batch_deposit`.

---

### #298 — `set_beneficiaries` empty list guard

Already resolved in the codebase — `is_empty()` guard and `test_set_beneficiaries_rejects_empty_list` were already present. No changes needed.