### PR TITLE
feat: mobile app — iOS (Swift) + Android (Kotlin)

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,98 @@
+# Mobile App Architecture
+
+## Overview
+
+TTL-Legacy mobile apps (iOS + Android) provide a native interface for managing vaults, checking in, and receiving expiry reminders. Both apps share the same REST API contract and feature set.
+
+## Structure
+
+```
+mobile/
+├── shared/
+│   └── api-contract.md          # Shared API spec (iOS + Android)
+├── ios/TTLLegacy/
+│   └── Sources/
+│       ├── App/                 # Entry point, app lifecycle
+│       ├── Models/              # Vault, AuthToken, etc.
+│       ├── Services/
+│       │   ├── APIClient.swift      # Ktor-style async HTTP client
+│       │   ├── PasskeyService.swift # ASAuthorization / WebAuthn
+│       │   ├── KeychainService.swift# Secure token storage
+│       │   ├── NotificationService.swift # APNs + local reminders
+│       │   └── OfflineSupport.swift # NetworkMonitor + disk cache
+│       ├── ViewModels/          # AuthStore, VaultStore (ObservableObject)
+│       └── Views/               # SwiftUI screens
+└── android/app/src/main/java/com/ttllegacy/
+    ├── api/
+    │   ├── ApiClient.kt         # Ktor HTTP client
+    │   └── Infrastructure.kt    # NetworkMonitor, OfflineCache, TokenProvider
+    ├── models/                  # Kotlinx.serialization data classes
+    ├── services/
+    │   ├── PasskeyService.kt    # CredentialManager / WebAuthn
+    │   ├── PushService.kt       # Firebase Messaging
+    │   └── NotificationHelper.kt# Local notification display
+    ├── ui/
+    │   ├── ViewModels.kt        # AuthViewModel, VaultViewModel (Hilt)
+    │   ├── MainActivity.kt      # NavHost entry point
+    │   ├── screens/Screens.kt   # Compose screens
+    │   └── theme/Theme.kt       # Material3 dynamic color
+    └── di/AppModule.kt          # Hilt DI bindings
+```
+
+## Key Design Decisions
+
+### Passkey Authentication (WebAuthn)
+- **iOS**: `ASAuthorizationPlatformPublicKeyCredentialProvider` (iOS 16+)
+- **Android**: `CredentialManager` API (Android 9+, API 28+)
+- Flow: `getChallenge()` → device biometric prompt → `verifyPasskey()` → JWT stored in Keychain/SharedPreferences
+- Relying party: `ttl-legacy.app` (requires `.well-known/assetlinks.json` + Apple App Site Association)
+
+### Push Notifications
+- **iOS**: APNs via `UNUserNotificationCenter`. Device token registered to backend on first launch.
+  - Local reminders scheduled 24h before vault expiry via `UNTimeIntervalNotificationTrigger`
+  - Actionable notification category `CHECK_IN` with inline "Check In" action
+- **Android**: Firebase Cloud Messaging (FCM). Token refreshed via `onNewToken`.
+  - Notification channel `ttl_reminders` (IMPORTANCE_HIGH)
+  - Deep-link intent to `MainActivity` with `vault_id` extra
+
+### Offline Support
+- `NetworkMonitor` checks live connectivity before every request
+- `OfflineCache` stores last successful GET responses keyed by URL (SHA-256 filename)
+- On network unavailable: cached data served transparently; mutations show "offline" error
+- iOS: `CryptoKit.SHA256` for cache keys; Android: `MessageDigest("SHA-256")`
+
+### State Management
+- **iOS**: `@StateObject` / `ObservableObject` stores (`AuthStore`, `VaultStore`) injected via SwiftUI environment
+- **Android**: Hilt-injected `ViewModel`s with `StateFlow` + `collectAsStateWithLifecycle`
+
+## Setup
+
+### iOS
+1. Open `mobile/ios/TTLLegacy` in Xcode 15+
+2. Set bundle ID and team in signing settings
+3. Add `API_BASE_URL` to `Info.plist`
+4. Configure Apple App Site Association at `https://ttl-legacy.app/.well-known/apple-app-site-association`
+5. Enable Push Notifications + Associated Domains capabilities
+
+### Android
+1. Open `mobile/android` in Android Studio Hedgehog+
+2. Add `google-services.json` from Firebase Console
+3. Configure `assetlinks.json` at `https://ttl-legacy.app/.well-known/assetlinks.json`
+4. Set `API_BASE_URL` in `build.gradle.kts` `buildConfigField`
+
+## Testing
+
+### iOS
+```bash
+cd mobile/ios/TTLLegacy
+swift test
+```
+Covers: model decoding, Keychain round-trip, offline cache, Base64URL encoding.
+
+### Android
+```bash
+cd mobile/android
+./gradlew test                  # Unit tests (JVM)
+./gradlew connectedAndroidTest  # Instrumented tests (device/emulator)
+```
+Covers: ViewModel state transitions, model logic, Compose UI smoke tests.

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -1,0 +1,85 @@
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.hilt)
+    alias(libs.plugins.ksp)
+}
+
+android {
+    namespace = "com.ttllegacy"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "com.ttllegacy"
+        minSdk = 28
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0.0"
+        buildConfigField("String", "API_BASE_URL", "\"https://api.ttl-legacy.app/v1\"")
+    }
+
+    buildFeatures { compose = true; buildConfig = true }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = true
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+dependencies {
+    // Compose BOM
+    implementation(platform(libs.compose.bom))
+    implementation(libs.compose.ui)
+    implementation(libs.compose.material3)
+    implementation(libs.compose.ui.tooling.preview)
+    implementation(libs.activity.compose)
+    implementation(libs.navigation.compose)
+    debugImplementation(libs.compose.ui.tooling)
+
+    // Lifecycle / ViewModel
+    implementation(libs.lifecycle.viewmodel.compose)
+    implementation(libs.lifecycle.runtime.compose)
+
+    // Hilt DI
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+    implementation(libs.hilt.navigation.compose)
+
+    // Networking
+    implementation(libs.ktor.client.android)
+    implementation(libs.ktor.client.content.negotiation)
+    implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.ktor.client.logging)
+
+    // Serialization
+    implementation(libs.kotlinx.serialization.json)
+
+    // DataStore (offline)
+    implementation(libs.datastore.preferences)
+
+    // Credentials (Passkey)
+    implementation(libs.credentials)
+    implementation(libs.credentials.play.services.auth)
+
+    // Firebase Messaging (push notifications)
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.messaging)
+
+    // Testing
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockk)
+    androidTestImplementation(libs.androidx.test.ext)
+    androidTestImplementation(libs.espresso.core)
+    androidTestImplementation(platform(libs.compose.bom))
+    androidTestImplementation(libs.compose.ui.test.junit4)
+}

