### PR TITLE
fix: validate positive amount in withdraw and partial_release (#299, #301)

### DIFF
--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -549,6 +549,26 @@ fn test_partial_release_fails_if_insufficient_balance() {
 }
 
 #[test]
+fn test_partial_release_rejects_zero_amount() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+    client.deposit(&vault_id, &owner, &500i128);
+
+    let result = client.try_partial_release(&vault_id, &0i128);
+    assert!(result.is_err(), "expected error for zero-amount partial release");
+}
+
+#[test]
+fn test_partial_release_rejects_negative_amount() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+    client.deposit(&vault_id, &owner, &500i128);
+
+    let result = client.try_partial_release(&vault_id, &-1i128);
+    assert!(result.is_err(), "expected error for negative-amount partial release");
+}
+
+#[test]
 fn test_partial_release_emits_partial_event() {
     let (env, owner, beneficiary, _, token_address, client) = setup();
     let token_client = token::Client::new(&env, &token_address);


### PR DESCRIPTION
## Summary

Closes #299
Closes #301

---

## Changes

### #299 — `withdraw` does not validate amount is positive
- The `amount <= 0` guard returning `ContractError::InvalidAmount` was already present in `withdraw`.
- Tests `test_withdraw_rejects_zero_amount` and `test_withdraw_rejects_negative_amount` were already present.
- No code changes required; issue confirmed resolved.

### #301 — `partial_release` does not validate amount is positive
- The `amount <= 0` guard returning `ContractError::InvalidAmount` was already present in `partial_release`.
- Added missing tests:
  - `test_partial_release_rejects_zero_amount`: verifies `try_partial_release` returns an error when `amount = 0`
  - `test_partial_release_rejects_negative_amount`: verifies `try_partial_release` returns an error when `amount = -1`

## Files Changed
- `contracts/ttl_vault/src/test.rs` — added 2 tests for `partial_release` invalid amount cases