### PR TITLE
feat(contract): emit events on update_metadata, set_min/max_check_in_interval, pause_contract (#313-#316)

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -9,8 +9,9 @@ mod types;
 use types::{
     BeneficiaryEntry, DataKey, ReleaseEvent, ReleaseStatus, Vault, EXPIRY_WARNING_THRESHOLD,
     BENEFICIARY_UPDATED_TOPIC, CANCEL_TOPIC, CHECK_IN_TOPIC, DEPOSIT_TOPIC, OWNERSHIP_TOPIC,
-    PING_EXPIRY_TOPIC, RELEASE_TOPIC, SET_BENEFICIARIES_TOPIC, UPDATE_INTERVAL_TOPIC,
-    UPDATE_METADATA_TOPIC, VAULT_CREATED_TOPIC, WITHDRAW_TOPIC, MAX_METADATA_LEN,
+    PING_EXPIRY_TOPIC, RELEASE_TOPIC, SET_BENEFICIARIES_TOPIC, SET_MIN_INTERVAL_TOPIC,
+    UPDATE_INTERVAL_TOPIC, UPDATE_METADATA_TOPIC, VAULT_CREATED_TOPIC, WITHDRAW_TOPIC,
+    MAX_METADATA_LEN,
 };
 
 #[cfg(test)]
@@ -167,6 +168,7 @@ impl TtlVaultContract {
         }
         env.storage().instance().set(&DataKey::MinCheckInInterval, &min_interval);
         env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((SET_MIN_INTERVAL_TOPIC,), min_interval);
     }
 
     /// Sets the maximum allowed check-in interval for vaults.

--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -9,9 +9,9 @@ mod types;
 use types::{
     BeneficiaryEntry, DataKey, ReleaseEvent, ReleaseStatus, Vault, EXPIRY_WARNING_THRESHOLD,
     BENEFICIARY_UPDATED_TOPIC, CANCEL_TOPIC, CHECK_IN_TOPIC, DEPOSIT_TOPIC, OWNERSHIP_TOPIC,
-    PAUSE_TOPIC, PING_EXPIRY_TOPIC, RELEASE_TOPIC, SET_BENEFICIARIES_TOPIC, SET_MIN_INTERVAL_TOPIC,
-    UNPAUSE_TOPIC, UPDATE_INTERVAL_TOPIC, UPDATE_METADATA_TOPIC, VAULT_CREATED_TOPIC,
-    WITHDRAW_TOPIC, MAX_METADATA_LEN,
+    PAUSE_TOPIC, PING_EXPIRY_TOPIC, RELEASE_TOPIC, SET_BENEFICIARIES_TOPIC, SET_MAX_INTERVAL_TOPIC,
+    SET_MIN_INTERVAL_TOPIC, UNPAUSE_TOPIC, UPDATE_INTERVAL_TOPIC, UPDATE_METADATA_TOPIC,
+    VAULT_CREATED_TOPIC, WITHDRAW_TOPIC, MAX_METADATA_LEN,
 };
 
 #[cfg(test)]
@@ -195,6 +195,7 @@ impl TtlVaultContract {
         }
         env.storage().instance().set(&DataKey::MaxCheckInInterval, &max_interval);
         env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((SET_MAX_INTERVAL_TOPIC,), max_interval);
     }
 
     /// Returns the minimum check-in interval if set.

--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -9,9 +9,9 @@ mod types;
 use types::{
     BeneficiaryEntry, DataKey, ReleaseEvent, ReleaseStatus, Vault, EXPIRY_WARNING_THRESHOLD,
     BENEFICIARY_UPDATED_TOPIC, CANCEL_TOPIC, CHECK_IN_TOPIC, DEPOSIT_TOPIC, OWNERSHIP_TOPIC,
-    PING_EXPIRY_TOPIC, RELEASE_TOPIC, SET_BENEFICIARIES_TOPIC, SET_MIN_INTERVAL_TOPIC,
-    UPDATE_INTERVAL_TOPIC, UPDATE_METADATA_TOPIC, VAULT_CREATED_TOPIC, WITHDRAW_TOPIC,
-    MAX_METADATA_LEN,
+    PAUSE_TOPIC, PING_EXPIRY_TOPIC, RELEASE_TOPIC, SET_BENEFICIARIES_TOPIC, SET_MIN_INTERVAL_TOPIC,
+    UNPAUSE_TOPIC, UPDATE_INTERVAL_TOPIC, UPDATE_METADATA_TOPIC, VAULT_CREATED_TOPIC,
+    WITHDRAW_TOPIC, MAX_METADATA_LEN,
 };
 
 #[cfg(test)]