--- a/mobile/android/app/src/androidTest/java/com/ttllegacy/VaultListScreenTest.kt
+++ b/mobile/android/app/src/androidTest/java/com/ttllegacy/VaultListScreenTest.kt
@@ -1,0 +1,33 @@
+package com.ttllegacy
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.ttllegacy.models.Vault
+import com.ttllegacy.models.VaultStatus
+import com.ttllegacy.ui.screens.VaultListScreen
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@HiltAndroidTest
+class VaultListScreenTest {
+
+    @get:Rule(order = 0) val hiltRule = HiltAndroidRule(this)
+    @get:Rule(order = 1) val composeRule = createComposeRule()
+
+    @Before fun setup() { hiltRule.inject() }
+
+    @Test
+    fun emptyState_showsCreatePrompt() {
+        composeRule.setContent { VaultListScreen(onVaultClick = {}) }
+        composeRule.onNodeWithText("No vaults yet", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun addButton_isDisplayed() {
+        composeRule.setContent { VaultListScreen(onVaultClick = {}) }
+        composeRule.onNodeWithContentDescription("Create vault").assertIsDisplayed()
+    }
+}

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <application
+        android:name=".TTLLegacyApplication"
+        android:label="TTL-Legacy"
+        android:theme="@style/Theme.TTLLegacy"
+        android:allowBackup="false"
+        android:supportsRtl="true">
+
+        <activity
+            android:name=".ui.MainActivity"
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <service
+            android:name=".services.TTLFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
+        <!-- Passkey / Digital Asset Links -->
+        <meta-data
+            android:name="asset_statements"
+            android:resource="@string/asset_statements" />
+
+    </application>
+</manifest>

--- a/mobile/android/app/src/main/java/com/ttllegacy/TTLLegacyApplication.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/TTLLegacyApplication.kt
@@ -1,0 +1,7 @@
+package com.ttllegacy
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class TTLLegacyApplication : Application()

--- a/mobile/android/app/src/main/java/com/ttllegacy/api/ApiClient.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/api/ApiClient.kt
@@ -1,0 +1,110 @@
+package com.ttllegacy.api
+
+import com.ttllegacy.models.*
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.android.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.plugins.logging.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+sealed class ApiResult<out T> {
+    data class Success<T>(val data: T) : ApiResult<T>()
+    data class Error(val message: String, val code: Int = 0) : ApiResult<Nothing>()
+    object NetworkUnavailable : ApiResult<Nothing>()
+}
+
+@Singleton
+class ApiClient @Inject constructor(
+    private val tokenProvider: TokenProvider,
+    private val networkMonitor: NetworkMonitor,
+    private val offlineCache: OfflineCache,
+    private val baseUrl: String
+) {
+    private val client = HttpClient(Android) {
+        install(ContentNegotiation) {
+            json(Json { ignoreUnknownKeys = true; isLenient = true })
+        }
+        install(Logging) { level = LogLevel.INFO }
+    }
+
+    // Auth
+    suspend fun getChallenge(): ApiResult<AuthChallenge> = get("/auth/challenge")
+    suspend fun verifyPasskey(req: PasskeyVerifyRequest): ApiResult<AuthToken> = post("/auth/verify", req)
+    suspend fun registerPasskey(req: PasskeyRegisterRequest): ApiResult<Unit> = post("/auth/register", req)
+
+    // Vaults
+    suspend fun listVaults(): ApiResult<List<Vault>> = get("/vaults")
+    suspend fun getVault(id: String): ApiResult<Vault> = get("/vaults/$id")
+    suspend fun createVault(req: CreateVaultRequest): ApiResult<Vault> = post("/vaults", req)
+    suspend fun checkIn(vaultId: String): ApiResult<Unit> = post("/vaults/$vaultId/checkin", Unit)
+    suspend fun deposit(vaultId: String, amount: Long): ApiResult<Vault> =
+        post("/vaults/$vaultId/deposit", mapOf("amount" to amount))
+    suspend fun withdraw(vaultId: String, amount: Long): ApiResult<Vault> =
+        post("/vaults/$vaultId/withdraw", mapOf("amount" to amount))
+
+    // Push
+    suspend fun registerPushToken(token: String): ApiResult<Unit> =
+        post("/notifications/register", PushRegistration(token = token))
+    suspend fun unregisterPushToken(token: String): ApiResult<Unit> =
+        delete("/notifications/register", PushRegistration(token = token))
+
+    // Internals
+    private suspend inline fun <reified T> get(path: String): ApiResult<T> {
+        if (!networkMonitor.isConnected) {
+            val cached = offlineCache.load(path)
+            return if (cached != null) ApiResult.Success(Json.decodeFromString(cached))
+            else ApiResult.NetworkUnavailable
+        }
+        return runCatching {
+            val response = client.get("$baseUrl$path") { bearerAuth() }
+            when (response.status.value) {
+                in 200..299 -> {
+                    val body: T = response.body()
+                    offlineCache.save(path, Json.encodeToString(kotlinx.serialization.serializer(), body))
+                    ApiResult.Success(body)
+                }
+                401 -> ApiResult.Error("Unauthorized", 401)
+                404 -> ApiResult.Error("Not found", 404)
+                else -> ApiResult.Error("Server error ${response.status.value}", response.status.value)
+            }
+        }.getOrElse { ApiResult.Error(it.message ?: "Unknown error") }
+    }
+
+    private suspend inline fun <reified B, reified T> post(path: String, body: B): ApiResult<T> {
+        if (!networkMonitor.isConnected) return ApiResult.NetworkUnavailable
+        return runCatching {
+            val response = client.post("$baseUrl$path") {
+                bearerAuth()
+                contentType(ContentType.Application.Json)
+                setBody(body)
+            }
+            when (response.status.value) {
+                in 200..299 -> ApiResult.Success(if (T::class == Unit::class) Unit as T else response.body())
+                401 -> ApiResult.Error("Unauthorized", 401)
+                else -> ApiResult.Error("Server error ${response.status.value}", response.status.value)
+            }
+        }.getOrElse { ApiResult.Error(it.message ?: "Unknown error") }
+    }
+
+    private suspend inline fun <reified B, reified T> delete(path: String, body: B): ApiResult<T> {
+        if (!networkMonitor.isConnected) return ApiResult.NetworkUnavailable
+        return runCatching {
+            val response = client.delete("$baseUrl$path") {
+                bearerAuth()
+                contentType(ContentType.Application.Json)
+                setBody(body)
+            }
+            ApiResult.Success(if (T::class == Unit::class) Unit as T else response.body())
+        }.getOrElse { ApiResult.Error(it.message ?: "Unknown error") }
+    }
+
+    private fun HttpRequestBuilder.bearerAuth() {
+        tokenProvider.token?.let { header(HttpHeaders.Authorization, "Bearer $it") }
+    }
+}

--- a/mobile/android/app/src/main/java/com/ttllegacy/api/Infrastructure.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/api/Infrastructure.kt
@@ -1,0 +1,50 @@
+package com.ttllegacy.api
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import java.security.MessageDigest
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NetworkMonitor @Inject constructor(@ApplicationContext private val context: Context) {
+    val isConnected: Boolean
+        get() {
+            val cm = context.getSystemService(ConnectivityManager::class.java)
+            val network = cm.activeNetwork ?: return false
+            val caps = cm.getNetworkCapabilities(network) ?: return false
+            return caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        }
+}
+
+@Singleton
+class OfflineCache @Inject constructor(@ApplicationContext private val context: Context) {
+    private val dir = File(context.cacheDir, "ttl_offline").also { it.mkdirs() }
+
+    fun save(key: String, json: String) {
+        File(dir, key.sha256()).writeText(json)
+    }
+
+    fun load(key: String): String? = runCatching { File(dir, key.sha256()).readText() }.getOrNull()
+
+    private fun String.sha256(): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(toByteArray())
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+}
+
+@Singleton
+class TokenProvider @Inject constructor(@ApplicationContext private val context: Context) {
+    private val prefs = context.getSharedPreferences("ttl_auth", Context.MODE_PRIVATE)
+
+    var token: String?
+        get() = prefs.getString("token", null)
+        set(value) = prefs.edit().apply {
+            if (value != null) putString("token", value) else remove("token")
+        }.apply()
+
+    fun clear() { token = null }
+}

--- a/mobile/android/app/src/main/java/com/ttllegacy/di/AppModule.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/di/AppModule.kt
@@ -1,0 +1,26 @@
+package com.ttllegacy.di
+
+import android.content.Context
+import com.ttllegacy.BuildConfig
+import com.ttllegacy.api.ApiClient
+import com.ttllegacy.api.NetworkMonitor
+import com.ttllegacy.api.OfflineCache
+import com.ttllegacy.api.TokenProvider
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+
+    @Provides @Singleton
+    fun provideApiClient(
+        tokenProvider: TokenProvider,
+        networkMonitor: NetworkMonitor,
+        offlineCache: OfflineCache
+    ): ApiClient = ApiClient(tokenProvider, networkMonitor, offlineCache, BuildConfig.API_BASE_URL)
+}

--- a/mobile/android/app/src/main/java/com/ttllegacy/models/Models.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/models/Models.kt
@@ -1,0 +1,60 @@
+package com.ttllegacy.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Vault(
+    val id: String,
+    val owner: String,
+    val beneficiary: String,
+    val balance: Long,
+    @SerialName("check_in_interval") val checkInInterval: Long,
+    @SerialName("last_check_in") val lastCheckIn: String,
+    @SerialName("ttl_remaining") val ttlRemaining: Long? = null,
+    val status: VaultStatus
+) {
+    val isExpiringSoon: Boolean get() = (ttlRemaining ?: Long.MAX_VALUE) < 86_400L
+    val formattedBalance: String get() = "%.7f XLM".format(balance / 10_000_000.0)
+}
+
+@Serializable
+enum class VaultStatus { active, expired, released, paused }
+
+@Serializable
+data class AuthChallenge(
+    val challenge: String,
+    @SerialName("expires_at") val expiresAt: String
+)
+
+@Serializable
+data class AuthToken(
+    val token: String,
+    @SerialName("expires_at") val expiresAt: String
+)
+
+@Serializable
+data class CreateVaultRequest(
+    val beneficiary: String,
+    @SerialName("check_in_interval") val checkInInterval: Long
+)
+
+@Serializable
+data class PushRegistration(
+    val token: String,
+    val platform: String = "android"
+)
+
+@Serializable
+data class PasskeyVerifyRequest(
+    @SerialName("credential_id") val credentialId: String,
+    @SerialName("client_data_json") val clientDataJson: String,
+    val signature: String
+)
+
+@Serializable
+data class PasskeyRegisterRequest(
+    @SerialName("credential_id") val credentialId: String,
+    @SerialName("public_key") val publicKey: String,
+    @SerialName("client_data_json") val clientDataJson: String
+)

--- a/mobile/android/app/src/main/java/com/ttllegacy/services/NotificationHelper.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/services/NotificationHelper.kt
@@ -1,0 +1,49 @@
+package com.ttllegacy.services
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import com.ttllegacy.ui.MainActivity
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NotificationHelper @Inject constructor(@ApplicationContext private val context: Context) {
+
+    companion object {
+        const val CHANNEL_ID = "ttl_reminders"
+        const val CHANNEL_NAME = "Check-in Reminders"
+    }
+
+    init { createChannel() }
+
+    fun show(title: String, body: String, vaultId: String?) {
+        val intent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+            vaultId?.let { putExtra("vault_id", it) }
+        }
+        val pi = PendingIntent.getActivity(context, 0, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_lock_idle_lock)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setAutoCancel(true)
+            .setContentIntent(pi)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .build()
+
+        val nm = context.getSystemService(NotificationManager::class.java)
+        nm.notify(vaultId.hashCode(), notification)
+    }
+
+    private fun createChannel() {
+        val channel = NotificationChannel(CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_HIGH)
+        context.getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+    }
+}

