### PR TITLE
feat(vault): emit unpause event on

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -9,7 +9,7 @@ mod types;
 use types::{
     BeneficiaryEntry, DataKey, ReleaseEvent, ReleaseStatus, Vault, EXPIRY_WARNING_THRESHOLD,
     CANCEL_TOPIC, CHECK_IN_TOPIC, DEPOSIT_TOPIC, OWNERSHIP_TOPIC, PING_EXPIRY_TOPIC,
-    RELEASE_TOPIC, VAULT_CREATED_TOPIC, WITHDRAW_TOPIC, MAX_METADATA_LEN,
+    RELEASE_TOPIC, UNPAUSE_TOPIC, VAULT_CREATED_TOPIC, WITHDRAW_TOPIC, MAX_METADATA_LEN,
 };
 
 #[cfg(test)]
@@ -139,6 +139,7 @@ impl TtlVaultContract {
     pub fn unpause(env: Env) {
         Self::require_admin(&env);
         env.storage().instance().set(&DataKey::Paused, &false);
+        env.events().publish((UNPAUSE_TOPIC,), false);
         env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
     }
 

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -207,6 +207,31 @@ fn test_pause_and_unpause_toggle() {
     assert!(!client.is_paused());
 }
 
+// ---- Issue #317: unpause event emission test ----
+
+#[test]
+fn test_unpause_emits_event() {
+    let (env, _, _, _, _, client) = setup();
+
+    client.pause();
+    client.unpause();
+
+    let events = env.events().all();
+    let unpause_event = events.iter().find(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
+        if topics.len() < 2 {
+            return false;
+        }
+        let topic0: Result<soroban_sdk::Symbol, _> = topics.get(0).unwrap().try_into_val(&env);
+        topic0.map(|s| s == soroban_sdk::symbol_short!("unpause")).unwrap_or(false)
+    });
+
+    assert!(unpause_event.is_some(), "unpause event not emitted");
+    // data field should be `false` (new paused state)
+    let data: bool = unpause_event.unwrap().2.into_val(&env);
+    assert!(!data);
+}
+
 #[test]
 fn test_get_admin_view() {
     let (_, _, _, admin, _, client) = setup();

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -8,6 +8,7 @@ pub const WITHDRAW_TOPIC: Symbol = symbol_short!("withdraw");
 pub const CHECK_IN_TOPIC: Symbol = symbol_short!("check_in");
 pub const CANCEL_TOPIC: Symbol = symbol_short!("cancel");
 pub const OWNERSHIP_TOPIC: Symbol = symbol_short!("own_xfer");
+pub const UNPAUSE_TOPIC: Symbol = symbol_short!("unpause");
 
 /// Warning threshold in seconds. If TTL remaining < this value, ping_expiry emits an event.
 pub const EXPIRY_WARNING_THRESHOLD: u64 = 86_400; // 24 hours


### PR DESCRIPTION
# PR Description                           
                                                   
## Summary
- `unpause_contract` was silently mutating paused state with no on-chain signal, making it impossible for off-chain indexers to detect the change without polling storage.

## Closes
Closes #317 