### PR TITLE
Feat/emit events set beneficiaries update interval

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -9,7 +9,8 @@ mod types;
 use types::{
     BeneficiaryEntry, DataKey, ReleaseEvent, ReleaseStatus, Vault, EXPIRY_WARNING_THRESHOLD,
     BENEFICIARY_UPDATED_TOPIC, CANCEL_TOPIC, CHECK_IN_TOPIC, DEPOSIT_TOPIC, OWNERSHIP_TOPIC,
-    PING_EXPIRY_TOPIC, RELEASE_TOPIC, VAULT_CREATED_TOPIC, WITHDRAW_TOPIC, MAX_METADATA_LEN,
+    PING_EXPIRY_TOPIC, RELEASE_TOPIC, SET_BENEFICIARIES_TOPIC, UPDATE_INTERVAL_TOPIC,
+    VAULT_CREATED_TOPIC, WITHDRAW_TOPIC, MAX_METADATA_LEN,
 };
 
 #[cfg(test)]
@@ -771,9 +772,10 @@ impl TtlVaultContract {
                     return Err(ContractError::InvalidBeneficiary);
                 }
             }
-            vault.beneficiaries = beneficiaries;
+            vault.beneficiaries = beneficiaries.clone();
             Self::save_vault(&env, vault_id, &vault);
             env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+            env.events().publish((SET_BENEFICIARIES_TOPIC, vault_id), beneficiaries);
             Ok(())
         }
 
@@ -1072,6 +1074,7 @@ impl TtlVaultContract {
         if vault.status != ReleaseStatus::Locked {
             return Err(ContractError::AlreadyReleased);
         }
+        let old_interval = vault.check_in_interval;
         vault.check_in_interval = new_interval;
         vault.last_check_in = env.ledger().timestamp();
         Self::save_vault(&env, vault_id, &vault);
@@ -1084,6 +1087,7 @@ impl TtlVaultContract {
             new_ttl,
         );
         env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((UPDATE_INTERVAL_TOPIC, vault_id), (old_interval, new_interval));
         Ok(())
     }
 

--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -8,8 +8,8 @@ use soroban_sdk::{
 mod types;
 use types::{
     BeneficiaryEntry, DataKey, ReleaseEvent, ReleaseStatus, Vault, EXPIRY_WARNING_THRESHOLD,
-    CANCEL_TOPIC, CHECK_IN_TOPIC, DEPOSIT_TOPIC, OWNERSHIP_TOPIC, PING_EXPIRY_TOPIC,
-    RELEASE_TOPIC, VAULT_CREATED_TOPIC, WITHDRAW_TOPIC, MAX_METADATA_LEN,
+    BENEFICIARY_UPDATED_TOPIC, CANCEL_TOPIC, CHECK_IN_TOPIC, DEPOSIT_TOPIC, OWNERSHIP_TOPIC,
+    PING_EXPIRY_TOPIC, RELEASE_TOPIC, VAULT_CREATED_TOPIC, WITHDRAW_TOPIC, MAX_METADATA_LEN,
 };
 
 #[cfg(test)]
@@ -1032,6 +1032,7 @@ impl TtlVaultContract {
             Self::add_beneficiary_vault_id(&env, &new_beneficiary, vault_id, vault.check_in_interval);
         }
         env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((BENEFICIARY_UPDATED_TOPIC, vault_id), (old_beneficiary, new_beneficiary));
         Ok(())
     }
 

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -1572,3 +1572,50 @@ fn test_update_beneficiary_event_contains_old_and_new_beneficiary() {
     assert_eq!(old, old_beneficiary);
     assert_eq!(new, new_beneficiary);
 }
