### PR TITLE
fix(#305, #306): document ledger time assumption and get_vault read-only behavior

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -1299,6 +1299,17 @@ impl TtlVaultContract {
     /// A vault is considered expired when the current timestamp is greater than
     /// or equal to the deadline (last_check_in + check_in_interval).
     ///
+    /// # Ledger time monotonicity assumption
+    /// This function relies on `env.ledger().timestamp()` being monotonically
+    /// non-decreasing across ledger closes. The Stellar consensus protocol
+    /// guarantees this property: each ledger's close time must be strictly
+    /// greater than the previous ledger's close time. Clock skew between
+    /// individual validators does not affect this guarantee because the
+    /// agreed-upon close time is determined by consensus, not by any single
+    /// node's wall clock. Therefore the comparison `now >= deadline` is
+    /// reliable and will never produce a false expiry due to time going
+    /// backwards.
+    ///
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `vault_id` - The unique identifier of the vault
@@ -1315,6 +1326,15 @@ impl TtlVaultContract {
     }
 
     /// Retrieves a vault by its unique identifier.
+    ///
+    /// This is a pure read-only function. It does **not** extend the vault's
+    /// persistent storage TTL. Extending TTL on every read would introduce
+    /// unintended side effects: callers (including off-chain indexers) would
+    /// inadvertently pay storage fees and mutate ledger state. TTL extension
+    /// is intentionally reserved for state-mutating operations such as
+    /// `check_in`, `deposit`, and `withdraw`. If a vault is only ever read
+    /// and never written to, its storage TTL will eventually lapse and the
+    /// entry will be archived by the network.
     ///
     /// # Arguments
     /// * `env` - The Soroban environment

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -2205,3 +2205,51 @@ fn test_get_vault_last_check_in_returns_correct_timestamp() {
     let expected = env.ledger().timestamp();
     assert_eq!(client.get_vault_last_check_in(&vault_id), expected);
 }
+
+// --- #305: is_expired boundary ---
+
+/// Verifies that is_expired returns true at the exact deadline (now == deadline).
+/// The expiry condition is `now >= deadline`, so the boundary must be expired.
+#[test]
+fn test_is_expired_at_exact_deadline() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let interval = 100u64;
+    let vault_id = client.create_vault(&owner, &beneficiary, &interval);
+
+    // One tick before deadline: not expired
+    env.ledger().with_mut(|l| l.timestamp += interval - 1);
+    assert!(!client.is_expired(&vault_id));
+
+    // Exactly at deadline: expired
+    env.ledger().with_mut(|l| l.timestamp += 1);
+    assert!(client.is_expired(&vault_id));
+}
+
+// --- #306: get_vault does not extend TTL ---
+
+/// Verifies that get_vault is read-only and does not extend the vault's
+/// persistent storage TTL. Repeated reads must not alter ledger state.
+#[test]
+fn test_get_vault_does_not_extend_ttl() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64);
+
+    // Capture TTL immediately after creation
+    let ttl_after_create = env
+        .storage()
+        .persistent()
+        .get_ttl(&DataKey::Vault(vault_id));
+
+    // Read the vault multiple times
+    client.get_vault(&vault_id);
+    client.get_vault(&vault_id);
+    client.get_vault(&vault_id);
+
+    // TTL must be unchanged — get_vault must not extend it
+    let ttl_after_reads = env
+        .storage()
+        .persistent()
+        .get_ttl(&DataKey::Vault(vault_id));
+
+    assert_eq!(ttl_after_create, ttl_after_reads);
+}


### PR DESCRIPTION
## Summary

Addresses two low-priority smart contract documentation and test gaps.

---

### #305 — `is_expired` does not account for ledger time precision

**Problem:** `is_expired` compares `now >= vault.last_check_in + vault.check_in_interval` using ledger timestamps. The concern was that clock skew could make this comparison unreliable.

**Changes:**
- Added a `# Ledger time monotonicity assumption` section to the `is_expired` doc comment. Documents that the Stellar consensus protocol guarantees ledger close timestamps are strictly non-decreasing — each ledger's close time must be greater than the previous one. Clock skew between individual validators does not affect this because the agreed-upon close time is determined by consensus, not any single node's wall clock. The `now >= deadline` comparison is therefore reliable.
- Added `test_is_expired_at_exact_deadline`: advances ledger time to `interval - 1` ticks (asserts not expired), then advances one more tick to hit exactly `now == deadline` (asserts expired), confirming the `>=` boundary behaves correctly.

---

### #306 — `get_vault` does not extend vault TTL on read

**Problem:** `get_vault` is read-only but does not extend the vault's TTL. The question was whether it should.

**Changes:**
- Added a doc comment to `get_vault` explicitly documenting it as a **pure read-only function that intentionally does not extend persistent storage TTL**. Rationale: extending TTL on every read would introduce unintended side effects — callers (including off-chain indexers) would inadvertently pay storage fees and mutate ledger state. TTL extension is reserved for state-mutating operations (`check_in`, `deposit`, `withdraw`). If a vault is only ever read and never written to, its storage TTL will eventually lapse and the entry will be archived by the network — this is expected behavior.
- Added `test_get_vault_does_not_extend_ttl`: captures the persistent storage TTL immediately after vault creation, calls `get_vault` three times, then asserts the TTL is unchanged.

---

## Files Changed

- `contracts/ttl_vault/src/lib.rs` — updated doc comments on `is_expired` and `get_vault`
- `contracts/ttl_vault/src/test.rs` — added `test_is_expired_at_exact_deadline` and `test_get_vault_does_not_extend_ttl`

Closes #305
Closes #306