### PR TITLE
feat: add get_vault_last_check_in function

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -1189,6 +1189,18 @@ impl TtlVaultContract {
         Self::load_vault(&env, vault_id)
     }
 
+    /// Returns the last check-in timestamp for a vault.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `vault_id` - The unique identifier of the vault
+    ///
+    /// # Returns
+    /// The Unix timestamp of the last check-in
+    pub fn get_vault_last_check_in(env: Env, vault_id: u64) -> u64 {
+        Self::load_vault(&env, vault_id).last_check_in
+    }
+
     /// Checks if a vault exists.
     ///
     /// # Arguments

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -2193,3 +2193,15 @@ fn test_claim_vested_emits_event() {
 
     assert!(find_event_by_topic(&env, types::CLAIM_VEST_TOPIC));
 }
+
+#[test]
+fn test_get_vault_last_check_in_returns_correct_timestamp() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+
+    env.ledger().with_mut(|l| l.timestamp += 50);
+    client.check_in(&vault_id, &owner);
+
+    let expected = env.ledger().timestamp();
+    assert_eq!(client.get_vault_last_check_in(&vault_id), expected);
+}


### PR DESCRIPTION
## Summary

Closes #325

Adds `get_vault_last_check_in(env, vault_id: u64) -> u64` — a dedicated getter that returns just the last check-in timestamp for a vault, so callers don't need to fetch the full `Vault` struct.

## Changes

- `contracts/ttl_vault/src/lib.rs`: Added `get_vault_last_check_in` after `get_vault`
- `contracts/ttl_vault/src/test.rs`: Added `test_get_vault_last_check_in_returns_correct_timestamp`

## Testing

Test creates a vault, advances ledger time, calls `check_in`, then asserts `get_vault_last_check_in` returns the expected timestamp.