@@ -126,6 +126,7 @@ impl TtlVaultContract {
     pub fn pause(env: Env) {
         Self::require_admin(&env);
         env.storage().instance().set(&DataKey::Paused, &true);
+        env.events().publish((PAUSE_TOPIC,), true);
         env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
     }
 

--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -10,7 +10,7 @@ use types::{
     BeneficiaryEntry, DataKey, ReleaseEvent, ReleaseStatus, Vault, EXPIRY_WARNING_THRESHOLD,
     BENEFICIARY_UPDATED_TOPIC, CANCEL_TOPIC, CHECK_IN_TOPIC, DEPOSIT_TOPIC, OWNERSHIP_TOPIC,
     PING_EXPIRY_TOPIC, RELEASE_TOPIC, SET_BENEFICIARIES_TOPIC, UPDATE_INTERVAL_TOPIC,
-    VAULT_CREATED_TOPIC, WITHDRAW_TOPIC, MAX_METADATA_LEN,
+    UPDATE_METADATA_TOPIC, VAULT_CREATED_TOPIC, WITHDRAW_TOPIC, MAX_METADATA_LEN,
 };
 
 #[cfg(test)]
@@ -809,9 +809,10 @@ impl TtlVaultContract {
             if vault.status != ReleaseStatus::Locked {
                 return Err(ContractError::AlreadyReleased);
             }
-            vault.metadata = metadata;
+            vault.metadata = metadata.clone();
             Self::save_vault(&env, vault_id, &vault);
             env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+            env.events().publish((UPDATE_METADATA_TOPIC, vault_id), metadata);
             Ok(())
         }
 

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -859,6 +859,26 @@ fn test_set_and_get_min_check_in_interval() {
 }
 
 #[test]
+fn test_set_min_check_in_interval_emits_event() {
+    let (env, _, _, _, _, client) = setup();
+    client.set_min_check_in_interval(&120u64);
+
+    let event = env.events().all().iter().find(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
+        topics
+            .get(0)
+            .and_then(|v| v.try_into_val(&env).ok())
+            .map(|s: soroban_sdk::Symbol| s == types::SET_MIN_INTERVAL_TOPIC)
+            .unwrap_or(false)
+    });
+    assert!(event.is_some(), "set_min event not emitted");
+
+    let data = event.unwrap().2.clone();
+    let emitted: u64 = data.try_into_val(&env).unwrap();
+    assert_eq!(emitted, 120u64);
+}
+
+#[test]
 fn test_create_vault_fails_when_interval_below_min() {
     let (_, owner, beneficiary, _, _, client) = setup();
     client.set_min_check_in_interval(&3_600u64);

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -845,6 +845,26 @@ fn test_set_and_get_max_check_in_interval() {
 }
 
 #[test]
+fn test_set_max_check_in_interval_emits_event() {
+    let (env, _, _, _, _, client) = setup();
+    client.set_max_check_in_interval(&7_200u64);
+
+    let event = env.events().all().iter().find(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
+        topics
+            .get(0)
+            .and_then(|v| v.try_into_val(&env).ok())
+            .map(|s: soroban_sdk::Symbol| s == types::SET_MAX_INTERVAL_TOPIC)
+            .unwrap_or(false)
+    });
+    assert!(event.is_some(), "set_max event not emitted");
+
+    let data = event.unwrap().2.clone();
+    let emitted: u64 = data.try_into_val(&env).unwrap();
+    assert_eq!(emitted, 7_200u64);
+}
+
+#[test]
 fn test_create_vault_fails_when_interval_exceeds_max() {
     let (_, owner, beneficiary, _, _, client) = setup();
     client.set_max_check_in_interval(&1_000u64);

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -222,6 +222,27 @@ fn test_pause_and_unpause_toggle() {
     assert!(!client.is_paused());
 }
 
+// ---- Issue #316: pause event emission test ----
+
+#[test]
+fn test_pause_emits_event() {
+    let (env, _, _, _, _, client) = setup();
+    client.pause();
+
+    let event = env.events().all().iter().find(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
+        topics
+            .get(0)
+            .and_then(|v| v.try_into_val(&env).ok())
+            .map(|s: soroban_sdk::Symbol| s == types::PAUSE_TOPIC)
+            .unwrap_or(false)
+    });
+    assert!(event.is_some(), "pause event not emitted");
+
+    let data: bool = event.unwrap().2.into_val(&env);
+    assert!(data);
+}
+
 // ---- Issue #317: unpause event emission test ----
 
 #[test]

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -710,6 +710,29 @@ fn test_update_metadata_rejects_oversized_value() {
 }
 
 #[test]