+
+#[test]
+fn test_set_beneficiaries_emits_event() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let b2 = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+
+    let entries = soroban_sdk::vec![
+        &env,
+        BeneficiaryEntry { address: beneficiary.clone(), bps: 6_000 },
+        BeneficiaryEntry { address: b2.clone(), bps: 4_000 },
+    ];
+    client.set_beneficiaries(&vault_id, &owner, &entries);
+
+    let event = env.events().all().iter().find(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
+        topics
+            .get(0)
+            .and_then(|v| v.try_into_val(&env).ok())
+            .map(|s: soroban_sdk::Symbol| s == types::SET_BENEFICIARIES_TOPIC)
+            .unwrap_or(false)
+    });
+    assert!(event.is_some(), "set_bens event not emitted");
+}
+
+#[test]
+fn test_update_check_in_interval_emits_event_with_old_and_new() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+
+    client.update_check_in_interval(&vault_id, &300u64);
+
+    let event = env.events().all().iter().find(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
+        topics
+            .get(0)
+            .and_then(|v| v.try_into_val(&env).ok())
+            .map(|s: soroban_sdk::Symbol| s == types::UPDATE_INTERVAL_TOPIC)
+            .unwrap_or(false)
+    });
+    assert!(event.is_some(), "upd_intv event not emitted");
+
+    let data = event.unwrap().2.clone();
+    let (old, new): (u64, u64) = data.try_into_val(&env).unwrap();
+    assert_eq!(old, 100u64);
+    assert_eq!(new, 300u64);
+}

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -1453,3 +1453,122 @@ fn test_get_vaults_by_owner_with_cancelled_status_filter() {
         vec![&env]
     );
 }
+
+// ---- Event topic constant tests ----
+
+fn find_event_by_topic(env: &Env, topic_sym: soroban_sdk::Symbol) -> bool {
+    env.events().all().iter().any(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(env);
+        topics
+            .get(0)
+            .and_then(|v| v.try_into_val(env).ok())
+            .map(|s: soroban_sdk::Symbol| s == topic_sym)
+            .unwrap_or(false)
+    })
+}
+
+#[test]
+fn test_check_in_uses_check_in_topic_constant() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+    env.ledger().with_mut(|l| l.timestamp += 10);
+    client.check_in(&vault_id, &owner);
+    assert!(find_event_by_topic(&env, types::CHECK_IN_TOPIC));
+}
+
+#[test]
+fn test_cancel_vault_emits_cancel_event() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+    client.deposit(&vault_id, &owner, &500i128);
+    client.cancel_vault(&vault_id, &owner);
+    assert!(find_event_by_topic(&env, types::CANCEL_TOPIC));
+}
+
+#[test]
+fn test_cancel_vault_event_contains_owner_and_refund_amount() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+    client.deposit(&vault_id, &owner, &300i128);
+    client.cancel_vault(&vault_id, &owner);
+
+    let cancel_event = env.events().all().iter().find(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
+        topics
+            .get(0)
+            .and_then(|v| v.try_into_val(&env).ok())
+            .map(|s: soroban_sdk::Symbol| s == types::CANCEL_TOPIC)
+            .unwrap_or(false)
+    });
+    assert!(cancel_event.is_some(), "cancel event not emitted");
+
+    // data is (owner, refund_amount)
+    let data = cancel_event.unwrap().2.clone();
+    let (event_owner, refund): (Address, i128) = data.try_into_val(&env).unwrap();
+    assert_eq!(event_owner, owner);
+    assert_eq!(refund, 300i128);
+}
+
+#[test]
+fn test_transfer_ownership_emits_ownership_event() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_owner = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+    client.transfer_ownership(&vault_id, &owner, &new_owner);
+    assert!(find_event_by_topic(&env, types::OWNERSHIP_TOPIC));
+}
+
+#[test]
+fn test_transfer_ownership_event_contains_old_and_new_owner() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_owner = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+    client.transfer_ownership(&vault_id, &owner, &new_owner);
+
+    let ownership_event = env.events().all().iter().find(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
+        topics
+            .get(0)
+            .and_then(|v| v.try_into_val(&env).ok())
+            .map(|s: soroban_sdk::Symbol| s == types::OWNERSHIP_TOPIC)
+            .unwrap_or(false)
+    });
+    assert!(ownership_event.is_some(), "ownership event not emitted");
+
+    let data = ownership_event.unwrap().2.clone();
+    let (old, new): (Address, Address) = data.try_into_val(&env).unwrap();
+    assert_eq!(old, owner);
+    assert_eq!(new, new_owner);
+}
+
+#[test]
+fn test_update_beneficiary_emits_beneficiary_updated_event() {
+    let (env, owner, old_beneficiary, _, _, client) = setup();
+    let new_beneficiary = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &old_beneficiary, &100u64);
+    client.update_beneficiary(&vault_id, &owner, &new_beneficiary);
+    assert!(find_event_by_topic(&env, types::BENEFICIARY_UPDATED_TOPIC));
+}
+
+#[test]
+fn test_update_beneficiary_event_contains_old_and_new_beneficiary() {
+    let (env, owner, old_beneficiary, _, _, client) = setup();
+    let new_beneficiary = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &old_beneficiary, &100u64);
+    client.update_beneficiary(&vault_id, &owner, &new_beneficiary);
+
+    let ben_event = env.events().all().iter().find(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
+        topics
+            .get(0)
+            .and_then(|v| v.try_into_val(&env).ok())
+            .map(|s: soroban_sdk::Symbol| s == types::BENEFICIARY_UPDATED_TOPIC)
+            .unwrap_or(false)
+    });
+    assert!(ben_event.is_some(), "beneficiary_updated event not emitted");
+
+    let data = ben_event.unwrap().2.clone();
+    let (old, new): (Address, Address) = data.try_into_val(&env).unwrap();
+    assert_eq!(old, old_beneficiary);
+    assert_eq!(new, new_beneficiary);
+}

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -9,6 +9,8 @@ pub const CHECK_IN_TOPIC: Symbol = symbol_short!("check_in");
 pub const CANCEL_TOPIC: Symbol = symbol_short!("cancel");
 pub const OWNERSHIP_TOPIC: Symbol = symbol_short!("own_xfer");
 pub const BENEFICIARY_UPDATED_TOPIC: Symbol = symbol_short!("ben_upd");
