### PR TITLE
feat: vault ownership transfer with time-lock and approval flow

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -9,6 +9,7 @@ mod types;
 use types::{
     BeneficiaryEntry, DataKey, ReleaseEvent, ReleaseStatus, ReleaseCondition, Vault, VestingSchedule,
     PasskeyHash, BackupCode, DisputeStatus, WithdrawalScheduleEntry, ConditionalAcceptanceEntry,
+    OwnershipTransferRequest,
     EXPIRY_WARNING_THRESHOLD, BENEFICIARY_UPDATED_TOPIC, CANCEL_TOPIC, CHECK_IN_TOPIC,
     CLAIM_VEST_TOPIC, DEPOSIT_TOPIC, OWNERSHIP_TOPIC, PAUSE_TOPIC, PING_EXPIRY_TOPIC,
     RELEASE_TOPIC, SET_BENEFICIARIES_TOPIC, SET_MAX_INTERVAL_TOPIC, SET_MIN_INTERVAL_TOPIC,
@@ -18,7 +19,8 @@ use types::{
     INHERITANCE_TOPIC, ADD_PASSKEY_TOPIC, REMOVE_PASSKEY_TOPIC, ROTATE_PASSKEY_TOPIC,
     BACKUP_CODE_USED_TOPIC, BACKUP_CODES_GENERATED_TOPIC, DELEGATE_BENEFICIARY_TOPIC,
     DISPUTE_FILED_TOPIC, DISPUTE_RESOLVED_TOPIC, WITHDRAWAL_SCHEDULED_TOPIC, WITHDRAWAL_EXECUTED_TOPIC,
-    CONDITIONS_ACCEPTED_TOPIC,
+    CONDITIONS_ACCEPTED_TOPIC, OWNERSHIP_INITIATED_TOPIC, OWNERSHIP_ACCEPTED_TOPIC,
+    OWNERSHIP_CANCELLED_TOPIC,
 };
 
 #[cfg(test)]
@@ -49,6 +51,14 @@ pub const INSTANCE_TTL_LEDGERS: u32 = 200_000;
 const LEDGER_SECOND: u32 = 5;
 /// Soroban maximum persistent entry TTL in ledgers (~180 days at 5s/ledger).
 const MAX_PERSISTENT_TTL: u32 = 3_110_400;
+
+/// Time-lock delay for ownership transfers in seconds (24 hours).
+/// The new owner cannot accept until this many seconds have elapsed after initiation.
+const OWNERSHIP_TRANSFER_TIMELOCK: u64 = 86_400;
+
+/// Expiry window for pending ownership transfer requests in seconds (7 days).
+/// If the new owner does not accept within this window, the request expires.
+const OWNERSHIP_TRANSFER_EXPIRY: u64 = 604_800;
 
 /// Compute a persistent storage TTL (in ledgers) for a vault with the given
 /// check-in interval. Applies a 2× safety buffer so storage outlives the
@@ -97,6 +107,9 @@ pub enum ContractError {
     DisputeFiled = 31,
     NoScheduledWithdrawals = 32,
     ConditionsNotApproved = 33,
+    NoPendingOwnershipTransfer = 34,
+    OwnershipTransferExpired = 35,
+    OwnershipTransferTimeLocked = 36,
 }
 
 #[contract]
@@ -2298,60 +2311,201 @@ impl TtlVaultContract {
         Ok(())
     }
 
-    /// Transfers ownership of a vault to a new address.
+    /// Initiates a vault ownership transfer to a new address.
     ///
-    /// Both the current owner and new owner must authorize this operation.
-    /// The vault must still be in Locked status.
+    /// This is step 1 of a 2-step ownership transfer with a 24-hour time-lock.
+    /// The new owner must call `accept_ownership_transfer` after the time-lock
+    /// expires to complete the transfer. The request expires after 7 days if
+    /// not accepted.
+    ///
+    /// Only one pending transfer can exist per vault at a time. Calling this
+    /// again replaces any existing pending request.
     ///
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `vault_id` - The unique identifier of the vault
-    /// * `new_owner` - The address of the new owner (must authorize)
+    /// * `caller` - The current owner (must authorize)
+    /// * `new_owner` - The proposed new owner address
     ///
     /// # Returns
-    /// `Ok(())` on success, `Err` on failure
+    /// `Ok(unlocks_at)` — the timestamp when the new owner may accept
     ///
     /// # Errors
     /// * `ContractError::Paused` - If the contract is paused
+    /// * `ContractError::NotOwner` - If caller is not the vault owner
     /// * `ContractError::AlreadyReleased` - If vault is not in Locked status
-    pub fn transfer_ownership(
-            env: Env,
-            vault_id: u64,
-            caller: Address,
-            new_owner: Address,
-        ) -> Result<(), ContractError> {
-            if Self::load_paused(&env) {
-                return Err(ContractError::Paused);
-            }
-            caller.require_auth();
-            let mut vault = Self::load_vault(&env, vault_id);
-            let old_owner = vault.owner.clone();
-            if caller != old_owner {
-                return Err(ContractError::NotOwner);
-            }
-            if vault.status != ReleaseStatus::Locked {
-                return Err(ContractError::AlreadyReleased);
-            }
-            // Invariant: owner and beneficiary must always be distinct addresses.
-            // BeneficiaryVaults is keyed by beneficiary address. Because ownership
-            // transfer never changes vault.beneficiary, the index requires no update:
-            // the existing entry (beneficiary → vault_id) remains valid. Any other
-            // vaults where new_owner appears as a beneficiary are unrelated entries
-            // in the index and are also unaffected.
-            if new_owner == vault.beneficiary {
-                return Err(ContractError::InvalidBeneficiary);
-            }
-            if old_owner != new_owner {
-                Self::remove_owner_vault_id(&env, &old_owner, vault_id, vault.check_in_interval);
-                Self::add_owner_vault_id(&env, &new_owner, vault_id, vault.check_in_interval);
-            }
-            vault.owner = new_owner.clone();
-            Self::save_vault(&env, vault_id, &vault);
-            Self::log_audit_entry(&env, vault_id, "transfer_ownership", &caller, "");
-            env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
-            env.events().publish((OWNERSHIP_TOPIC, vault_id), (old_owner, new_owner));
-            Ok(())
+    /// * `ContractError::InvalidBeneficiary` - If new_owner equals the vault beneficiary
+    pub fn initiate_ownership_transfer(
+        env: Env,
+        vault_id: u64,
+        caller: Address,
+        new_owner: Address,
+    ) -> Result<u64, ContractError> {
+        if Self::load_paused(&env) {
+            return Err(ContractError::Paused);
         }
+        caller.require_auth();
+        let vault = Self::load_vault(&env, vault_id);
+        if caller != vault.owner {
+            return Err(ContractError::NotOwner);
+        }
+        if vault.status != ReleaseStatus::Locked {
+            return Err(ContractError::AlreadyReleased);
+        }
+        if new_owner == vault.beneficiary {
+            return Err(ContractError::InvalidBeneficiary);
+        }
+
+        let now = env.ledger().timestamp();
+        let unlocks_at = now + OWNERSHIP_TRANSFER_TIMELOCK;
+        let expires_at = now + OWNERSHIP_TRANSFER_EXPIRY;
+
+        let request = OwnershipTransferRequest {
+            new_owner: new_owner.clone(),
+            unlocks_at,
+            expires_at,
+        };
+        let key = DataKey::PendingOwnership(vault_id);
+        env.storage().persistent().set(&key, &request);
+        env.storage().persistent().extend_ttl(&key, VAULT_TTL_THRESHOLD, vault_ttl_ledgers(vault.check_in_interval));
+
+        Self::log_audit_entry(&env, vault_id, "initiate_ownership_transfer", &caller, "");
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((OWNERSHIP_INITIATED_TOPIC, vault_id), (caller, new_owner, unlocks_at));
+        Ok(unlocks_at)
+    }
+
+    /// Accepts a pending ownership transfer (step 2).
+    ///
+    /// The new owner calls this after the 24-hour time-lock has passed.
+    /// On success, vault ownership is transferred immediately.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `vault_id` - The unique identifier of the vault
+    /// * `new_owner` - The new owner accepting the transfer (must authorize)
+    ///
+    /// # Returns
+    /// `Ok(())` on success
+    ///
+    /// # Errors
+    /// * `ContractError::Paused` - If the contract is paused
+    /// * `ContractError::NoPendingOwnershipTransfer` - If no pending request exists
+    /// * `ContractError::NotOwner` - If caller is not the designated new owner
+    /// * `ContractError::OwnershipTransferTimeLocked` - If the time-lock has not yet elapsed
+    /// * `ContractError::OwnershipTransferExpired` - If the request has expired
+    /// * `ContractError::AlreadyReleased` - If vault is not in Locked status
+    pub fn accept_ownership_transfer(
+        env: Env,
+        vault_id: u64,
+        new_owner: Address,
+    ) -> Result<(), ContractError> {
+        if Self::load_paused(&env) {
+            return Err(ContractError::Paused);
+        }
+        new_owner.require_auth();
+
+        let key = DataKey::PendingOwnership(vault_id);
+        let request = env
+            .storage()
+            .persistent()
+            .get::<DataKey, OwnershipTransferRequest>(&key)
+            .ok_or(ContractError::NoPendingOwnershipTransfer)?;
+
+        if new_owner != request.new_owner {
+            return Err(ContractError::NotOwner);
+        }
+
+        let now = env.ledger().timestamp();
+        if now < request.unlocks_at {
+            return Err(ContractError::OwnershipTransferTimeLocked);
+        }
+        if now > request.expires_at {
+            return Err(ContractError::OwnershipTransferExpired);
+        }
+
+        let mut vault = Self::load_vault(&env, vault_id);
+        if vault.status != ReleaseStatus::Locked {
+            return Err(ContractError::AlreadyReleased);
+        }
+
+        let old_owner = vault.owner.clone();
+        if old_owner != new_owner {
+            Self::remove_owner_vault_id(&env, &old_owner, vault_id, vault.check_in_interval);
+            Self::add_owner_vault_id(&env, &new_owner, vault_id, vault.check_in_interval);
+        }
+        vault.owner = new_owner.clone();
+        Self::save_vault(&env, vault_id, &vault);
+
+        // Clear the pending request
+        env.storage().persistent().remove(&key);
+
+        Self::log_audit_entry(&env, vault_id, "accept_ownership_transfer", &new_owner, "");
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((OWNERSHIP_ACCEPTED_TOPIC, vault_id), (old_owner.clone(), new_owner.clone()));
+        // Backwards-compatible event for consumers watching OWNERSHIP_TOPIC
+        env.events().publish((OWNERSHIP_TOPIC, vault_id), (old_owner, new_owner));
+        Ok(())
+    }
+
+    /// Cancels a pending ownership transfer.
+    ///
+    /// Only the current vault owner can cancel. This removes the pending request
+    /// and the proposed new owner can no longer accept.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `vault_id` - The unique identifier of the vault
+    /// * `caller` - The current owner (must authorize)
+    ///
+    /// # Returns
+    /// `Ok(())` on success
+    ///
+    /// # Errors
+    /// * `ContractError::NotOwner` - If caller is not the vault owner
+    /// * `ContractError::NoPendingOwnershipTransfer` - If no pending request exists
+    pub fn cancel_ownership_transfer(
+        env: Env,
+        vault_id: u64,
+        caller: Address,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        let vault = Self::load_vault(&env, vault_id);
+        if caller != vault.owner {
+            return Err(ContractError::NotOwner);
+        }
+
+        let key = DataKey::PendingOwnership(vault_id);
+        if !env.storage().persistent().has(&key) {
+            return Err(ContractError::NoPendingOwnershipTransfer);
+        }
+        let request = env
+            .storage()
+            .persistent()
+            .get::<DataKey, OwnershipTransferRequest>(&key)
+            .unwrap();
+        let cancelled_new_owner = request.new_owner.clone();
+        env.storage().persistent().remove(&key);
+
+        Self::log_audit_entry(&env, vault_id, "cancel_ownership_transfer", &caller, "");
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((OWNERSHIP_CANCELLED_TOPIC, vault_id), (caller, cancelled_new_owner));
+        Ok(())
+    }
+
+    /// Returns the pending ownership transfer request for a vault, if any.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `vault_id` - The unique identifier of the vault
+    ///
+    /// # Returns
+    /// `Some(OwnershipTransferRequest)` if a pending transfer exists, `None` otherwise
+    pub fn get_pending_ownership_transfer(env: Env, vault_id: u64) -> Option<OwnershipTransferRequest> {
+        env.storage()
+            .persistent()
+            .get::<DataKey, OwnershipTransferRequest>(&DataKey::PendingOwnership(vault_id))
+    }
 
     // --- Issue #378: Vault Metadata ---
 

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -384,7 +384,16 @@ fn test_transfer_ownership_updates_owner_and_owner_index() {
     assert_eq!(client.get_vaults_by_owner(&owner, &None, &0u32, &10u32), vec![&env, vault_id]);
     assert_eq!(client.get_vaults_by_owner(&new_owner, &None, &0u32, &10u32), vec![&env]);
 
-    client.transfer_ownership(&vault_id, &owner, &new_owner);
+    // Step 1: initiate
+    client.initiate_ownership_transfer(&vault_id, &owner, &new_owner);
+    // Owner index unchanged until accepted
+    assert_eq!(client.get_vault(&vault_id).owner, owner);
+
+    // Step 2: advance past time-lock (24h + 1s)
+    env.ledger().with_mut(|l| l.timestamp += 86_401);
+
+    // Step 3: new owner accepts
+    client.accept_ownership_transfer(&vault_id, &new_owner);
 
     assert_eq!(client.get_vault(&vault_id).owner, new_owner);
     assert_eq!(client.get_vaults_by_owner(&owner, &None, &0u32, &10u32), vec![&env]);
@@ -392,7 +401,7 @@ fn test_transfer_ownership_updates_owner_and_owner_index() {
 }
 
 /// Invariant: owner and beneficiary must always be distinct.
-/// transfer_ownership must reject a new_owner that equals the vault's beneficiary,
+/// initiate_ownership_transfer must reject a new_owner that equals the vault's beneficiary,
 /// and must not corrupt the BeneficiaryVaults index.
 #[test]
 #[should_panic(expected = "Error(Contract, #17)")]
@@ -402,7 +411,7 @@ fn test_transfer_ownership_rejects_new_owner_equal_to_beneficiary() {
     // beneficiary is the vault's primary beneficiary; transferring ownership to
     // them would violate the owner != beneficiary invariant.
     let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
-    client.transfer_ownership(&vault_id, &owner, &beneficiary);
+    client.initiate_ownership_transfer(&vault_id, &owner, &beneficiary);
 }
 
 /// BeneficiaryVaults index must remain consistent after a successful ownership transfer.
@@ -418,11 +427,166 @@ fn test_transfer_ownership_preserves_beneficiary_index() {
     // beneficiary index contains the vault before transfer
     assert_eq!(client.get_vaults_by_beneficiary(&beneficiary, &None, &0u32, &10u32), vec![&env, vault_id]);
 
-    client.transfer_ownership(&vault_id, &owner, &new_owner);
+    client.initiate_ownership_transfer(&vault_id, &owner, &new_owner);
+    env.ledger().with_mut(|l| l.timestamp += 86_401);
+    client.accept_ownership_transfer(&vault_id, &new_owner);
 
     // vault.beneficiary is unchanged — index must still be intact
     assert_eq!(client.get_vault(&vault_id).beneficiary, beneficiary);
     assert_eq!(client.get_vaults_by_beneficiary(&beneficiary, &None, &0u32, &10u32), vec![&env, vault_id]);
+}
+
+// --- Ownership Transfer: 2-step flow tests ---
+
+#[test]
+fn test_initiate_ownership_transfer_stores_pending_request() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_owner = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+
+    let unlocks_at = client.initiate_ownership_transfer(&vault_id, &owner, &new_owner);
+    let req = client.get_pending_ownership_transfer(&vault_id).expect("pending request should exist");
+    assert_eq!(req.new_owner, new_owner);
+    assert_eq!(req.unlocks_at, unlocks_at);
+    // Vault owner unchanged until accepted
+    assert_eq!(client.get_vault(&vault_id).owner, owner);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #36)")]
+fn test_accept_ownership_transfer_before_timelock_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_owner = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+
+    client.initiate_ownership_transfer(&vault_id, &owner, &new_owner);
+    // Do NOT advance time — time-lock not yet elapsed
+    client.accept_ownership_transfer(&vault_id, &new_owner);
+}
+
+#[test]
+fn test_accept_ownership_transfer_after_timelock_succeeds() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_owner = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+
+    client.initiate_ownership_transfer(&vault_id, &owner, &new_owner);
+    env.ledger().with_mut(|l| l.timestamp += 86_401);
+    client.accept_ownership_transfer(&vault_id, &new_owner);
+
+    assert_eq!(client.get_vault(&vault_id).owner, new_owner);
+    // Pending request cleared
+    assert!(client.get_pending_ownership_transfer(&vault_id).is_none());
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #35)")]
+fn test_accept_ownership_transfer_after_expiry_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_owner = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+
+    client.initiate_ownership_transfer(&vault_id, &owner, &new_owner);
+    // Advance past 7-day expiry
+    env.ledger().with_mut(|l| l.timestamp += 604_801);
+    client.accept_ownership_transfer(&vault_id, &new_owner);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_accept_ownership_transfer_wrong_address_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_owner = Address::generate(&env);
+    let impostor = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+
+    client.initiate_ownership_transfer(&vault_id, &owner, &new_owner);
+    env.ledger().with_mut(|l| l.timestamp += 86_401);
+    // impostor tries to accept
+    client.accept_ownership_transfer(&vault_id, &impostor);
+}
+
+#[test]
+fn test_cancel_ownership_transfer_removes_pending_request() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_owner = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+
+    client.initiate_ownership_transfer(&vault_id, &owner, &new_owner);
+    assert!(client.get_pending_ownership_transfer(&vault_id).is_some());
+
+    client.cancel_ownership_transfer(&vault_id, &owner);
+    assert!(client.get_pending_ownership_transfer(&vault_id).is_none());
+    // Owner unchanged
+    assert_eq!(client.get_vault(&vault_id).owner, owner);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #34)")]
+fn test_cancel_ownership_transfer_with_no_pending_fails() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+    // No pending request — should fail
+    client.cancel_ownership_transfer(&vault_id, &owner);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #34)")]
+fn test_accept_ownership_transfer_with_no_pending_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_owner = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+    env.ledger().with_mut(|l| l.timestamp += 86_401);
+    // No pending request — should fail
+    client.accept_ownership_transfer(&vault_id, &new_owner);
+}
+
+#[test]
+fn test_initiate_ownership_transfer_replaces_existing_pending() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_owner1 = Address::generate(&env);
+    let new_owner2 = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+
+    client.initiate_ownership_transfer(&vault_id, &owner, &new_owner1);
+    // Replace with a different new owner
+    client.initiate_ownership_transfer(&vault_id, &owner, &new_owner2);
+
+    let req = client.get_pending_ownership_transfer(&vault_id).unwrap();
+    assert_eq!(req.new_owner, new_owner2);
+}
+
+#[test]
+fn test_initiate_ownership_transfer_emits_initiated_event() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_owner = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+
+    client.initiate_ownership_transfer(&vault_id, &owner, &new_owner);
+    assert!(find_event_by_topic(&env, types::OWNERSHIP_INITIATED_TOPIC));
+}
+
+#[test]
+fn test_cancel_ownership_transfer_emits_cancelled_event() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_owner = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+
+    client.initiate_ownership_transfer(&vault_id, &owner, &new_owner);
+    client.cancel_ownership_transfer(&vault_id, &owner);
+    assert!(find_event_by_topic(&env, types::OWNERSHIP_CANCELLED_TOPIC));
+}
+
+#[test]
+fn test_accept_ownership_transfer_emits_accepted_event() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_owner = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+
+    client.initiate_ownership_transfer(&vault_id, &owner, &new_owner);
+    env.ledger().with_mut(|l| l.timestamp += 86_401);
+    client.accept_ownership_transfer(&vault_id, &new_owner);
+    assert!(find_event_by_topic(&env, types::OWNERSHIP_ACCEPTED_TOPIC));
 }
 
 #[test]