--- a/mobile/android/app/src/main/java/com/ttllegacy/services/PasskeyService.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/services/PasskeyService.kt
@@ -1,0 +1,73 @@
+package com.ttllegacy.services
+
+import android.app.Activity
+import androidx.credentials.*
+import com.ttllegacy.api.ApiClient
+import com.ttllegacy.api.ApiResult
+import com.ttllegacy.api.TokenProvider
+import com.ttllegacy.models.PasskeyRegisterRequest
+import com.ttllegacy.models.PasskeyVerifyRequest
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.Base64
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PasskeyService @Inject constructor(
+    private val apiClient: ApiClient,
+    private val tokenProvider: TokenProvider
+) {
+    suspend fun register(activity: Activity, username: String): Result<Unit> = runCatching {
+        val challenge = requireSuccess(apiClient.getChallenge()).challenge
+        val requestJson = JSONObject().apply {
+            put("challenge", challenge)
+            put("rp", JSONObject().put("id", "ttl-legacy.app").put("name", "TTL-Legacy"))
+            put("user", JSONObject()
+                .put("id", Base64.getUrlEncoder().withoutPadding().encodeToString(username.toByteArray()))
+                .put("name", username).put("displayName", username))
+            put("pubKeyCredParams", JSONArray().put(JSONObject().put("type", "public-key").put("alg", -7)))
+            put("authenticatorSelection", JSONObject()
+                .put("authenticatorAttachment", "platform")
+                .put("requireResidentKey", true)
+                .put("userVerification", "required"))
+        }.toString()
+
+        val credManager = CredentialManager.create(activity)
+        val resp = credManager.createCredential(activity, CreatePublicKeyCredentialRequest(requestJson))
+                as CreatePublicKeyCredentialResponse
+        val json = JSONObject(resp.registrationResponseJson)
+        val regReq = PasskeyRegisterRequest(
+            credentialId = json.getString("id"),
+            publicKey = json.getJSONObject("response").getString("attestationObject"),
+            clientDataJson = json.getJSONObject("response").getString("clientDataJSON")
+        )
+        requireSuccess(apiClient.registerPasskey(regReq))
+    }
+
+    suspend fun authenticate(activity: Activity): Result<Unit> = runCatching {
+        val challenge = requireSuccess(apiClient.getChallenge()).challenge
+        val requestJson = JSONObject()
+            .put("challenge", challenge).put("rpId", "ttl-legacy.app")
+            .put("userVerification", "required").toString()
+
+        val credManager = CredentialManager.create(activity)
+        val request = GetCredentialRequest(listOf(GetPublicKeyCredentialOption(requestJson)))
+        val credential = credManager.getCredential(activity, request).credential as PublicKeyCredential
+        val json = JSONObject(credential.authenticationResponseJson)
+        val verifyReq = PasskeyVerifyRequest(
+            credentialId = json.getString("id"),
+            clientDataJson = json.getJSONObject("response").getString("clientDataJSON"),
+            signature = json.getJSONObject("response").getString("signature")
+        )
+        tokenProvider.token = requireSuccess(apiClient.verifyPasskey(verifyReq)).token
+    }
+
+    private fun <T> requireSuccess(result: ApiResult<T>): T {
+        return when (result) {
+            is ApiResult.Success -> result.data
+            is ApiResult.Error -> error(result.message)
+            ApiResult.NetworkUnavailable -> error("No network connection")
+        }
+    }
+}

--- a/mobile/android/app/src/main/java/com/ttllegacy/services/PushService.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/services/PushService.kt
@@ -1,0 +1,35 @@
+package com.ttllegacy.services
+
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import com.ttllegacy.api.ApiClient
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class TTLFirebaseMessagingService : FirebaseMessagingService() {
+
+    @Inject lateinit var apiClient: ApiClient
+    @Inject lateinit var notificationHelper: NotificationHelper
+
+    override fun onNewToken(token: String) {
+        CoroutineScope(Dispatchers.IO).launch {
+            apiClient.registerPushToken(token)
+        }
+    }
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        val vaultId = message.data["vault_id"]
+        val type = message.data["type"] ?: "reminder"
+        val title = message.notification?.title ?: "TTL-Legacy"
+        val body = message.notification?.body ?: when (type) {
+            "expiry_warning" -> "Your vault is expiring soon. Check in now."
+            "released" -> "Your vault has been released to the beneficiary."
+            else -> "Action required for your vault."
+        }
+        notificationHelper.show(title, body, vaultId)
+    }
+}

--- a/mobile/android/app/src/main/java/com/ttllegacy/ui/MainActivity.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/ui/MainActivity.kt
@@ -1,0 +1,48 @@
+package com.ttllegacy.ui
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.*
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.ttllegacy.ui.screens.AuthScreen
+import com.ttllegacy.ui.screens.VaultListScreen
+import com.ttllegacy.ui.theme.TTLLegacyTheme
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            TTLLegacyTheme {
+                AppNavigation()
+            }
+        }
+    }
+}
+
+@Composable
+private fun AppNavigation() {
+    val navController = rememberNavController()
+    val authVm: AuthViewModel = hiltViewModel()
+    val authState by authVm.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(authState.isAuthenticated) {
+        if (authState.isAuthenticated) navController.navigate("vaults") { popUpTo("auth") { inclusive = true } }
+        else navController.navigate("auth") { popUpTo("vaults") { inclusive = true } }
+    }
+
+    NavHost(navController, startDestination = if (authState.isAuthenticated) "vaults" else "auth") {
+        composable("auth") { AuthScreen(vm = authVm) }
+        composable("vaults") {
+            VaultListScreen(onVaultClick = { /* navigate to detail */ })
+        }
+    }
+}

--- a/mobile/android/app/src/main/java/com/ttllegacy/ui/ViewModels.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/ui/ViewModels.kt
@@ -1,0 +1,106 @@
+package com.ttllegacy.ui
+
+import android.app.Activity
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ttllegacy.api.ApiClient
+import com.ttllegacy.api.ApiResult
+import com.ttllegacy.api.TokenProvider
+import com.ttllegacy.models.CreateVaultRequest
+import com.ttllegacy.models.Vault
+import com.ttllegacy.services.NotificationHelper
+import com.ttllegacy.services.PasskeyService
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+// --- Auth ViewModel ---
+
+data class AuthUiState(
+    val isAuthenticated: Boolean = false,
+    val isLoading: Boolean = false,
+    val error: String? = null
+)
+
+@HiltViewModel
+class AuthViewModel @Inject constructor(
+    private val passkeyService: PasskeyService,
+    private val tokenProvider: TokenProvider
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(AuthUiState(isAuthenticated = tokenProvider.token != null))
+    val state = _state.asStateFlow()
+
+    fun signIn(activity: Activity) = viewModelScope.launch {
+        _state.update { it.copy(isLoading = true, error = null) }
+        passkeyService.authenticate(activity)
+            .onSuccess { _state.update { it.copy(isAuthenticated = true, isLoading = false) } }
+            .onFailure { e -> _state.update { it.copy(isLoading = false, error = e.message) } }
+    }
+
+    fun register(activity: Activity, username: String) = viewModelScope.launch {
+        _state.update { it.copy(isLoading = true, error = null) }
+        passkeyService.register(activity, username)
+            .onSuccess { signIn(activity) }
+            .onFailure { e -> _state.update { it.copy(isLoading = false, error = e.message) } }
+    }
+
+    fun signOut() {
+        tokenProvider.clear()
+        _state.update { it.copy(isAuthenticated = false) }
+    }
+}
+
+// --- Vault ViewModel ---
+
+data class VaultUiState(
+    val vaults: List<Vault> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    val isOffline: Boolean = false
+)
+
+@HiltViewModel
+class VaultViewModel @Inject constructor(
+    private val apiClient: ApiClient,
+    private val notificationHelper: NotificationHelper
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(VaultUiState())
+    val state = _state.asStateFlow()
+
+    fun load() = viewModelScope.launch {
+        _state.update { it.copy(isLoading = true, error = null) }
+        when (val result = apiClient.listVaults()) {
+            is ApiResult.Success -> {
+                _state.update { it.copy(vaults = result.data, isLoading = false, isOffline = false) }
+            }
+            ApiResult.NetworkUnavailable -> {
+                _state.update { it.copy(isLoading = false, isOffline = true) }
+            }
+            is ApiResult.Error -> {
+                _state.update { it.copy(isLoading = false, error = result.message) }
+            }
+        }
+    }
+
+    fun checkIn(vaultId: String) = viewModelScope.launch {
+        when (val result = apiClient.checkIn(vaultId)) {
+            is ApiResult.Success -> load()
+            is ApiResult.Error -> _state.update { it.copy(error = result.message) }
+            ApiResult.NetworkUnavailable -> _state.update { it.copy(error = "No network — check-in queued") }
+        }
+    }
+
+    fun createVault(beneficiary: String, intervalDays: Int) = viewModelScope.launch {
+        val req = CreateVaultRequest(beneficiary, intervalDays * 86_400L)
+        when (val result = apiClient.createVault(req)) {
+            is ApiResult.Success -> load()
+            is ApiResult.Error -> _state.update { it.copy(error = result.message) }
+            ApiResult.NetworkUnavailable -> _state.update { it.copy(error = "No network") }
+        }
+    }
+}