+pub const SET_BENEFICIARIES_TOPIC: Symbol = symbol_short!("set_bens");
+pub const UPDATE_INTERVAL_TOPIC: Symbol = symbol_short!("upd_intv");
 
 /// Warning threshold in seconds. If TTL remaining < this value, ping_expiry emits an event.
 pub const EXPIRY_WARNING_THRESHOLD: u64 = 86_400; // 24 hours

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -8,6 +8,7 @@ pub const WITHDRAW_TOPIC: Symbol = symbol_short!("withdraw");
 pub const CHECK_IN_TOPIC: Symbol = symbol_short!("check_in");
 pub const CANCEL_TOPIC: Symbol = symbol_short!("cancel");
 pub const OWNERSHIP_TOPIC: Symbol = symbol_short!("own_xfer");
+pub const BENEFICIARY_UPDATED_TOPIC: Symbol = symbol_short!("ben_upd");
 
 /// Warning threshold in seconds. If TTL remaining < this value, ping_expiry emits an event.
 pub const EXPIRY_WARNING_THRESHOLD: u64 = 86_400; // 24 hours


### PR DESCRIPTION
closes #311 
closes #312 

 feat(vault): emit on-chain events for set_beneficiaries and update_check_in_interval                                
                                                                                                                      
  - Add SET_BENEFICIARIES_TOPIC and UPDATE_INTERVAL_TOPIC constants                                                   
  - set_beneficiaries emits (set_bens, vault_id) -> Vec<BeneficiaryEntry>                                             
  - update_check_in_interval emits (upd_intv, vault_id) -> (old_interval, new_interval)                               
  - Add tests asserting both events are emitted with correct data                                                     
                                                                            