@@ -1630,7 +1794,9 @@ fn test_transfer_ownership_emits_ownership_event() {
     let (env, owner, beneficiary, _, _, client) = setup();
     let new_owner = Address::generate(&env);
     let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
-    client.transfer_ownership(&vault_id, &owner, &new_owner);
+    client.initiate_ownership_transfer(&vault_id, &owner, &new_owner);
+    env.ledger().with_mut(|l| l.timestamp += 86_401);
+    client.accept_ownership_transfer(&vault_id, &new_owner);
     assert!(find_event_by_topic(&env, types::OWNERSHIP_TOPIC));
 }
 
@@ -1639,17 +1805,19 @@ fn test_transfer_ownership_event_contains_old_and_new_owner() {
     let (env, owner, beneficiary, _, _, client) = setup();
     let new_owner = Address::generate(&env);
     let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
-    client.transfer_ownership(&vault_id, &owner, &new_owner);
+    client.initiate_ownership_transfer(&vault_id, &owner, &new_owner);
+    env.ledger().with_mut(|l| l.timestamp += 86_401);
+    client.accept_ownership_transfer(&vault_id, &new_owner);
 
     let ownership_event = env.events().all().iter().find(|e| {
         let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
         topics
             .get(0)
             .and_then(|v| v.try_into_val(&env).ok())
-            .map(|s: soroban_sdk::Symbol| s == types::OWNERSHIP_TOPIC)
+            .map(|s: soroban_sdk::Symbol| s == types::OWNERSHIP_ACCEPTED_TOPIC)
             .unwrap_or(false)
     });
-    assert!(ownership_event.is_some(), "ownership event not emitted");
+    assert!(ownership_event.is_some(), "ownership_accepted event not emitted");
 
     let data = ownership_event.unwrap().2.clone();
     let (old, new): (Address, Address) = data.try_into_val(&env).unwrap();

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -8,6 +8,9 @@ pub const WITHDRAW_TOPIC: Symbol = symbol_short!("withdraw");
 pub const CHECK_IN_TOPIC: Symbol = symbol_short!("check_in");
 pub const CANCEL_TOPIC: Symbol = symbol_short!("cancel");
 pub const OWNERSHIP_TOPIC: Symbol = symbol_short!("own_xfer");
+pub const OWNERSHIP_INITIATED_TOPIC: Symbol = symbol_short!("own_init");
+pub const OWNERSHIP_ACCEPTED_TOPIC: Symbol = symbol_short!("own_acc");
+pub const OWNERSHIP_CANCELLED_TOPIC: Symbol = symbol_short!("own_can");
 pub const BENEFICIARY_UPDATED_TOPIC: Symbol = symbol_short!("ben_upd");
 pub const SET_BENEFICIARIES_TOPIC: Symbol = symbol_short!("set_bens");
 pub const UPDATE_INTERVAL_TOPIC: Symbol = symbol_short!("upd_intv");
@@ -79,6 +82,7 @@ pub enum DataKey {
     WithdrawalSchedule(u64),
     DisputeStatus(u64),
     ConditionalAcceptance(u64),
+    PendingOwnership(u64),
 }
 
 /// A vesting schedule attached to a vault.
@@ -252,4 +256,17 @@ pub struct WithdrawalScheduleEntry {
 pub struct ConditionalAcceptanceEntry {
     pub conditions: String,
     pub approved_by_owner: bool,
+}
+
+/// Pending ownership transfer request with time-lock.
+/// The new owner must call `accept_ownership_transfer` after `unlocks_at` to complete the transfer.
+#[contracttype]
+#[derive(Clone)]
+pub struct OwnershipTransferRequest {
+    /// The proposed new owner address.
+    pub new_owner: Address,
+    /// Unix timestamp when the new owner is allowed to accept (time-lock expiry).
+    pub unlocks_at: u64,
+    /// Unix timestamp after which the request expires and must be re-initiated.
+    pub expires_at: u64,
 }

--- a/docs/ownership-transfer.md
+++ b/docs/ownership-transfer.md
@@ -1,0 +1,98 @@
+# Vault Ownership Transfer
+
+Vault owners can transfer ownership to another address — useful for account recovery or business transfers. The process uses a **2-step flow with a 24-hour time-lock** to prevent accidental or malicious transfers.
+
+## Flow
+
+```
+Owner                          New Owner
+  |                                |
+  |-- initiate_ownership_transfer -->  (pending request stored, 24h time-lock starts)
+  |                                |
+  |       [24 hours pass]          |
+  |                                |
+  |                <-- accept_ownership_transfer --  (ownership transferred)
+```
+
+### Step 1 — Initiate (current owner)
+
+```rust
+initiate_ownership_transfer(vault_id: u64, caller: Address, new_owner: Address) -> Result<u64, ContractError>
+```
+
+- Only the current vault owner can call this.
+- Stores a `PendingOwnershipTransfer` with:
+  - `new_owner` — the proposed new owner
+  - `unlocks_at` — `now + 24 hours` (time-lock; new owner cannot accept before this)
+  - `expires_at` — `now + 7 days` (request expires if not accepted)
+- Returns `unlocks_at` so the caller knows when the new owner can accept.
+- Replaces any existing pending request for the vault.
+
+### Step 2 — Accept (new owner)
+
+```rust
+accept_ownership_transfer(vault_id: u64, new_owner: Address) -> Result<(), ContractError>
+```
+
+- Only the designated `new_owner` from the pending request can call this.
+- Must be called **after** `unlocks_at` and **before** `expires_at`.
+- On success: vault `owner` is updated, owner indexes are updated, pending request is cleared.
+
+### Cancel (current owner)
+
+```rust
+cancel_ownership_transfer(vault_id: u64, caller: Address) -> Result<(), ContractError>
+```
+
+- Only the current vault owner can cancel.
+- Removes the pending request; the proposed new owner can no longer accept.
+
+### Query pending request
+
+```rust
+get_pending_ownership_transfer(vault_id: u64) -> Option<OwnershipTransferRequest>
+```
+
+Returns the pending request if one exists, `None` otherwise.
+
+## Security Properties
+
+| Property | Detail |
+|---|---|
+| **Time-lock** | 24-hour delay before new owner can accept — prevents rushed/coerced transfers |
+| **Expiry** | Request expires after 7 days — prevents stale pending transfers |
+| **Approval required** | New owner must explicitly accept — no unilateral transfers |
+| **Owner-only initiation** | Only the current owner can start or cancel a transfer |
+| **Beneficiary invariant** | `new_owner` cannot equal the vault's beneficiary |
+| **Vault must be Locked** | Transfers are blocked on Released/Cancelled vaults |
+| **Contract pause respected** | Initiation and acceptance are blocked when contract is paused |
+
+## Events
+
+| Event | Topic constant | Data |
+|---|---|---|
+| Transfer initiated | `OWNERSHIP_INITIATED_TOPIC` (`own_init`) | `(old_owner, new_owner, unlocks_at)` |
+| Transfer accepted | `OWNERSHIP_ACCEPTED_TOPIC` (`own_acc`) | `(old_owner, new_owner)` |
+| Transfer cancelled | `OWNERSHIP_CANCELLED_TOPIC` (`own_can`) | `(owner, cancelled_new_owner)` |
+| Legacy compat | `OWNERSHIP_TOPIC` (`own_xfer`) | `(old_owner, new_owner)` — emitted on accept for backwards compatibility |
+
+## Error Codes
+
+| Code | Constant | Meaning |
+|---|---|---|
+| `#34` | `NoPendingOwnershipTransfer` | No pending request exists for this vault |
+| `#35` | `OwnershipTransferExpired` | The 7-day acceptance window has passed |
+| `#36` | `OwnershipTransferTimeLocked` | The 24-hour time-lock has not yet elapsed |
+
+## Example
+
+```rust
+// Step 1: owner initiates
+let unlocks_at = client.initiate_ownership_transfer(&vault_id, &owner, &new_owner)?;
+
+// Step 2: wait 24 hours, then new owner accepts
+client.accept_ownership_transfer(&vault_id, &new_owner)?;
+
+// Or: owner changes their mind and cancels
+client.cancel_ownership_transfer(&vault_id, &owner)?;
+```


### PR DESCRIPTION
closes #359
- Replace immediate transfer_ownership with 2-step flow:
  - initiate_ownership_transfer: owner proposes new owner, stores pending request with 24h time-lock and 7-day expiry
  - accept_ownership_transfer: new owner accepts after time-lock
  - cancel_ownership_transfer: owner cancels pending request
  - get_pending_ownership_transfer: query pending request

- Add OwnershipTransferRequest struct to types
- Add PendingOwnership(u64) DataKey
- Add OWNERSHIP_INITIATED/ACCEPTED/CANCELLED event topics
- Add error codes 34-36 (NoPendingOwnershipTransfer, OwnershipTransferExpired, OwnershipTransferTimeLocked)
- Add OWNERSHIP_TRANSFER_TIMELOCK (24h) and EXPIRY (7d) constants
- Emit backwards-compatible OWNERSHIP_TOPIC on accept

Tests:
- Update existing transfer_ownership tests to use new 2-step API
- Add 11 new tests covering: pending request storage, time-lock enforcement, expiry, wrong-address rejection, cancel flow, replace-pending, and event emission

Docs: add docs/ownership-transfer.md