### PR TITLE
Add vault metadata and notes functionality

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -12,7 +12,8 @@ use types::{
     CLAIM_VEST_TOPIC, DEPOSIT_TOPIC, OWNERSHIP_TOPIC, PAUSE_TOPIC, PING_EXPIRY_TOPIC,
     RELEASE_TOPIC, SET_BENEFICIARIES_TOPIC, SET_MAX_INTERVAL_TOPIC, SET_MIN_INTERVAL_TOPIC,
     SET_VESTING_TOPIC, UNPAUSE_TOPIC, UPDATE_INTERVAL_TOPIC, UPDATE_METADATA_TOPIC,
-    VAULT_CREATED_TOPIC, WITHDRAW_TOPIC, MAX_METADATA_LEN,
+    VAULT_CREATED_TOPIC, WITHDRAW_TOPIC, MAX_METADATA_LEN, MAX_NAME_LEN, MAX_DESCRIPTION_LEN,
+    MAX_NOTES_LEN,
 };
 
 #[cfg(test)]
@@ -312,61 +313,64 @@ impl TtlVaultContract {
     /// * Panics if `check_in_interval` is 0
     /// * Panics if `check_in_interval` is outside the configured min/max bounds
     pub fn create_vault(
-        env: Env,
-        owner: Address,
-        beneficiary: Address,
-        check_in_interval: u64,
-    ) -> u64 {
-        owner.require_auth();
-        Self::require_initialized(&env);
-        if check_in_interval == 0 {
-            panic_with_error!(&env, ContractError::InvalidInterval);
+            env: Env,
+            owner: Address,
+            beneficiary: Address,
+            check_in_interval: u64,
+        ) -> u64 {
+            owner.require_auth();
+            Self::require_initialized(&env);
+            if check_in_interval == 0 {
+                panic_with_error!(&env, ContractError::InvalidInterval);
+            }
+
+            Self::assert_interval_in_bounds(&env, check_in_interval);
+
+            if owner == beneficiary {
+                panic_with_error!(&env, ContractError::InvalidBeneficiary);
+            }
+
+            let vault_id = Self::vault_count(env.clone()) + 1;
+            let timestamp = env.ledger().timestamp();
+            let metadata = String::from_str(&env, "");
+            Self::assert_metadata_len(&env, &metadata);
+            let vault = Vault {
+                owner: owner.clone(),
+                beneficiary: beneficiary.clone(),
+                balance: 0,
+                check_in_interval,
+                last_check_in: timestamp,
+                created_at: timestamp,
+                status: ReleaseStatus::Locked,
+                beneficiaries: Vec::new(&env),
+                metadata,
+                name: String::from_str(&env, ""),
+                description: String::from_str(&env, ""),
+                notes: String::from_str(&env, ""),
+            };
+            Self::save_vault(&env, vault_id, &vault);
+            Self::add_owner_vault_id(&env, &owner, vault_id, check_in_interval);
+            Self::add_beneficiary_vault_id(&env, &beneficiary, vault_id, check_in_interval);
+            // VaultCount is an incrementing generation ID and must be updated
+            // only after the vault and its owner/beneficiary indexes are persisted.
+            //
+            // Ordering guarantee:
+            //  1) Compute next ID from current vault count
+            //  2) Persist the vault and owner/beneficiary indexes
+            //  3) Persist VaultCount only after the vault is fully saved
+            // If any prior call (save_vault/add_owner_vault_id/add_beneficiary_vault_id)
+            // panics, VaultCount remains unchanged and consumers cannot observe
+            // a hole in the sequence.
+            let key = DataKey::VaultCount;
+            env.storage().persistent().set(&key, &vault_id);
+            env.storage().persistent().extend_ttl(&key, VAULT_TTL_THRESHOLD, VAULT_TTL_LEDGERS);
+            env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+            env.events().publish(
+                (VAULT_CREATED_TOPIC,),
+                (vault_id, owner, beneficiary, check_in_interval, timestamp),
+            );
+            vault_id
         }
-
-        Self::assert_interval_in_bounds(&env, check_in_interval);
-
-        if owner == beneficiary {
-            panic_with_error!(&env, ContractError::InvalidBeneficiary);
-        }
-
-        let vault_id = Self::vault_count(env.clone()) + 1;
-        let timestamp = env.ledger().timestamp();
-        let metadata = String::from_str(&env, "");
-        Self::assert_metadata_len(&env, &metadata);
-        let vault = Vault {
-            owner: owner.clone(),
-            beneficiary: beneficiary.clone(),
-            balance: 0,
-            check_in_interval,
-            last_check_in: timestamp,
-            created_at: timestamp,
-            status: ReleaseStatus::Locked,
-            beneficiaries: Vec::new(&env),
-            metadata,
-        };
-        Self::save_vault(&env, vault_id, &vault);
-        Self::add_owner_vault_id(&env, &owner, vault_id, check_in_interval);
-        Self::add_beneficiary_vault_id(&env, &beneficiary, vault_id, check_in_interval);
-        // VaultCount is an incrementing generation ID and must be updated
-        // only after the vault and its owner/beneficiary indexes are persisted.
-        //
-        // Ordering guarantee:
-        //  1) Compute next ID from current vault count
-        //  2) Persist the vault and owner/beneficiary indexes
-        //  3) Persist VaultCount only after the vault is fully saved
-        // If any prior call (save_vault/add_owner_vault_id/add_beneficiary_vault_id)
-        // panics, VaultCount remains unchanged and consumers cannot observe
-        // a hole in the sequence.
-        let key = DataKey::VaultCount;
-        env.storage().persistent().set(&key, &vault_id);
-        env.storage().persistent().extend_ttl(&key, VAULT_TTL_THRESHOLD, VAULT_TTL_LEDGERS);
-        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
-        env.events().publish(
-            (VAULT_CREATED_TOPIC,),
-            (vault_id, owner, beneficiary, check_in_interval, timestamp),
-        );
-        vault_id
-    }
 
     /// Records a check-in to reset the vault's expiry timer.
     ///
@@ -971,6 +975,68 @@ impl TtlVaultContract {
             env.events().publish((UPDATE_METADATA_TOPIC, vault_id), metadata);
             Ok(())
         }
+
+    /// Sets the vault name, description, and notes fields.
+    /// 
+    /// # Arguments
+    /// * `vault_id` - The vault ID
+    /// * `caller` - The address calling this function (must be vault owner)
+    /// * `name` - Vault name/title (max 64 chars)
+    /// * `description` - Vault description (max 512 chars)
+    /// * `notes` - Notes/instructions for beneficiary (max 1024 chars)
+    /// 
+    /// # Errors
+    /// * `ContractError::NotOwner` - If caller is not the vault owner
+    /// * `ContractError::AlreadyReleased` - If vault is not in Locked status
+    /// * `ContractError::InvalidAmount` - If any field exceeds size limits
+    pub fn set_vault_notes(
+        env: Env,
+        vault_id: u64,
+        caller: Address,
+        name: String,
+        description: String,
+        notes: String,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        
+        // Validate field lengths
+        if name.len() > MAX_NAME_LEN {
+            return Err(ContractError::InvalidAmount);
+        }
+        if description.len() > MAX_DESCRIPTION_LEN {
+            return Err(ContractError::InvalidAmount);
+        }
+        if notes.len() > MAX_NOTES_LEN {
+            return Err(ContractError::InvalidAmount);
+        }
+        
+        let mut vault = Self::load_vault(&env, vault_id);
+        if caller != vault.owner {
+            return Err(ContractError::NotOwner);
+        }
+        if vault.status != ReleaseStatus::Locked {
+            return Err(ContractError::AlreadyReleased);
+        }
+        
+        vault.name = name;
+        vault.description = description;
+        vault.notes = notes;
+        Self::save_vault(&env, vault_id, &vault);
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        Ok(())
+    }
+
+    /// Gets the vault metadata fields (name, description, notes).
+    /// 
+    /// # Arguments
+    /// * `vault_id` - The vault ID
+    /// 
+    /// # Returns
+    /// A tuple of (name, description, notes)
+    pub fn get_vault_notes(env: Env, vault_id: u64) -> (String, String, String) {
+        let vault = Self::load_vault(&env, vault_id);
+        (vault.name, vault.description, vault.notes)
+    }
 
     // --- Task 5: vesting schedules ---
 

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -25,6 +25,15 @@ pub const EXPIRY_WARNING_THRESHOLD: u64 = 86_400; // 24 hours
 /// Maximum length for vault metadata string
 pub const MAX_METADATA_LEN: u32 = 256;
 
+/// Maximum length for vault name
+pub const MAX_NAME_LEN: u32 = 64;
+
+/// Maximum length for vault description
+pub const MAX_DESCRIPTION_LEN: u32 = 512;
+
+/// Maximum length for vault notes
+pub const MAX_NOTES_LEN: u32 = 1024;
+
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
@@ -102,4 +111,10 @@ pub struct Vault {
     pub beneficiaries: Vec<BeneficiaryEntry>,
     /// Optional short metadata string (label or IPFS hash).
     pub metadata: String,
+    /// Vault name/title for easy identification
+    pub name: String,
+    /// Detailed description of vault purpose
+    pub description: String,
+    /// Notes/instructions for beneficiary
+    pub notes: String,
 }

--- a/contracts/ttl_vault/test_snapshots/test/test_batch_check_in_extends_vault_expiry.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_batch_check_in_extends_vault_expiry.1.json
@@ -574,6 +574,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -583,6 +591,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -699,6 +723,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -708,6 +740,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_batch_check_in_fails_for_non_owner.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_batch_check_in_fails_for_non_owner.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_batch_check_in_resets_last_check_in_for_multiple_vaults.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_batch_check_in_resets_last_check_in_for_multiple_vaults.1.json
@@ -574,6 +574,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -583,6 +591,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -699,6 +723,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -708,6 +740,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1719,6 +1767,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1728,6 +1784,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""
@@ -1848,6 +1920,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1857,6 +1937,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_batch_deposit_rejected_when_any_vault_expired.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_batch_deposit_rejected_when_any_vault_expired.1.json
@@ -514,6 +514,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -523,6 +531,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -639,6 +663,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -648,6 +680,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1763,6 +1811,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1772,6 +1828,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""
@@ -1892,6 +1964,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1901,6 +1981,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_batch_deposit_updates_multiple_vaults.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_batch_deposit_updates_multiple_vaults.1.json
@@ -619,6 +619,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -628,6 +636,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -744,6 +768,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -753,6 +785,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1903,6 +1951,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1912,6 +1968,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""
@@ -2032,6 +2104,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -2041,6 +2121,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_batch_deposit_validates_all_items_before_transfer.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_batch_deposit_validates_all_items_before_transfer.1.json
@@ -452,6 +452,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -461,6 +469,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1481,6 +1505,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1490,6 +1522,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""
@@ -1873,6 +1921,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1882,6 +1938,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_batch_withdraw_decrements_multiple_vaults.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_batch_withdraw_decrements_multiple_vaults.1.json
@@ -761,6 +761,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -770,6 +778,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -886,6 +910,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -895,6 +927,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -2581,6 +2629,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -2590,6 +2646,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""
@@ -2710,6 +2782,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -2719,6 +2799,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_batch_withdraw_rolls_back_on_insufficient_balance.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_batch_withdraw_rolls_back_on_insufficient_balance.1.json
@@ -598,6 +598,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -607,6 +615,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -723,6 +747,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -732,6 +764,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -2068,6 +2116,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -2077,6 +2133,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""
@@ -2197,6 +2269,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -2206,6 +2286,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_batch_withdraw_validates_mismatched_lengths.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_batch_withdraw_validates_mismatched_lengths.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_cancel_vault_emits_cancel_event.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_cancel_vault_emits_cancel_event.1.json
@@ -488,6 +488,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -497,6 +505,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_cancel_vault_event_contains_owner_and_refund_amount.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_cancel_vault_event_contains_owner_and_refund_amount.1.json
@@ -488,6 +488,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -497,6 +505,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_cancel_vault_refunds_owner_and_marks_cancelled.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_cancel_vault_refunds_owner_and_marks_cancelled.1.json
@@ -491,6 +491,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -500,6 +508,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_cancel_vault_removes_from_owner_and_beneficiary_indexes.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_cancel_vault_removes_from_owner_and_beneficiary_indexes.1.json
@@ -407,6 +407,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -416,6 +424,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_cancel_vault_requires_auth_before_load.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_cancel_vault_requires_auth_before_load.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_check_in_emits_event_with_correct_topic.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_check_in_emits_event_with_correct_topic.1.json
@@ -501,6 +501,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -510,6 +518,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_check_in_extends_owner_index_ttl.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_check_in_extends_owner_index_ttl.1.json
@@ -502,6 +502,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -511,6 +519,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_check_in_uses_check_in_topic_constant.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_check_in_uses_check_in_topic_constant.1.json
@@ -501,6 +501,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -510,6 +518,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_claim_all_installments_drains_vault.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_claim_all_installments_drains_vault.1.json
@@ -600,6 +600,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -609,6 +617,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -2270,6 +2294,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -2279,6 +2311,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_claim_already_complete_error.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_claim_already_complete_error.1.json
@@ -598,6 +598,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -607,6 +615,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_claim_first_installment.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_claim_first_installment.1.json
@@ -600,6 +600,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -609,6 +617,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -2270,6 +2294,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -2279,6 +2311,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_claim_multiple_installments_at_once.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_claim_multiple_installments_at_once.1.json
@@ -599,6 +599,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -608,6 +616,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_claim_no_schedule_returns_vesting_not_found.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_claim_no_schedule_returns_vesting_not_found.1.json
@@ -535,6 +535,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -544,6 +552,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1874,6 +1898,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1883,6 +1915,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_claim_nothing_to_claim_before_start_time.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_claim_nothing_to_claim_before_start_time.1.json
@@ -597,6 +597,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -606,6 +614,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_claim_vested_emits_event.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_claim_vested_emits_event.1.json
@@ -597,6 +597,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -606,6 +614,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_create_vault_initial_metadata_respects_max_len.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_create_vault_initial_metadata_respects_max_len.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1265,6 +1289,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1274,6 +1306,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_create_vault_long_interval_remains_accessible.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_create_vault_long_interval_remains_accessible.1.json
@@ -449,6 +449,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -458,6 +466,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1267,6 +1291,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1276,6 +1308,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_create_vault_succeeds_at_max_boundary.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_create_vault_succeeds_at_max_boundary.1.json
@@ -499,6 +499,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -508,6 +516,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1396,6 +1420,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1405,6 +1437,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_create_vault_succeeds_at_min_boundary.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_create_vault_succeeds_at_min_boundary.1.json
@@ -499,6 +499,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -508,6 +516,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1396,6 +1420,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1405,6 +1437,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_deposit_emits_event.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_deposit_emits_event.1.json
@@ -531,6 +531,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -540,6 +548,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_deposit_into_expired_vault_is_rejected.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_deposit_into_expired_vault_is_rejected.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_deposit_into_expired_vault_returns_vault_expired_error.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_deposit_into_expired_vault_returns_vault_expired_error.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_deposit_rejects_balance_overflow.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_deposit_rejects_balance_overflow.1.json
@@ -648,6 +648,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -657,6 +665,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_deposit_rejects_negative_amount.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_deposit_rejects_negative_amount.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_deposit_rejects_zero_amount.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_deposit_rejects_zero_amount.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_get_active_vaults_by_beneficiary_excludes_released.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_get_active_vaults_by_beneficiary_excludes_released.1.json
@@ -536,6 +536,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -545,6 +553,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_get_release_status_returns_locked_released_cancelled.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_get_release_status_returns_locked_released_cancelled.1.json
@@ -693,6 +693,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -702,6 +710,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -818,6 +842,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -827,6 +859,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_get_release_status_view.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_get_release_status_view.1.json
@@ -535,6 +535,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -544,6 +552,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_get_ttl_remaining_returns_none_when_expired.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_get_ttl_remaining_returns_none_when_expired.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_get_vaults_by_beneficiary_pagination.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_get_vaults_by_beneficiary_pagination.1.json
@@ -707,6 +707,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -716,6 +724,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -832,6 +856,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -841,6 +873,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -957,6 +1005,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -966,6 +1022,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1082,6 +1154,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -1091,6 +1171,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1207,6 +1303,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -1216,6 +1320,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_get_vaults_by_beneficiary_tracks_vaults.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_get_vaults_by_beneficiary_tracks_vaults.1.json
@@ -623,6 +623,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -632,6 +640,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -748,6 +772,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -757,6 +789,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -873,6 +921,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -882,6 +938,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_get_vaults_by_beneficiary_with_status_filter.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_get_vaults_by_beneficiary_with_status_filter.1.json
@@ -684,6 +684,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -693,6 +701,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -809,6 +833,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -818,6 +850,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_get_vaults_by_owner_pagination.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_get_vaults_by_owner_pagination.1.json
@@ -707,6 +707,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -716,6 +724,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -832,6 +856,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -841,6 +873,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -957,6 +1005,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -966,6 +1022,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1082,6 +1154,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -1091,6 +1171,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1207,6 +1303,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -1216,6 +1320,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_get_vaults_by_owner_tracks_multiple_vaults.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_get_vaults_by_owner_tracks_multiple_vaults.1.json
@@ -511,6 +511,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -520,6 +528,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -636,6 +660,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -645,6 +677,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_get_vaults_by_owner_with_cancelled_status_filter.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_get_vaults_by_owner_with_cancelled_status_filter.1.json
@@ -405,6 +405,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -414,6 +422,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_get_vaults_by_owner_with_status_filter.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_get_vaults_by_owner_with_status_filter.1.json
@@ -684,6 +684,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -693,6 +701,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -809,6 +833,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -818,6 +850,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_min_and_max_both_enforced.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_min_and_max_both_enforced.1.json
@@ -553,6 +553,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -562,6 +570,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1855,6 +1879,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1864,6 +1896,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_partial_release_emits_partial_event.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_partial_release_emits_partial_event.1.json
@@ -591,6 +591,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -600,6 +608,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1925,6 +1949,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1934,6 +1966,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_partial_release_fails_if_insufficient_balance.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_partial_release_fails_if_insufficient_balance.1.json
@@ -532,6 +532,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -541,6 +549,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_partial_release_rejected_on_expired_vault.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_partial_release_rejected_on_expired_vault.1.json
@@ -532,6 +532,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -541,6 +549,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_partial_release_rejects_negative_amount.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_partial_release_rejects_negative_amount.1.json
@@ -532,6 +532,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -541,6 +549,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_partial_release_rejects_zero_amount.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_partial_release_rejects_zero_amount.1.json
@@ -532,6 +532,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -541,6 +549,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_partial_release_transfers_amount_to_beneficiary.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_partial_release_transfers_amount_to_beneficiary.1.json
@@ -592,6 +592,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -601,6 +609,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1978,6 +2002,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1987,6 +2019,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_partial_release_with_multi_beneficiary_applies_bps_split.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_partial_release_with_multi_beneficiary_applies_bps_split.1.json
@@ -791,6 +791,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -800,6 +808,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -2719,6 +2743,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -2728,6 +2760,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_partial_release_with_multi_beneficiary_last_entry_absorbs_dust.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_partial_release_with_multi_beneficiary_last_entry_absorbs_dust.1.json
@@ -790,6 +790,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -799,6 +807,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -2718,6 +2742,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -2727,6 +2759,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_partial_release_without_multi_beneficiary_sends_to_primary.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_partial_release_without_multi_beneficiary_sends_to_primary.1.json
@@ -592,6 +592,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -601,6 +609,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1978,6 +2002,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1987,6 +2019,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_paused_blocks_check_in_withdraw_and_trigger_release.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_paused_blocks_check_in_withdraw_and_trigger_release.1.json
@@ -632,6 +632,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -641,6 +649,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_ping_expiry_emits_event_when_near_expiry.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_ping_expiry_emits_event_when_near_expiry.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_ping_expiry_no_event_when_far_from_expiry.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_ping_expiry_no_event_when_far_from_expiry.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_ping_expiry_returns_zero_when_expired.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_ping_expiry_returns_zero_when_expired.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_set_beneficiaries_emits_event.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_set_beneficiaries_emits_event.1.json
@@ -586,6 +586,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -595,6 +603,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_set_beneficiaries_rejects_empty_list.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_set_beneficiaries_rejects_empty_list.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_set_beneficiaries_rejects_invalid_bps.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_set_beneficiaries_rejects_invalid_bps.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_set_beneficiaries_rejects_owner_as_beneficiary.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_set_beneficiaries_rejects_owner_as_beneficiary.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_set_vesting_emits_event.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_set_vesting_emits_event.1.json
@@ -595,6 +595,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -604,6 +612,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_set_vesting_schedule_rejects_empty_vault.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_set_vesting_schedule_rejects_empty_vault.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_set_vesting_schedule_rejects_zero_installments.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_set_vesting_schedule_rejects_zero_installments.1.json
@@ -532,6 +532,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -541,6 +549,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_set_vesting_schedule_rejects_zero_interval.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_set_vesting_schedule_rejects_zero_interval.1.json
@@ -532,6 +532,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -541,6 +549,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_set_vesting_schedule_requires_owner.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_set_vesting_schedule_requires_owner.1.json
@@ -532,6 +532,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -541,6 +549,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_set_vesting_schedule_stores_schedule.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_set_vesting_schedule_stores_schedule.1.json
@@ -596,6 +596,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -605,6 +613,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_state_mutating_calls_extend_instance_ttl.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_state_mutating_calls_extend_instance_ttl.1.json
@@ -1240,6 +1240,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -1252,6 +1260,22 @@
                       },
                       "val": {
                         "string": "test"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
+                      },
+                      "val": {
+                        "string": ""
                       }
                     },
                     {
@@ -1365,6 +1389,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -1374,6 +1406,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_transfer_ownership_emits_ownership_event.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_transfer_ownership_emits_ownership_event.1.json
@@ -504,6 +504,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -513,6 +521,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_transfer_ownership_event_contains_old_and_new_owner.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_transfer_ownership_event_contains_old_and_new_owner.1.json
@@ -504,6 +504,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -513,6 +521,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_transfer_ownership_preserves_beneficiary_index.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_transfer_ownership_preserves_beneficiary_index.1.json
@@ -507,6 +507,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -516,6 +524,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1476,6 +1500,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1485,6 +1517,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_transfer_ownership_rejects_new_owner_equal_to_beneficiary.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_transfer_ownership_rejects_new_owner_equal_to_beneficiary.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_transfer_ownership_updates_owner_and_owner_index.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_transfer_ownership_updates_owner_and_owner_index.1.json
@@ -509,6 +509,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -518,6 +526,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1538,6 +1562,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1547,6 +1579,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_trigger_release_emits_event_with_zero_balance.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_trigger_release_emits_event_with_zero_balance.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_trigger_release_multi_beneficiary_bps_split_distributes_correctly.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_trigger_release_multi_beneficiary_bps_split_distributes_correctly.1.json
@@ -720,6 +720,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -729,6 +737,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -2801,6 +2825,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -2810,6 +2842,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_trigger_release_returns_not_expired_error_before_ttl_lapses.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_trigger_release_returns_not_expired_error_before_ttl_lapses.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_trigger_release_with_vesting_keeps_balance.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_trigger_release_with_vesting_keeps_balance.1.json
@@ -598,6 +598,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -607,6 +615,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -2016,6 +2040,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -2025,6 +2057,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_update_beneficiary_emits_beneficiary_updated_event.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_update_beneficiary_emits_beneficiary_updated_event.1.json
@@ -504,6 +504,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -513,6 +521,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_update_beneficiary_event_contains_old_and_new_beneficiary.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_update_beneficiary_event_contains_old_and_new_beneficiary.1.json
@@ -504,6 +504,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -513,6 +521,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_update_beneficiary_rejects_owner_as_beneficiary.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_update_beneficiary_rejects_owner_as_beneficiary.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_update_beneficiary_requires_auth_before_load.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_update_beneficiary_requires_auth_before_load.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_update_beneficiary_updates_index.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_update_beneficiary_updates_index.1.json
@@ -508,6 +508,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -517,6 +525,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_update_check_in_interval.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_update_check_in_interval.1.json
@@ -503,6 +503,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -512,6 +520,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1405,6 +1429,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1414,6 +1446,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_update_check_in_interval_emits_event_with_old_and_new.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_update_check_in_interval_emits_event_with_old_and_new.1.json
@@ -501,6 +501,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -510,6 +518,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_update_check_in_interval_extends_vault_storage_ttl.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_update_check_in_interval_extends_vault_storage_ttl.1.json
@@ -503,6 +503,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -512,6 +520,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -1405,6 +1429,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1414,6 +1446,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""
@@ -1534,6 +1582,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1543,6 +1599,22 @@
                 {
                   "key": {
                     "symbol": "metadata"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
                   },
                   "val": {
                     "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_update_check_in_interval_fails_when_below_min.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_update_check_in_interval_fails_when_below_min.1.json
@@ -499,6 +499,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -508,6 +516,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_update_check_in_interval_fails_when_exceeds_max.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_update_check_in_interval_fails_when_exceeds_max.1.json
@@ -499,6 +499,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -508,6 +516,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_update_metadata_can_be_overwritten.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_update_metadata_can_be_overwritten.1.json
@@ -563,6 +563,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -575,6 +583,22 @@
                       },
                       "val": {
                         "string": "v2"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
+                      },
+                      "val": {
+                        "string": ""
                       }
                     },
                     {
@@ -1541,6 +1565,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "description"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "last_check_in"
                   },
                   "val": {
@@ -1553,6 +1585,22 @@
                   },
                   "val": {
                     "string": "v2"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "name"
+                  },
+                  "val": {
+                    "string": ""
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "notes"
+                  },
+                  "val": {
+                    "string": ""
                   }
                 },
                 {

--- a/contracts/ttl_vault/test_snapshots/test/test_update_metadata_emits_event.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_update_metadata_emits_event.1.json
@@ -504,6 +504,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -516,6 +524,22 @@
                       },
                       "val": {
                         "string": "ipfs://Qm123"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
+                      },
+                      "val": {
+                        "string": ""
                       }
                     },
                     {

--- a/contracts/ttl_vault/test_snapshots/test/test_update_metadata_rejects_oversized_value.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_update_metadata_rejects_oversized_value.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_upgrade_fails_for_non_admin.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_upgrade_fails_for_non_admin.1.json
@@ -447,6 +447,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -456,6 +464,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_vault_count_consistent_after_creation.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_vault_count_consistent_after_creation.1.json
@@ -448,6 +448,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -457,6 +465,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_vault_count_is_consistent_after_create.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_vault_count_is_consistent_after_create.1.json
@@ -513,6 +513,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -522,6 +530,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -638,6 +662,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -647,6 +679,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_vault_count_view.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_vault_count_view.1.json
@@ -512,6 +512,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -521,6 +529,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""
@@ -637,6 +661,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -646,6 +678,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_vault_exists_for_existing_and_missing_ids.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_vault_exists_for_existing_and_missing_ids.1.json
@@ -449,6 +449,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -458,6 +466,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_vesting_with_multi_beneficiary_split.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_vesting_with_multi_beneficiary_split.1.json
@@ -739,6 +739,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -748,6 +756,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_withdraw_emits_event.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_withdraw_emits_event.1.json
@@ -592,6 +592,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -601,6 +609,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_withdraw_rejected_on_cancelled_vault.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_withdraw_rejected_on_cancelled_vault.1.json
@@ -404,6 +404,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -413,6 +421,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_withdraw_rejected_on_released_vault.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_withdraw_rejected_on_released_vault.1.json
@@ -533,6 +533,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -542,6 +550,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_withdraw_rejects_negative_amount.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_withdraw_rejects_negative_amount.1.json
@@ -532,6 +532,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -541,6 +549,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""

--- a/contracts/ttl_vault/test_snapshots/test/test_withdraw_rejects_zero_amount.1.json
+++ b/contracts/ttl_vault/test_snapshots/test/test_withdraw_rejects_zero_amount.1.json
@@ -532,6 +532,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "description"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "last_check_in"
                       },
                       "val": {
@@ -541,6 +549,22 @@
                     {
                       "key": {
                         "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "notes"
                       },
                       "val": {
                         "string": ""


### PR DESCRIPTION
- Extended Vault struct with name, description, and notes fields
- Added set_vault_notes() function with size limits (name: 64, description: 512, notes: 1024 chars)
- Added get_vault_notes() function to retrieve metadata
- Metadata persists across check-ins and vault operations
- All fields are optional and initialized as empty strings

Closes #351
closes #353