+fn test_update_metadata_emits_event() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+    let new_meta = soroban_sdk::String::from_str(&env, "ipfs://Qm123");
+
+    client.update_metadata(&vault_id, &owner, &new_meta);
+
+    let event = env.events().all().iter().find(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
+        topics
+            .get(0)
+            .and_then(|v| v.try_into_val(&env).ok())
+            .map(|s: soroban_sdk::Symbol| s == types::UPDATE_METADATA_TOPIC)
+            .unwrap_or(false)
+    });
+    assert!(event.is_some(), "upd_meta event not emitted");
+
+    let data = event.unwrap().2.clone();
+    let emitted: soroban_sdk::String = data.try_into_val(&env).unwrap();
+    assert_eq!(emitted, new_meta);
+}
+
+#[test]
 fn test_get_contract_token_returns_correct_address() {
     let (_, _, _, _, token_address, client) = setup();
     assert_eq!(client.get_contract_token(), token_address);

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -12,6 +12,7 @@ pub const BENEFICIARY_UPDATED_TOPIC: Symbol = symbol_short!("ben_upd");
 pub const SET_BENEFICIARIES_TOPIC: Symbol = symbol_short!("set_bens");
 pub const UPDATE_INTERVAL_TOPIC: Symbol = symbol_short!("upd_intv");
 pub const UPDATE_METADATA_TOPIC: Symbol = symbol_short!("upd_meta");
+pub const SET_MIN_INTERVAL_TOPIC: Symbol = symbol_short!("set_min");
 
 /// Warning threshold in seconds. If TTL remaining < this value, ping_expiry emits an event.
 pub const EXPIRY_WARNING_THRESHOLD: u64 = 86_400; // 24 hours

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -13,6 +13,7 @@ pub const SET_BENEFICIARIES_TOPIC: Symbol = symbol_short!("set_bens");
 pub const UPDATE_INTERVAL_TOPIC: Symbol = symbol_short!("upd_intv");
 pub const UPDATE_METADATA_TOPIC: Symbol = symbol_short!("upd_meta");
 pub const SET_MIN_INTERVAL_TOPIC: Symbol = symbol_short!("set_min");
+pub const SET_MAX_INTERVAL_TOPIC: Symbol = symbol_short!("set_max");
 pub const PAUSE_TOPIC: Symbol = symbol_short!("pause");
 pub const UNPAUSE_TOPIC: Symbol = symbol_short!("unpause");
 

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -13,6 +13,8 @@ pub const SET_BENEFICIARIES_TOPIC: Symbol = symbol_short!("set_bens");
 pub const UPDATE_INTERVAL_TOPIC: Symbol = symbol_short!("upd_intv");
 pub const UPDATE_METADATA_TOPIC: Symbol = symbol_short!("upd_meta");
 pub const SET_MIN_INTERVAL_TOPIC: Symbol = symbol_short!("set_min");
+pub const PAUSE_TOPIC: Symbol = symbol_short!("pause");
+pub const UNPAUSE_TOPIC: Symbol = symbol_short!("unpause");
 
 /// Warning threshold in seconds. If TTL remaining < this value, ping_expiry emits an event.
 pub const EXPIRY_WARNING_THRESHOLD: u64 = 86_400; // 24 hours

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -11,6 +11,7 @@ pub const OWNERSHIP_TOPIC: Symbol = symbol_short!("own_xfer");
 pub const BENEFICIARY_UPDATED_TOPIC: Symbol = symbol_short!("ben_upd");
 pub const SET_BENEFICIARIES_TOPIC: Symbol = symbol_short!("set_bens");
 pub const UPDATE_INTERVAL_TOPIC: Symbol = symbol_short!("upd_intv");
+pub const UPDATE_METADATA_TOPIC: Symbol = symbol_short!("upd_meta");
 
 /// Warning threshold in seconds. If TTL remaining < this value, ping_expiry emits an event.
 pub const EXPIRY_WARNING_THRESHOLD: u64 = 86_400; // 24 hours


### PR DESCRIPTION
## Changes

Adds event emissions for four admin contract functions:

- **#313** – emit `UPDATE_METADATA_TOPIC` event on `update_metadata`
- **#314** – emit `SET_MIN_INTERVAL_TOPIC` event on `set_min_check_in_interval`
- **#315** – emit `SET_MAX_INTERVAL_TOPIC` event on `set_max_check_in_interval`
- **#316** – emit `PAUSE_TOPIC` event on `pause_contract`

Also adds corresponding topic constants in `types.rs` and test coverage in `test.rs`.

## Commits
- `b378817` feat(contract): emit event on update_metadata (#313)
- `0ffd466` feat(contract): emit event on set_min_check_in_interval (#314)
- `ccc24b4` feat(contract): emit event on set_max_check_in_interval (#315)
- `b0ce051` feat(contract): emit event on pause_contract (#316)


Closes #313 
Closes #314 
Closes #315
Closes #316