--- a/mobile/android/app/src/main/java/com/ttllegacy/ui/screens/Screens.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/ui/screens/Screens.kt
@@ -1,0 +1,217 @@
+package com.ttllegacy.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.ttllegacy.models.Vault
+import com.ttllegacy.ui.AuthViewModel
+import com.ttllegacy.ui.VaultViewModel
+
+// MARK: - Auth Screen
+
+@Composable
+fun AuthScreen(vm: AuthViewModel = hiltViewModel()) {
+    val state by vm.state.collectAsStateWithLifecycle()
+    val activity = LocalContext.current as android.app.Activity
+    var showRegister by remember { mutableStateOf(false) }
+
+    if (showRegister) {
+        RegisterSheet(
+            onRegister = { username -> vm.register(activity, username); showRegister = false },
+            onDismiss = { showRegister = false }
+        )
+    }
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(Icons.Default.Lock, contentDescription = null,
+            modifier = Modifier.size(72.dp), tint = MaterialTheme.colorScheme.primary)
+        Spacer(Modifier.height(16.dp))
+        Text("TTL-Legacy", style = MaterialTheme.typography.headlineLarge)
+        Text("Secure digital inheritance", style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Spacer(Modifier.height(32.dp))
+
+        state.error?.let {
+            Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+            Spacer(Modifier.height(8.dp))
+        }
+
+        Button(
+            onClick = { vm.signIn(activity) },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !state.isLoading
+        ) {
+            if (state.isLoading) CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp)
+            else { Icon(Icons.Default.Key, null); Spacer(Modifier.width(8.dp)); Text("Sign in with Passkey") }
+        }
+        Spacer(Modifier.height(8.dp))
+        TextButton(onClick = { showRegister = true }) { Text("Create account") }
+    }
+}
+
+@Composable
+private fun RegisterSheet(onRegister: (String) -> Unit, onDismiss: () -> Unit) {
+    var username by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Create Account") },
+        text = {
+            OutlinedTextField(value = username, onValueChange = { username = it },
+                label = { Text("Username") }, singleLine = true)
+        },
+        confirmButton = {
+            TextButton(onClick = { onRegister(username) }, enabled = username.isNotBlank()) { Text("Register") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } }
+    )
+}
+
+// MARK: - Vault List Screen
+
+@Composable
+fun VaultListScreen(
+    onVaultClick: (String) -> Unit,
+    vm: VaultViewModel = hiltViewModel()
+) {
+    val state by vm.state.collectAsStateWithLifecycle()
+    var showCreate by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) { vm.load() }
+
+    if (showCreate) {
+        CreateVaultDialog(
+            onCreate = { ben, days -> vm.createVault(ben, days); showCreate = false },
+            onDismiss = { showCreate = false }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("My Vaults") }, actions = {
+                IconButton(onClick = { showCreate = true }) { Icon(Icons.Default.Add, "Create vault") }
+            })
+        }
+    ) { padding ->
+        Box(Modifier.padding(padding).fillMaxSize()) {
+            when {
+                state.isLoading && state.vaults.isEmpty() ->
+                    CircularProgressIndicator(Modifier.align(Alignment.Center))
+                state.vaults.isEmpty() ->
+                    Text("No vaults yet. Tap + to create one.",
+                        Modifier.align(Alignment.Center),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                else -> {
+                    LazyColumn {
+                        if (state.isOffline) item {
+                            OfflineBanner()
+                        }
+                        state.error?.let { err -> item {
+                            Text(err, color = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.padding(16.dp))
+                        }}
+                        items(state.vaults, key = { it.id }) { vault ->
+                            VaultCard(vault = vault, onClick = { onVaultClick(vault.id) },
+                                onCheckIn = { vm.checkIn(vault.id) })
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun OfflineBanner() {
+    Surface(color = MaterialTheme.colorScheme.tertiaryContainer) {
+        Row(Modifier.fillMaxWidth().padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
+            Icon(Icons.Default.WifiOff, null, tint = MaterialTheme.colorScheme.onTertiaryContainer)
+            Spacer(Modifier.width(8.dp))
+            Text("Offline — showing cached data", color = MaterialTheme.colorScheme.onTertiaryContainer,
+                style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+@Composable
+private fun VaultCard(vault: Vault, onClick: () -> Unit, onCheckIn: () -> Unit) {
+    Card(onClick = onClick, modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 6.dp)) {
+        Column(Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(vault.id.take(12) + "…", style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f))
+                StatusChip(vault.status)
+            }
+            Spacer(Modifier.height(4.dp))
+            Text(vault.formattedBalance, style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant)
+            if (vault.isExpiringSoon) {
+                Spacer(Modifier.height(4.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.Warning, null, tint = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.size(14.dp))
+                    Spacer(Modifier.width(4.dp))
+                    Text("Expiring soon!", color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.labelSmall)
+                }
+            }
+            if (vault.status == com.ttllegacy.models.VaultStatus.active) {
+                Spacer(Modifier.height(8.dp))
+                OutlinedButton(onClick = onCheckIn, modifier = Modifier.fillMaxWidth()) {
+                    Text("Check In")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusChip(status: com.ttllegacy.models.VaultStatus) {
+    val (label, color) = when (status) {
+        com.ttllegacy.models.VaultStatus.active -> "Active" to MaterialTheme.colorScheme.primary
+        com.ttllegacy.models.VaultStatus.expired -> "Expired" to MaterialTheme.colorScheme.error
+        com.ttllegacy.models.VaultStatus.released -> "Released" to MaterialTheme.colorScheme.secondary
+        com.ttllegacy.models.VaultStatus.paused -> "Paused" to MaterialTheme.colorScheme.outline
+    }
+    SuggestionChip(onClick = {}, label = { Text(label, style = MaterialTheme.typography.labelSmall) },
+        colors = SuggestionChipDefaults.suggestionChipColors(labelColor = color))
+}
+
+@Composable
+private fun CreateVaultDialog(onCreate: (String, Int) -> Unit, onDismiss: () -> Unit) {
+    var beneficiary by remember { mutableStateOf("") }
+    var days by remember { mutableStateOf(30f) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("New Vault") },
+        text = {
+            Column {
+                OutlinedTextField(value = beneficiary, onValueChange = { beneficiary = it },
+                    label = { Text("Beneficiary address") }, singleLine = true,
+                    modifier = Modifier.fillMaxWidth())
+                Spacer(Modifier.height(12.dp))
+                Text("Check-in interval: ${days.toInt()} days",
+                    style = MaterialTheme.typography.bodySmall)
+                Slider(value = days, onValueChange = { days = it }, valueRange = 1f..365f, steps = 363)
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onCreate(beneficiary, days.toInt()) },
+                enabled = beneficiary.isNotBlank()) { Text("Create") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } }
+    )
+}

--- a/mobile/android/app/src/main/java/com/ttllegacy/ui/theme/Theme.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/ui/theme/Theme.kt
@@ -1,0 +1,23 @@
+package com.ttllegacy.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import android.os.Build
+
+@Composable
+fun TTLLegacyTheme(darkTheme: Boolean = androidx.compose.foundation.isSystemInDarkTheme(), content: @Composable () -> Unit) {
+    val colorScheme = when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val ctx = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(ctx) else dynamicLightColorScheme(ctx)
+        }
+        darkTheme -> darkColorScheme()
+        else -> lightColorScheme()
+    }
+    MaterialTheme(colorScheme = colorScheme, content = content)
+}

--- a/mobile/android/app/src/test/java/com/ttllegacy/VaultModelTest.kt
+++ b/mobile/android/app/src/test/java/com/ttllegacy/VaultModelTest.kt
@@ -1,0 +1,46 @@
+package com.ttllegacy
+
+import com.ttllegacy.models.Vault
+import com.ttllegacy.models.VaultStatus
+import org.junit.Assert.*
+import org.junit.Test
+
+class VaultModelTest {
+
+    @Test
+    fun `isExpiringSoon true when ttl under 24h`() {
+        val vault = makeVault(ttlRemaining = 3_600L)
+        assertTrue(vault.isExpiringSoon)
+    }
+
+    @Test
+    fun `isExpiringSoon false when ttl over 24h`() {
+        val vault = makeVault(ttlRemaining = 172_800L)
+        assertFalse(vault.isExpiringSoon)
+    }
+
+    @Test
+    fun `isExpiringSoon false when ttl null`() {
+        val vault = makeVault(ttlRemaining = null)
+        assertFalse(vault.isExpiringSoon)
+    }
+
+    @Test
+    fun `formattedBalance converts stroops to XLM`() {
+        val vault = makeVault(balance = 10_000_000L)
+        assertEquals("1.0000000 XLM", vault.formattedBalance)
+    }
+
+    @Test
+    fun `formattedBalance handles zero`() {
+        val vault = makeVault(balance = 0L)
+        assertEquals("0.0000000 XLM", vault.formattedBalance)
+    }
+
+    private fun makeVault(balance: Long = 0L, ttlRemaining: Long?) = Vault(
+        id = "v1", owner = "GABC", beneficiary = "GXYZ",
+        balance = balance, checkInInterval = 2_592_000L,
+        lastCheckIn = "2026-04-01T00:00:00Z", ttlRemaining = ttlRemaining,
+        status = VaultStatus.active
+    )
+}

--- a/mobile/android/app/src/test/java/com/ttllegacy/VaultViewModelTest.kt
+++ b/mobile/android/app/src/test/java/com/ttllegacy/VaultViewModelTest.kt
@@ -1,0 +1,95 @@
+package com.ttllegacy
+
+import com.ttllegacy.api.ApiResult
+import com.ttllegacy.models.Vault
+import com.ttllegacy.models.VaultStatus
+import com.ttllegacy.ui.VaultUiState
+import com.ttllegacy.ui.VaultViewModel
+import com.ttllegacy.api.ApiClient
+import com.ttllegacy.services.NotificationHelper
+import io.mockk.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class VaultViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val apiClient: ApiClient = mockk()
+    private val notificationHelper: NotificationHelper = mockk(relaxed = true)
+    private lateinit var vm: VaultViewModel
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        vm = VaultViewModel(apiClient, notificationHelper)
+    }
+
+    @After
+    fun teardown() { Dispatchers.resetMain() }
+
+    @Test
+    fun `load success updates vaults`() = runTest {
+        val vaults = listOf(makeVault("v1"), makeVault("v2"))
+        coEvery { apiClient.listVaults() } returns ApiResult.Success(vaults)
+
+        vm.load()
+
+        assertEquals(vaults, vm.state.value.vaults)
+        assertFalse(vm.state.value.isLoading)
+        assertNull(vm.state.value.error)
+    }
+
+    @Test
+    fun `load network unavailable sets offline flag`() = runTest {
+        coEvery { apiClient.listVaults() } returns ApiResult.NetworkUnavailable
+
+        vm.load()
+
+        assertTrue(vm.state.value.isOffline)
+        assertFalse(vm.state.value.isLoading)
+    }
+
+    @Test
+    fun `load error sets error message`() = runTest {
+        coEvery { apiClient.listVaults() } returns ApiResult.Error("Server error", 500)
+
+        vm.load()
+
+        assertEquals("Server error", vm.state.value.error)
+        assertFalse(vm.state.value.isLoading)
+    }
+
+    @Test
+    fun `checkIn success reloads vaults`() = runTest {
+        val vaults = listOf(makeVault("v1"))
+        coEvery { apiClient.checkIn("v1") } returns ApiResult.Success(Unit)
+        coEvery { apiClient.listVaults() } returns ApiResult.Success(vaults)
+
+        vm.checkIn("v1")
+
+        coVerify { apiClient.checkIn("v1") }
+        coVerify { apiClient.listVaults() }
+    }
+
+    @Test
+    fun `checkIn network unavailable sets error`() = runTest {
+        coEvery { apiClient.checkIn("v1") } returns ApiResult.NetworkUnavailable
+
+        vm.checkIn("v1")
+
+        assertNotNull(vm.state.value.error)
+    }
+
+    private fun makeVault(id: String) = Vault(
+        id = id, owner = "GABC", beneficiary = "GXYZ",
+        balance = 10_000_000L, checkInInterval = 2_592_000L,
+        lastCheckIn = "2026-04-01T00:00:00Z", ttlRemaining = 172_800L,
+        status = VaultStatus.active
+    )
+}

--- a/mobile/android/gradle/libs.versions.toml
+++ b/mobile/android/gradle/libs.versions.toml
@@ -1,0 +1,53 @@
+kotlinx.serialization.json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.7.3" }
+
+[versions]
+agp = "8.7.3"
+kotlin = "2.1.0"
+compose-bom = "2024.12.01"
+hilt = "2.53"
+ktor = "3.0.3"
+lifecycle = "2.8.7"
+navigation = "2.8.5"
+credentials = "1.3.0"
+firebase-bom = "33.7.0"
+datastore = "1.1.1"
+coroutines = "1.9.0"
+mockk = "1.13.13"
+
+[libraries]
+compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
+compose-ui = { group = "androidx.compose.ui", name = "ui" }
+compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+activity-compose = { group = "androidx.activity", name = "activity-compose", version = "1.9.3" }
+navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
+lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
+hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
+hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version = "1.2.0" }
+ktor-client-android = { group = "io.ktor", name = "ktor-client-android", version.ref = "ktor" }
+ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
+credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
+credentials-play-services-auth = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentials" }
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
+firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging-ktx" }
+junit = { group = "junit", name = "junit", version = "4.13.2" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+androidx-test-ext = { group = "androidx.test.ext", name = "junit", version = "1.2.1" }
+espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version = "3.6.1" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+ksp = { id = "com.google.devtools.ksp", version = "2.1.0-1.0.29" }

--- a/mobile/ios/TTLLegacy/Package.swift
+++ b/mobile/ios/TTLLegacy/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "TTLLegacy",
+    platforms: [.iOS(.v17)],
+    products: [
+        .library(name: "TTLLegacy", targets: ["TTLLegacy"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "TTLLegacy",
+            path: "Sources"
+        ),
+        .testTarget(
+            name: "TTLLegacyTests",
+            dependencies: ["TTLLegacy"],
+            path: "Tests"
+        )
+    ]
+)

--- a/mobile/ios/TTLLegacy/Sources/App/TTLLegacyApp.swift
+++ b/mobile/ios/TTLLegacy/Sources/App/TTLLegacyApp.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+@main
+struct TTLLegacyApp: App {
+    @StateObject private var authStore = AuthStore()
+    @StateObject private var vaultStore = VaultStore()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environmentObject(authStore)
+                .environmentObject(vaultStore)
+                .task { await NotificationService.shared.requestPermission() }
+        }
+    }
+}

--- a/mobile/ios/TTLLegacy/Sources/Models/Models.swift
+++ b/mobile/ios/TTLLegacy/Sources/Models/Models.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+struct Vault: Codable, Identifiable, Equatable {
+    let id: String
+    let owner: String
+    let beneficiary: String
+    let balance: Int64
+    let checkInInterval: UInt64
+    let lastCheckIn: Date
+    let ttlRemaining: UInt64?
+    let status: VaultStatus
+
+    enum VaultStatus: String, Codable {
+        case active, expired, released, paused
+    }
+
+    var isExpiringSoon: Bool {
+        guard let ttl = ttlRemaining else { return false }
+        return ttl < 86_400 // < 24 hours
+    }
+
+    var formattedBalance: String {
+        let xlm = Double(balance) / 10_000_000
+        return String(format: "%.7f XLM", xlm)
+    }
+}
+
+struct AuthChallenge: Codable {
+    let challenge: String
+    let expiresAt: Date
+}
+
+struct AuthToken: Codable {
+    let token: String
+    let expiresAt: Date
+}
+
+struct PushRegistration: Codable {
+    let token: String
+    let platform: String  // "ios" | "android"
+}

--- a/mobile/ios/TTLLegacy/Sources/Services/APIClient.swift
+++ b/mobile/ios/TTLLegacy/Sources/Services/APIClient.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+enum APIError: LocalizedError {
+    case unauthorized
+    case notFound
+    case serverError(String)
+    case networkUnavailable
+    case decodingFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .unauthorized:       return "Authentication required"
+        case .notFound:           return "Resource not found"
+        case .serverError(let m): return m
+        case .networkUnavailable: return "No internet connection"
+        case .decodingFailed:     return "Invalid server response"
+        }
+    }
+}
+
+final class APIClient {
+    static let shared = APIClient()
+
+    private let baseURL: URL
+    private let session: URLSession
+    private let decoder: JSONDecoder
+
+    private init() {
+        let urlString = Bundle.main.object(forInfoDictionaryKey: "API_BASE_URL") as? String
+            ?? "https://api.ttl-legacy.app/v1"
+        baseURL = URL(string: urlString)!
+        session = URLSession(configuration: .default)
+        decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .iso8601
+    }
+
+    // MARK: - Auth
+
+    func getChallenge() async throws -> AuthChallenge {
+        try await post(path: "/auth/challenge", body: EmptyBody())
+    }
+
+    func verifyPasskey(credentialID: String, clientDataJSON: String, signature: String) async throws -> AuthToken {
+        let body = ["credential_id": credentialID,
+                    "client_data_json": clientDataJSON,
+                    "signature": signature]
+        return try await post(path: "/auth/verify", body: body)
+    }
+
+    func registerPasskey(credentialID: String, publicKey: String, clientDataJSON: String) async throws {
+        let body = ["credential_id": credentialID,
+                    "public_key": publicKey,
+                    "client_data_json": clientDataJSON]
+        let _: EmptyBody = try await post(path: "/auth/register", body: body)
+    }
+
+    // MARK: - Vaults
+
+    func listVaults() async throws -> [Vault] {
+        try await get(path: "/vaults")
+    }
+
+    func getVault(id: String) async throws -> Vault {
+        try await get(path: "/vaults/\(id)")
+    }
+
+    func createVault(beneficiary: String, checkInInterval: UInt64) async throws -> Vault {
+        let body = ["beneficiary": beneficiary, "check_in_interval": checkInInterval] as [String: Any]
+        return try await post(path: "/vaults", body: body)
+    }
+
+    func checkIn(vaultID: String) async throws {
+        let _: EmptyBody = try await post(path: "/vaults/\(vaultID)/checkin", body: EmptyBody())
+    }
+
+    func deposit(vaultID: String, amount: Int64) async throws -> Vault {
+        try await post(path: "/vaults/\(vaultID)/deposit", body: ["amount": amount])
+    }
+
+    func withdraw(vaultID: String, amount: Int64) async throws -> Vault {
+        try await post(path: "/vaults/\(vaultID)/withdraw", body: ["amount": amount])
+    }
+
+    func getTTL(vaultID: String) async throws -> UInt64 {
+        let result: [String: UInt64] = try await get(path: "/vaults/\(vaultID)/ttl")
+        return result["ttl_remaining"] ?? 0
+    }
+
+    // MARK: - Push Notifications
+
+    func registerPushToken(_ token: String) async throws {
+        let body = PushRegistration(token: token, platform: "ios")
+        let _: EmptyBody = try await post(path: "/notifications/register", body: body)
+    }
+
+    func unregisterPushToken(_ token: String) async throws {
+        var req = request(path: "/notifications/register")
+        req.httpMethod = "DELETE"
+        req.httpBody = try? JSONEncoder().encode(PushRegistration(token: token, platform: "ios"))
+        _ = try await execute(req)
+    }
+
+    // MARK: - Private helpers
+
+    private func get<T: Decodable>(path: String) async throws -> T {
+        var req = request(path: path)
+        req.httpMethod = "GET"
+        let data = try await execute(req)
+        return try decode(data)
+    }
+
+    private func post<B: Encodable, T: Decodable>(path: String, body: B) async throws -> T {
+        var req = request(path: path)
+        req.httpMethod = "POST"
+        req.httpBody = try JSONEncoder().encode(body)
+        let data = try await execute(req)
+        return try decode(data)
+    }
+
+    private func request(path: String) -> URLRequest {
+        var req = URLRequest(url: baseURL.appendingPathComponent(path))
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token = KeychainService.shared.loadToken() {
+            req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        return req
+    }
+
+    private func execute(_ request: URLRequest) async throws -> Data {
+        guard NetworkMonitor.shared.isConnected else {
+            // Return cached data if available
+            if let cached = OfflineCache.shared.load(for: request.url?.absoluteString ?? "") {
+                return cached
+            }
+            throw APIError.networkUnavailable
+        }
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw APIError.serverError("Invalid response") }
+        switch http.statusCode {
+        case 200...299:
+            OfflineCache.shared.save(data, for: request.url?.absoluteString ?? "")
+            return data
+        case 401: throw APIError.unauthorized
+        case 404: throw APIError.notFound
+        default:
+            let msg = (try? JSONDecoder().decode([String: String].self, from: data))?["error"] ?? "Server error"
+            throw APIError.serverError(msg)
+        }
+    }
+
+    private func decode<T: Decodable>(_ data: Data) throws -> T {
+        if T.self == EmptyBody.self { return EmptyBody() as! T }
+        do { return try decoder.decode(T.self, from: data) }
+        catch { throw APIError.decodingFailed }
+    }
+}
+
+private struct EmptyBody: Codable {}

--- a/mobile/ios/TTLLegacy/Sources/Services/KeychainService.swift
+++ b/mobile/ios/TTLLegacy/Sources/Services/KeychainService.swift
@@ -1,0 +1,60 @@
+import Security
+import Foundation
+
+final class KeychainService {
+    static let shared = KeychainService()
+    private init() {}
+
+    private let tokenKey = "com.ttllegacy.auth_token"
+    private let credentialKey = "com.ttllegacy.passkey_credential"
+
+    func saveToken(_ token: String) {
+        save(token, forKey: tokenKey)
+    }
+
+    func loadToken() -> String? {
+        load(forKey: tokenKey)
+    }
+
+    func deleteToken() {
+        delete(forKey: tokenKey)
+    }
+
+    func saveCredentialID(_ id: String) {
+        save(id, forKey: credentialKey)
+    }
+
+    func loadCredentialID() -> String? {
+        load(forKey: credentialKey)
+    }
+
+    private func save(_ value: String, forKey key: String) {
+        let data = Data(value.utf8)
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecValueData: data,
+            kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        ]
+        SecItemDelete(query as CFDictionary)
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    private func load(forKey key: String) -> String? {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: key,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private func delete(forKey key: String) {
+        let query: [CFString: Any] = [kSecClass: kSecClassGenericPassword, kSecAttrAccount: key]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/mobile/ios/TTLLegacy/Sources/Services/NotificationService.swift
+++ b/mobile/ios/TTLLegacy/Sources/Services/NotificationService.swift
@@ -1,0 +1,65 @@
+import UserNotifications
+import Foundation
+
+final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
+    static let shared = NotificationService()
+    private override init() {
+        super.init()
+        UNUserNotificationCenter.current().delegate = self
+    }
+
+    func requestPermission() async {
+        let granted = (try? await UNUserNotificationCenter.current()
+            .requestAuthorization(options: [.alert, .badge, .sound])) ?? false
+        if granted { await registerForRemoteNotifications() }
+    }
+
+    @MainActor
+    private func registerForRemoteNotifications() {
+        UIApplication.shared.registerForRemoteNotifications()
+    }
+
+    func handleDeviceToken(_ tokenData: Data) {
+        let token = tokenData.map { String(format: "%02x", $0) }.joined()
+        Task { try? await APIClient.shared.registerPushToken(token) }
+    }
+
+    // Schedule a local check-in reminder
+    func scheduleCheckInReminder(vaultID: String, vaultName: String, ttlRemaining: UInt64) {
+        let center = UNUserNotificationCenter.current()
+        center.removePendingNotificationRequests(withIdentifiers: ["checkin-\(vaultID)"])
+
+        guard ttlRemaining > 0 else { return }
+        let fireIn = max(Int(ttlRemaining) - 86_400, 60) // 24h before expiry, min 1 min
+
+        let content = UNMutableNotificationContent()
+        content.title = "Check-in Required"
+        content.body = "Your vault expires in ~24 hours. Tap to check in now."
+        content.sound = .default
+        content.userInfo = ["vault_id": vaultID]
+        content.categoryIdentifier = "CHECK_IN"
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: TimeInterval(fireIn), repeats: false)
+        let request = UNNotificationRequest(identifier: "checkin-\(vaultID)", content: content, trigger: trigger)
+        center.add(request)
+    }
+
+    // MARK: - UNUserNotificationCenterDelegate
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                 didReceive response: UNNotificationResponse,
+                                 withCompletionHandler completionHandler: @escaping () -> Void) {
+        let vaultID = response.notification.request.content.userInfo["vault_id"] as? String
+        if response.actionIdentifier == "CHECK_IN_ACTION", let id = vaultID {
+            Task { try? await APIClient.shared.checkIn(vaultID: id) }
+        }
+        completionHandler()
+    }
+
+    func registerNotificationCategories() {
+        let checkInAction = UNNotificationAction(identifier: "CHECK_IN_ACTION", title: "Check In", options: .foreground)
+        let category = UNNotificationCategory(identifier: "CHECK_IN", actions: [checkInAction],
+                                               intentIdentifiers: [], options: [])
+        UNUserNotificationCenter.current().setNotificationCategories([category])
+    }
+}

--- a/mobile/ios/TTLLegacy/Sources/Services/OfflineSupport.swift
+++ b/mobile/ios/TTLLegacy/Sources/Services/OfflineSupport.swift
@@ -1,0 +1,45 @@
+import Network
+import Foundation
+
+final class NetworkMonitor {
+    static let shared = NetworkMonitor()
+    private let monitor = NWPathMonitor()
+    private(set) var isConnected = true
+
+    private init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            self?.isConnected = path.status == .satisfied
+        }
+        monitor.start(queue: DispatchQueue(label: "NetworkMonitor"))
+    }
+}
+
+/// Simple disk-based cache for offline reads.
+final class OfflineCache {
+    static let shared = OfflineCache()
+    private let dir: URL
+
+    private init() {
+        dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("TTLLegacyOfflineCache", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    }
+
+    func save(_ data: Data, for key: String) {
+        let file = dir.appendingPathComponent(key.sha256Hex)
+        try? data.write(to: file)
+    }
+
+    func load(for key: String) -> Data? {
+        let file = dir.appendingPathComponent(key.sha256Hex)
+        return try? Data(contentsOf: file)
+    }
+}
+
+import CryptoKit
+extension String {
+    var sha256Hex: String {
+        let digest = SHA256.hash(data: Data(utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/mobile/ios/TTLLegacy/Sources/Services/PasskeyService.swift
+++ b/mobile/ios/TTLLegacy/Sources/Services/PasskeyService.swift
@@ -1,0 +1,82 @@
+import AuthenticationServices
+import Foundation
+
+final class PasskeyService: NSObject {
+    static let shared = PasskeyService()
+    private override init() {}
+
+    func register(username: String) async throws -> String {
+        let challenge = try await APIClient.shared.getChallenge()
+        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: "ttl-legacy.app")
+        let request = provider.createCredentialRegistrationRequest(
+            challenge: Data(base64URLEncoded: challenge.challenge)!,
+            name: username,
+            userID: Data(username.utf8)
+        )
+        let credential = try await performRequest(request)
+        guard let reg = credential as? ASAuthorizationPlatformPublicKeyCredentialRegistration else {
+            throw PasskeyError.registrationFailed
+        }
+        let credID = reg.credentialID.base64URLEncodedString()
+        let pubKey = reg.rawAttestationObject?.base64URLEncodedString() ?? ""
+        let clientData = reg.rawClientDataJSON.base64URLEncodedString()
+        try await APIClient.shared.registerPasskey(credentialID: credID, publicKey: pubKey, clientDataJSON: clientData)
+        return credID
+    }
+
+    func authenticate() async throws -> AuthToken {
+        let challenge = try await APIClient.shared.getChallenge()
+        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: "ttl-legacy.app")
+        let request = provider.createCredentialAssertionRequest(challenge: Data(base64URLEncoded: challenge.challenge)!)
+        let credential = try await performRequest(request)
+        guard let assertion = credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion else {
+            throw PasskeyError.authenticationFailed
+        }
+        let credID = assertion.credentialID.base64URLEncodedString()
+        let clientData = assertion.rawClientDataJSON.base64URLEncodedString()
+        let signature = assertion.signature.base64URLEncodedString()
+        return try await APIClient.shared.verifyPasskey(credentialID: credID, clientDataJSON: clientData, signature: signature)
+    }
+
+    private func performRequest(_ request: ASAuthorizationRequest) async throws -> ASAuthorizationCredential {
+        try await withCheckedThrowingContinuation { continuation in
+            let controller = ASAuthorizationController(authorizationRequests: [request])
+            let delegate = PasskeyDelegate(continuation: continuation)
+            controller.delegate = delegate
+            controller.performRequests()
+            objc_setAssociatedObject(controller, "delegate", delegate, .OBJC_ASSOCIATION_RETAIN)
+        }
+    }
+}
+
+private class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate {
+    let continuation: CheckedContinuation<ASAuthorizationCredential, Error>
+    init(continuation: CheckedContinuation<ASAuthorizationCredential, Error>) { self.continuation = continuation }
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        continuation.resume(returning: authorization.credential)
+    }
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        continuation.resume(throwing: error)
+    }
+}
+
+enum PasskeyError: LocalizedError {
+    case registrationFailed, authenticationFailed
+    var errorDescription: String? {
+        switch self {
+        case .registrationFailed: return "Passkey registration failed"
+        case .authenticationFailed: return "Passkey authentication failed"
+        }
+    }
+}
+
+extension Data {
+    init?(base64URLEncoded string: String) {
+        var base64 = string.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+        while base64.count % 4 != 0 { base64.append("=") }
+        self.init(base64Encoded: base64)
+    }
+    func base64URLEncodedString() -> String {
+        base64EncodedString().replacingOccurrences(of: "+", with: "-").replacingOccurrences(of: "/", with: "_").replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/mobile/ios/TTLLegacy/Sources/ViewModels/Stores.swift
+++ b/mobile/ios/TTLLegacy/Sources/ViewModels/Stores.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Combine
+
+@MainActor
+final class AuthStore: ObservableObject {
+    @Published var isAuthenticated = false
+    @Published var isLoading = false
+    @Published var error: String?
+
+    init() {
+        isAuthenticated = KeychainService.shared.loadToken() != nil
+    }
+
+    func signIn() async {
+        isLoading = true; error = nil
+        do {
+            let token = try await PasskeyService.shared.authenticate()
+            KeychainService.shared.saveToken(token.token)
+            isAuthenticated = true
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    func register(username: String) async {
+        isLoading = true; error = nil
+        do {
+            let credID = try await PasskeyService.shared.register(username: username)
+            KeychainService.shared.saveCredentialID(credID)
+            await signIn()
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    func signOut() {
+        KeychainService.shared.deleteToken()
+        isAuthenticated = false
+    }
+}
+
+@MainActor
+final class VaultStore: ObservableObject {
+    @Published var vaults: [Vault] = []
+    @Published var isLoading = false
+    @Published var error: String?
+
+    func load() async {
+        isLoading = true; error = nil
+        do {
+            vaults = try await APIClient.shared.listVaults()
+            scheduleReminders()
+        } catch APIError.networkUnavailable {
+            // Vaults already populated from offline cache via APIClient
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    func checkIn(vault: Vault) async {
+        do {
+            try await APIClient.shared.checkIn(vaultID: vault.id)
+            await load()
+        } catch { self.error = error.localizedDescription }
+    }
+
+    private func scheduleReminders() {
+        for vault in vaults where vault.status == .active {
+            if let ttl = vault.ttlRemaining {
+                NotificationService.shared.scheduleCheckInReminder(
+                    vaultID: vault.id, vaultName: vault.id, ttlRemaining: ttl)
+            }
+        }
+    }
+}

--- a/mobile/ios/TTLLegacy/Sources/Views/Views.swift
+++ b/mobile/ios/TTLLegacy/Sources/Views/Views.swift
@@ -1,0 +1,256 @@
+import SwiftUI
+
+struct RootView: View {
+    @EnvironmentObject var authStore: AuthStore
+
+    var body: some View {
+        if authStore.isAuthenticated {
+            VaultListView()
+        } else {
+            AuthView()
+        }
+    }
+}
+
+// MARK: - Auth
+
+struct AuthView: View {
+    @EnvironmentObject var authStore: AuthStore
+    @State private var username = ""
+    @State private var showRegister = false
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Image(systemName: "lock.shield.fill")
+                    .font(.system(size: 64))
+                    .foregroundStyle(.blue)
+                Text("TTL-Legacy").font(.largeTitle.bold())
+                Text("Secure digital inheritance").foregroundStyle(.secondary)
+
+                if let error = authStore.error {
+                    Text(error).foregroundStyle(.red).font(.caption).multilineTextAlignment(.center)
+                }
+
+                Button(action: { Task { await authStore.signIn() } }) {
+                    Label("Sign in with Passkey", systemImage: "person.badge.key.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(authStore.isLoading)
+
+                Button("Create account") { showRegister = true }
+                    .foregroundStyle(.blue)
+            }
+            .padding(32)
+            .overlay { if authStore.isLoading { ProgressView() } }
+            .sheet(isPresented: $showRegister) { RegisterView() }
+        }
+    }
+}
+
+struct RegisterView: View {
+    @EnvironmentObject var authStore: AuthStore
+    @Environment(\.dismiss) var dismiss
+    @State private var username = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Account") {
+                    TextField("Username", text: $username)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                }
+                if let error = authStore.error {
+                    Section { Text(error).foregroundStyle(.red).font(.caption) }
+                }
+            }
+            .navigationTitle("Create Account")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Register") {
+                        Task { await authStore.register(username: username); dismiss() }
+                    }
+                    .disabled(username.isEmpty || authStore.isLoading)
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Vault List
+
+struct VaultListView: View {
+    @EnvironmentObject var vaultStore: VaultStore
+    @EnvironmentObject var authStore: AuthStore
+    @State private var showCreate = false
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if vaultStore.isLoading && vaultStore.vaults.isEmpty {
+                    ProgressView("Loading vaults…")
+                } else if vaultStore.vaults.isEmpty {
+                    ContentUnavailableView("No Vaults", systemImage: "lock.open", description: Text("Create your first vault to get started."))
+                } else {
+                    List(vaultStore.vaults) { vault in
+                        NavigationLink(destination: VaultDetailView(vault: vault)) {
+                            VaultRowView(vault: vault)
+                        }
+                    }
+                    .refreshable { await vaultStore.load() }
+                }
+            }
+            .navigationTitle("My Vaults")
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button(action: { showCreate = true }) { Image(systemName: "plus") }
+                }
+                ToolbarItem(placement: .secondaryAction) {
+                    Button("Sign Out") { authStore.signOut() }
+                }
+            }
+            .task { await vaultStore.load() }
+            .sheet(isPresented: $showCreate) { CreateVaultView() }
+        }
+    }
+}
+
+struct VaultRowView: View {
+    let vault: Vault
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(vault.id.prefix(12) + "…").font(.headline)
+                Spacer()
+                StatusBadge(status: vault.status)
+            }
+            Text(vault.formattedBalance).font(.subheadline).foregroundStyle(.secondary)
+            if vault.isExpiringSoon {
+                Label("Expiring soon!", systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption).foregroundStyle(.orange)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+struct StatusBadge: View {
+    let status: Vault.VaultStatus
+    var body: some View {
+        Text(status.rawValue.capitalized)
+            .font(.caption.bold())
+            .padding(.horizontal, 8).padding(.vertical, 2)
+            .background(color.opacity(0.15))
+            .foregroundStyle(color)
+            .clipShape(Capsule())
+    }
+    private var color: Color {
+        switch status {
+        case .active:   return .green
+        case .expired:  return .orange
+        case .released: return .blue
+        case .paused:   return .gray
+        }
+    }
+}
+
+// MARK: - Vault Detail
+
+struct VaultDetailView: View {
+    let vault: Vault
+    @EnvironmentObject var vaultStore: VaultStore
+    @State private var isCheckingIn = false
+
+    var body: some View {
+        List {
+            Section("Overview") {
+                LabeledContent("Balance", value: vault.formattedBalance)
+                LabeledContent("Status", value: vault.status.rawValue.capitalized)
+                LabeledContent("Beneficiary", value: vault.beneficiary.prefix(16) + "…")
+                if let ttl = vault.ttlRemaining {
+                    LabeledContent("TTL Remaining", value: formatDuration(ttl))
+                }
+            }
+            Section {
+                Button(action: checkIn) {
+                    Label(isCheckingIn ? "Checking in…" : "Check In Now", systemImage: "checkmark.circle.fill")
+                }
+                .disabled(isCheckingIn || vault.status != .active)
+            }
+        }
+        .navigationTitle("Vault")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func checkIn() {
+        isCheckingIn = true
+        Task {
+            await vaultStore.checkIn(vault: vault)
+            isCheckingIn = false
+        }
+    }
+
+    private func formatDuration(_ seconds: UInt64) -> String {
+        let days = seconds / 86_400
+        let hours = (seconds % 86_400) / 3_600
+        if days > 0 { return "\(days)d \(hours)h" }
+        return "\(hours)h"
+    }
+}
+
+// MARK: - Create Vault
+
+struct CreateVaultView: View {
+    @EnvironmentObject var vaultStore: VaultStore
+    @Environment(\.dismiss) var dismiss
+    @State private var beneficiary = ""
+    @State private var intervalDays = 30.0
+    @State private var isCreating = false
+    @State private var error: String?
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Beneficiary") {
+                    TextField("Stellar address", text: $beneficiary)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .font(.system(.body, design: .monospaced))
+                }
+                Section("Check-in Interval") {
+                    Slider(value: $intervalDays, in: 1...365, step: 1)
+                    Text("\(Int(intervalDays)) days").foregroundStyle(.secondary)
+                }
+                if let error { Section { Text(error).foregroundStyle(.red).font(.caption) } }
+            }
+            .navigationTitle("New Vault")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Create") { create() }.disabled(beneficiary.isEmpty || isCreating)
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func create() {
+        isCreating = true
+        Task {
+            do {
+                let interval = UInt64(intervalDays * 86_400)
+                _ = try await APIClient.shared.createVault(beneficiary: beneficiary, checkInInterval: interval)
+                await vaultStore.load()
+                dismiss()
+            } catch { self.error = error.localizedDescription }
+            isCreating = false
+        }
+    }
+}

--- a/mobile/ios/TTLLegacy/Tests/TTLLegacyTests.swift
+++ b/mobile/ios/TTLLegacy/Tests/TTLLegacyTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import TTLLegacy
+
+final class VaultModelTests: XCTestCase {
+
+    func test_isExpiringSoon_whenTTLUnder24h_returnsTrue() {
+        let vault = makeVault(ttlRemaining: 3_600) // 1 hour
+        XCTAssertTrue(vault.isExpiringSoon)
+    }
+
+    func test_isExpiringSoon_whenTTLOver24h_returnsFalse() {
+        let vault = makeVault(ttlRemaining: 172_800) // 2 days
+        XCTAssertFalse(vault.isExpiringSoon)
+    }
+
+    func test_isExpiringSoon_whenTTLNil_returnsFalse() {
+        let vault = makeVault(ttlRemaining: nil)
+        XCTAssertFalse(vault.isExpiringSoon)
+    }
+
+    func test_formattedBalance_convertsStroopsToXLM() {
+        let vault = makeVault(balance: 10_000_000) // 1 XLM
+        XCTAssertEqual(vault.formattedBalance, "1.0000000 XLM")
+    }
+
+    func test_vaultDecoding_fromJSON() throws {
+        let json = """
+        {
+          "id": "vault-1",
+          "owner": "GABC",
+          "beneficiary": "GXYZ",
+          "balance": 50000000,
+          "check_in_interval": 2592000,
+          "last_check_in": "2026-04-01T00:00:00Z",
+          "ttl_remaining": 100000,
+          "status": "active"
+        }
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .iso8601
+        let vault = try decoder.decode(Vault.self, from: json)
+        XCTAssertEqual(vault.id, "vault-1")
+        XCTAssertEqual(vault.status, .active)
+        XCTAssertEqual(vault.balance, 50_000_000)
+    }
+
+    // MARK: - Helpers
+
+    private func makeVault(balance: Int64 = 0, ttlRemaining: UInt64?) -> Vault {
+        Vault(id: "v1", owner: "GABC", beneficiary: "GXYZ",
+              balance: balance, checkInInterval: 2_592_000,
+              lastCheckIn: Date(), ttlRemaining: ttlRemaining, status: .active)
+    }
+}
+
+final class KeychainServiceTests: XCTestCase {
+
+    func test_saveAndLoadToken() {
+        KeychainService.shared.saveToken("test-token-123")
+        XCTAssertEqual(KeychainService.shared.loadToken(), "test-token-123")
+    }
+
+    func test_deleteToken_returnsNil() {
+        KeychainService.shared.saveToken("to-delete")
+        KeychainService.shared.deleteToken()
+        XCTAssertNil(KeychainService.shared.loadToken())
+    }
+}
+
+final class OfflineCacheTests: XCTestCase {
+
+    func test_saveAndLoad_returnsData() {
+        let data = Data("hello".utf8)
+        OfflineCache.shared.save(data, for: "test-key")
+        XCTAssertEqual(OfflineCache.shared.load(for: "test-key"), data)
+    }
+
+    func test_load_missingKey_returnsNil() {
+        XCTAssertNil(OfflineCache.shared.load(for: "nonexistent-key-\(UUID())"))
+    }
+}
+
+final class Base64URLTests: XCTestCase {
+
+    func test_roundTrip() {
+        let original = Data([0x01, 0x02, 0xFE, 0xFF])
+        let encoded = original.base64URLEncodedString()
+        XCTAssertFalse(encoded.contains("+"))
+        XCTAssertFalse(encoded.contains("/"))
+        XCTAssertFalse(encoded.contains("="))
+        let decoded = Data(base64URLEncoded: encoded)
+        XCTAssertEqual(decoded, original)
+    }
+}

--- a/mobile/shared/api-contract.md
+++ b/mobile/shared/api-contract.md
@@ -1,0 +1,62 @@
+# TTL-Legacy Mobile API Contract
+
+Base URL: `https://api.ttl-legacy.app/v1` (configurable via env)
+
+## Authentication
+All authenticated endpoints require `Authorization: Bearer <jwt>` header.
+JWT is obtained via Passkey (WebAuthn) challenge/response flow.
+
+## Endpoints
+
+### Auth
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/auth/challenge` | Get WebAuthn challenge |
+| POST | `/auth/verify` | Verify passkey assertion, returns JWT |
+| POST | `/auth/register` | Register new passkey credential |
+
+### Vaults
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/vaults` | List owner's vaults |
+| POST | `/vaults` | Create vault |
+| GET | `/vaults/{id}` | Get vault detail |
+| POST | `/vaults/{id}/checkin` | Check in (extend TTL) |
+| POST | `/vaults/{id}/deposit` | Deposit funds |
+| POST | `/vaults/{id}/withdraw` | Withdraw funds |
+| GET | `/vaults/{id}/ttl` | Get TTL remaining |
+
+### Notifications
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/notifications/register` | Register push token |
+| DELETE | `/notifications/register` | Unregister push token |
+
+## WebSocket
+`wss://api.ttl-legacy.app/v1/ws?vault_id={id}` — real-time vault events
+
+## Models
+
+### Vault
+```json
+{
+  "id": "string",
+  "owner": "string",
+  "beneficiary": "string",
+  "balance": 0,
+  "check_in_interval": 0,
+  "last_check_in": "ISO8601",
+  "ttl_remaining": 0,
+  "status": "active|expired|released|paused"
+}
+```
+
+### AuthChallenge
+```json
+{ "challenge": "base64url", "expires_at": "ISO8601" }
+```
+
+### AuthToken
+```json
+{ "token": "string", "expires_at": "ISO8601" }
+```


### PR DESCRIPTION
closes #360
iOS (SwiftUI, iOS 17+):
- TTLLegacyApp: entry point, environment injection
- Models: Vault, AuthToken, AuthChallenge with Codable
- APIClient: async/await HTTP client with offline fallback
- PasskeyService: ASAuthorizationPlatformPublicKeyCredential register + authenticate flows
- KeychainService: secure token + credential ID storage
- NotificationService: APNs registration, local check-in reminders (24h before expiry), actionable CHECK_IN category
- OfflineSupport: NWPathMonitor + SHA-256 keyed disk cache
- AuthStore / VaultStore: ObservableObject view models
- Views: AuthView, RegisterView, VaultListView, VaultDetailView, CreateVaultView (full SwiftUI)
- Tests: model decoding, Keychain, OfflineCache, Base64URL

Android (Jetpack Compose, API 28+):
- Models: Kotlinx.serialization data classes
- ApiClient: Ktor client with offline cache + bearer auth
- Infrastructure: NetworkMonitor, OfflineCache, TokenProvider
- PasskeyService: CredentialManager WebAuthn register + auth
- PushService: Firebase Messaging token refresh + message handler
- NotificationHelper: FCM notification channel + display
- AuthViewModel / VaultViewModel: Hilt + StateFlow
- Screens: AuthScreen, VaultListScreen with offline banner, CreateVaultDialog, StatusChip, VaultCard
- MainActivity: NavHost with auth-gated navigation
- Theme: Material3 dynamic color
- AppModule: Hilt DI bindings
- Unit tests: VaultModelTest, VaultViewModelTest (MockK + coroutines-test)
- Instrumented tests: VaultListScreenTest (Compose UI)

Shared:
- mobile/shared/api-contract.md: REST + WebSocket API spec
- mobile/README.md: architecture, setup, testing guide