### PR TITLE
feat: push notifications via FCM with scheduling, preferences, and de…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,11 @@ REMINDER_EMAIL_API_KEY=
 REMINDER_SMS_API_KEY=
 # Secret key used to encrypt reminder data (email/phone) before storage
 REMINDER_ENCRYPTION_SECRET=
+
+# --- Push Notifications (Firebase Cloud Messaging) ---
+# FCM server key (OAuth2 access token or legacy server key)
+FCM_SERVER_KEY=
+# Firebase project ID (e.g. ttl-legacy-prod)
+FCM_PROJECT_ID=
+# How often (seconds) the background scheduler checks for due notifications
+NOTIFICATION_SCHEDULER_INTERVAL_SECS=60

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +469,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -1248,9 +1260,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1393,6 +1407,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1448,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http 1.4.0",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.3",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1588,6 +1684,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1754,6 +1866,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
@@ -2026,6 +2144,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2053,8 +2226,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2079,12 +2262,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2178,6 +2380,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,10 +2428,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2200,6 +2460,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2527,7 +2822,7 @@ dependencies = [
  "num-traits",
  "p256",
  "rand 0.8.5",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "sec1",
  "sha2",
  "sha3",
@@ -2565,7 +2860,7 @@ dependencies = [
  "serde_with",
  "soroban-env-common",
  "soroban-env-host",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2618,7 +2913,7 @@ checksum = "c2c70b20e68cae3ef700b8fa3ae29db1c6a294b311fba66918f90cb8f9fd0a1a"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmparser 0.116.1",
 ]
 
@@ -2635,7 +2930,7 @@ dependencies = [
  "soroban-spec",
  "stellar-xdr",
  "syn",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2687,7 +2982,7 @@ checksum = "12d2bf45e114117ea91d820a846fd1afbe3ba7d717988fee094ce8227a3bf8bd"
 dependencies = [
  "base32",
  "crate-git-revision",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2730,6 +3025,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2746,7 +3050,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2754,6 +3067,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2812,6 +3136,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,6 +3176,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2887,6 +3236,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2919,6 +3313,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "ttl-legacy-backend"
 version = "0.1.0"
 dependencies = [
@@ -2929,9 +3329,10 @@ dependencies = [
  "env_logger",
  "futures",
  "log",
+ "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-test",
  "tokio-tungstenite",
@@ -2960,7 +3361,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "sha1 0.10.6",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "utf-8",
 ]
@@ -2988,6 +3389,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -3048,6 +3455,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3082,6 +3498,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3195,6 +3625,25 @@ checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -17,6 +17,8 @@ log = "0.4"
 env_logger = "0.11"
 thiserror = "1"
 csv = "1"
+# Push notifications (FCM via HTTP v1 API)
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -1,8 +1,10 @@
 use crate::models::*;
 use crate::db::*;
+use crate::notifications::NotificationService;
 use chrono::Utc;
 use serde_json::json;
 use std::io::Write;
+use std::sync::Arc;
 
 pub fn search_vaults_handler(
     store: &VaultStore,
@@ -284,6 +286,51 @@ pub fn create_vault_from_template(
     Ok(vault)
 }
 
+// ── Push notification HTTP handlers ─────────────────────────────────────────
+
+/// POST /notifications/register
+/// Register a device push token for an owner.
+pub fn register_push_token_handler(
+    svc: &NotificationService,
+    req: RegisterTokenRequest,
+) {
+    svc.register_token(req);
+}
+
+/// DELETE /notifications/register
+/// Unregister a device push token.
+pub fn unregister_push_token_handler(
+    svc: &NotificationService,
+    owner: &str,
+    token: &str,
+) {
+    svc.unregister_token(owner, token);
+}
+
+/// GET /notifications/preferences?owner=…
+pub fn get_preferences_handler(
+    svc: &NotificationService,
+    owner: &str,
+) -> NotificationPreferences {
+    svc.get_preferences(owner)
+}
+
+/// PUT /notifications/preferences
+pub fn update_preferences_handler(
+    svc: &NotificationService,
+    req: UpdatePreferencesRequest,
+) {
+    svc.update_preferences(req);
+}
+
+/// GET /notifications/delivery?owner=…
+pub fn get_delivery_log_handler(
+    svc: &NotificationService,
+    owner: &str,
+) -> Vec<DeliveryRecord> {
+    svc.get_delivery_log(owner)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -467,5 +514,71 @@ mod tests {
         let pdf_str = result.unwrap();
         assert!(pdf_str.contains("COMPLIANCE REPORT"));
         assert!(pdf_str.contains("v1"));
+    }
+
+    // ── Notification handler tests ───────────────────────────────────────────
+
+    fn make_notification_service() -> NotificationService {
+        use crate::notifications::*;
+        use std::sync::Arc;
+        NotificationService::new(
+            Arc::new(FcmClient::new("key".into(), "proj".into())),
+            create_token_store(),
+            create_prefs_store(),
+            create_schedule_store(),
+            create_delivery_store(),
+        )
+    }
+
+    #[test]
+    fn test_register_push_token_handler() {
+        let svc = make_notification_service();
+        register_push_token_handler(&svc, RegisterTokenRequest {
+            owner: "owner1".into(),
+            token: "tok-xyz".into(),
+            platform: "android".into(),
+        });
+        assert_eq!(svc.get_tokens("owner1").len(), 1);
+    }
+
+    #[test]
+    fn test_unregister_push_token_handler() {
+        let svc = make_notification_service();
+        register_push_token_handler(&svc, RegisterTokenRequest {
+            owner: "owner1".into(),
+            token: "tok-xyz".into(),
+            platform: "ios".into(),
+        });
+        unregister_push_token_handler(&svc, "owner1", "tok-xyz");
+        assert!(svc.get_tokens("owner1").is_empty());
+    }
+
+    #[test]
+    fn test_get_preferences_handler_returns_defaults() {
+        let svc = make_notification_service();
+        let prefs = get_preferences_handler(&svc, "owner1");
+        assert!(prefs.expiry_warning_enabled);
+        assert_eq!(prefs.warning_hours_before, 24);
+    }
+
+    #[test]
+    fn test_update_preferences_handler() {
+        let svc = make_notification_service();
+        update_preferences_handler(&svc, UpdatePreferencesRequest {
+            owner: "owner1".into(),
+            expiry_warning_enabled: Some(false),
+            check_in_reminder_enabled: None,
+            vault_released_enabled: None,
+            warning_hours_before: Some(12),
+        });
+        let prefs = get_preferences_handler(&svc, "owner1");
+        assert!(!prefs.expiry_warning_enabled);
+        assert_eq!(prefs.warning_hours_before, 12);
+    }
+
+    #[test]
+    fn test_get_delivery_log_handler_empty() {
+        let svc = make_notification_service();
+        assert!(get_delivery_log_handler(&svc, "owner1").is_empty());
     }
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -3,9 +3,11 @@ pub mod handlers;
 pub mod websocket;
 pub mod db;
 pub mod templates;
+pub mod notifications;
 
 pub use models::*;
 pub use handlers::*;
 pub use websocket::*;
 pub use db::*;
 pub use templates::*;
+pub use notifications::*;

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -1,6 +1,105 @@
 use serde::{Deserialize, Serialize};
 use chrono::{DateTime, Utc};
 
+// ── Notification models ──────────────────────────────────────────────────────
+
+/// Notification type sent to a device.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum NotificationType {
+    ExpiryWarning,
+    CheckInReminder,
+    VaultReleased,
+    VaultPaused,
+}
+
+/// Delivery status of a single notification attempt.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum DeliveryStatus {
+    Pending,
+    Sent,
+    Failed,
+}
+
+/// A registered device push token.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceToken {
+    pub owner: String,
+    pub token: String,
+    /// "ios" | "android" | "web"
+    pub platform: String,
+    pub registered_at: DateTime<Utc>,
+}
+
+/// Per-owner notification preferences.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotificationPreferences {
+    pub owner: String,
+    pub expiry_warning_enabled: bool,
+    pub check_in_reminder_enabled: bool,
+    pub vault_released_enabled: bool,
+    /// Hours before expiry to send the warning (default 24).
+    pub warning_hours_before: u64,
+}
+
+impl Default for NotificationPreferences {
+    fn default() -> Self {
+        Self {
+            owner: String::new(),
+            expiry_warning_enabled: true,
+            check_in_reminder_enabled: true,
+            vault_released_enabled: true,
+            warning_hours_before: 24,
+        }
+    }
+}
+
+/// A scheduled notification (pending delivery).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScheduledNotification {
+    pub id: String,
+    pub vault_id: String,
+    pub owner: String,
+    pub notification_type: NotificationType,
+    /// Unix timestamp when this should fire.
+    pub scheduled_at: DateTime<Utc>,
+    pub status: DeliveryStatus,
+}
+
+/// Delivery record written after each send attempt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeliveryRecord {
+    pub notification_id: String,
+    pub vault_id: String,
+    pub owner: String,
+    pub notification_type: NotificationType,
+    pub status: DeliveryStatus,
+    pub sent_at: DateTime<Utc>,
+    /// FCM message ID on success, error string on failure.
+    pub provider_response: String,
+}
+
+/// Request body for `POST /notifications/register`.
+#[derive(Debug, Deserialize)]
+pub struct RegisterTokenRequest {
+    pub owner: String,
+    pub token: String,
+    pub platform: String,
+}
+
+/// Request body for `PUT /notifications/preferences`.
+#[derive(Debug, Deserialize)]
+pub struct UpdatePreferencesRequest {
+    pub owner: String,
+    pub expiry_warning_enabled: Option<bool>,
+    pub check_in_reminder_enabled: Option<bool>,
+    pub vault_released_enabled: Option<bool>,
+    pub warning_hours_before: Option<u64>,
+}
+
+// ── Existing models (unchanged) ──────────────────────────────────────────────
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Vault {
     pub id: String,

--- a/backend/src/notifications.rs
+++ b/backend/src/notifications.rs
@@ -1,0 +1,593 @@
+/// Push notification service: FCM delivery, scheduling, preferences, tracking.
+///
+/// Architecture:
+///   FcmClient          — sends a single message via FCM HTTP v1 API
+///   NotificationStore  — in-memory stores (tokens, prefs, schedule, delivery log)
+///   NotificationService — orchestrates scheduling + delivery
+use crate::models::{
+    DeliveryRecord, DeliveryStatus, DeviceToken, NotificationPreferences, NotificationType,
+    RegisterTokenRequest, ScheduledNotification, UpdatePreferencesRequest, Vault,
+};
+use chrono::Utc;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use uuid::Uuid;
+
+// ── Shared store types ───────────────────────────────────────────────────────
+
+pub type TokenStore = Arc<Mutex<HashMap<String, Vec<DeviceToken>>>>;
+pub type PrefsStore = Arc<Mutex<HashMap<String, NotificationPreferences>>>;
+pub type ScheduleStore = Arc<Mutex<Vec<ScheduledNotification>>>;
+pub type DeliveryStore = Arc<Mutex<Vec<DeliveryRecord>>>;
+
+pub fn create_token_store() -> TokenStore {
+    Arc::new(Mutex::new(HashMap::new()))
+}
+pub fn create_prefs_store() -> PrefsStore {
+    Arc::new(Mutex::new(HashMap::new()))
+}
+pub fn create_schedule_store() -> ScheduleStore {
+    Arc::new(Mutex::new(Vec::new()))
+}
+pub fn create_delivery_store() -> DeliveryStore {
+    Arc::new(Mutex::new(Vec::new()))
+}
+
+// ── FCM HTTP v1 client ───────────────────────────────────────────────────────
+
+/// Thin wrapper around the FCM HTTP v1 send endpoint.
+/// Set `FCM_SERVER_KEY` env var to your Firebase server key.
+pub struct FcmClient {
+    http: reqwest::Client,
+    server_key: String,
+    project_id: String,
+}
+
+impl FcmClient {
+    pub fn new(server_key: String, project_id: String) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            server_key,
+            project_id,
+        }
+    }
+
+    /// Send a notification to a single FCM registration token.
+    /// Returns the FCM message ID on success.
+    pub async fn send(
+        &self,
+        device_token: &str,
+        title: &str,
+        body: &str,
+        data: Value,
+    ) -> Result<String, String> {
+        let payload = json!({
+            "message": {
+                "token": device_token,
+                "notification": { "title": title, "body": body },
+                "data": data,
+                "android": {
+                    "priority": "high",
+                    "notification": { "channel_id": "ttl_reminders" }
+                },
+                "apns": {
+                    "headers": { "apns-priority": "10" },
+                    "payload": { "aps": { "sound": "default" } }
+                }
+            }
+        });
+
+        let url = format!(
+            "https://fcm.googleapis.com/v1/projects/{}/messages:send",
+            self.project_id
+        );
+
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(&self.server_key)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+
+        if resp.status().is_success() {
+            let body: Value = resp.json().await.map_err(|e| e.to_string())?;
+            Ok(body["name"].as_str().unwrap_or("ok").to_string())
+        } else {
+            let status = resp.status().as_u16();
+            let text = resp.text().await.unwrap_or_default();
+            Err(format!("FCM error {status}: {text}"))
+        }
+    }
+}
+
+// ── Notification content helpers ─────────────────────────────────────────────
+
+fn notification_content(
+    notification_type: &NotificationType,
+    vault_id: &str,
+    ttl_hours: Option<u64>,
+) -> (&'static str, String, Value) {
+    match notification_type {
+        NotificationType::ExpiryWarning => {
+            let hours = ttl_hours.unwrap_or(24);
+            (
+                "⚠️ Vault Expiring Soon",
+                format!("Your vault expires in ~{hours}h. Check in now to keep it active."),
+                json!({ "type": "expiry_warning", "vault_id": vault_id }),
+            )
+        }
+        NotificationType::CheckInReminder => (
+            "🔔 Check-In Reminder",
+            "Time to check in to your TTL-Legacy vault.".to_string(),
+            json!({ "type": "check_in_reminder", "vault_id": vault_id }),
+        ),
+        NotificationType::VaultReleased => (
+            "🔓 Vault Released",
+            "Your vault has been released to the beneficiary.".to_string(),
+            json!({ "type": "vault_released", "vault_id": vault_id }),
+        ),
+        NotificationType::VaultPaused => (
+            "⏸ Vault Paused",
+            "Your vault has been paused.".to_string(),
+            json!({ "type": "vault_paused", "vault_id": vault_id }),
+        ),
+    }
+}
+
+// ── NotificationService ──────────────────────────────────────────────────────
+
+pub struct NotificationService {
+    pub fcm: Arc<FcmClient>,
+    pub tokens: TokenStore,
+    pub prefs: PrefsStore,
+    pub schedule: ScheduleStore,
+    pub delivery: DeliveryStore,
+}
+
+impl NotificationService {
+    pub fn new(
+        fcm: Arc<FcmClient>,
+        tokens: TokenStore,
+        prefs: PrefsStore,
+        schedule: ScheduleStore,
+        delivery: DeliveryStore,
+    ) -> Self {
+        Self { fcm, tokens, prefs, schedule, delivery }
+    }
+
+    // ── Token management ─────────────────────────────────────────────────────
+
+    pub fn register_token(&self, req: RegisterTokenRequest) {
+        let mut store = self.tokens.lock().unwrap();
+        let entry = store.entry(req.owner.clone()).or_default();
+        // Deduplicate by token value
+        if !entry.iter().any(|t| t.token == req.token) {
+            entry.push(DeviceToken {
+                owner: req.owner,
+                token: req.token,
+                platform: req.platform,
+                registered_at: Utc::now(),
+            });
+        }
+    }
+
+    pub fn unregister_token(&self, owner: &str, token: &str) {
+        let mut store = self.tokens.lock().unwrap();
+        if let Some(tokens) = store.get_mut(owner) {
+            tokens.retain(|t| t.token != token);
+        }
+    }
+
+    pub fn get_tokens(&self, owner: &str) -> Vec<DeviceToken> {
+        self.tokens.lock().unwrap().get(owner).cloned().unwrap_or_default()
+    }
+
+    // ── Preferences ──────────────────────────────────────────────────────────
+
+    pub fn get_preferences(&self, owner: &str) -> NotificationPreferences {
+        self.prefs
+            .lock()
+            .unwrap()
+            .get(owner)
+            .cloned()
+            .unwrap_or_else(|| NotificationPreferences {
+                owner: owner.to_string(),
+                ..Default::default()
+            })
+    }
+
+    pub fn update_preferences(&self, req: UpdatePreferencesRequest) {
+        let mut store = self.prefs.lock().unwrap();
+        let prefs = store.entry(req.owner.clone()).or_insert_with(|| NotificationPreferences {
+            owner: req.owner.clone(),
+            ..Default::default()
+        });
+        if let Some(v) = req.expiry_warning_enabled { prefs.expiry_warning_enabled = v; }
+        if let Some(v) = req.check_in_reminder_enabled { prefs.check_in_reminder_enabled = v; }
+        if let Some(v) = req.vault_released_enabled { prefs.vault_released_enabled = v; }
+        if let Some(v) = req.warning_hours_before { prefs.warning_hours_before = v; }
+    }
+
+    // ── Scheduling ───────────────────────────────────────────────────────────
+
+    /// Schedule an expiry-warning notification for a vault.
+    /// Fires `warning_hours_before` hours before the vault expires.
+    pub fn schedule_expiry_warning(&self, vault: &Vault) {
+        let prefs = self.get_preferences(&vault.owner);
+        if !prefs.expiry_warning_enabled { return; }
+
+        let Some(ttl) = vault.ttl_remaining else { return };
+        let warning_secs = prefs.warning_hours_before * 3600;
+        if ttl <= warning_secs { return; } // already past warning threshold
+
+        let fire_at = Utc::now()
+            + chrono::Duration::seconds((ttl - warning_secs) as i64);
+
+        // Avoid duplicate schedules for the same vault + type
+        let mut store = self.schedule.lock().unwrap();
+        let already = store.iter().any(|s| {
+            s.vault_id == vault.id
+                && s.notification_type == NotificationType::ExpiryWarning
+                && s.status == DeliveryStatus::Pending
+        });
+        if already { return; }
+
+        store.push(ScheduledNotification {
+            id: Uuid::new_v4().to_string(),
+            vault_id: vault.id.clone(),
+            owner: vault.owner.clone(),
+            notification_type: NotificationType::ExpiryWarning,
+            scheduled_at: fire_at,
+            status: DeliveryStatus::Pending,
+        });
+    }
+
+    /// Schedule an immediate notification (fires now).
+    pub fn schedule_immediate(
+        &self,
+        vault_id: &str,
+        owner: &str,
+        notification_type: NotificationType,
+    ) {
+        let prefs = self.get_preferences(owner);
+        let enabled = match &notification_type {
+            NotificationType::VaultReleased => prefs.vault_released_enabled,
+            NotificationType::CheckInReminder => prefs.check_in_reminder_enabled,
+            _ => true,
+        };
+        if !enabled { return; }
+
+        self.schedule.lock().unwrap().push(ScheduledNotification {
+            id: Uuid::new_v4().to_string(),
+            vault_id: vault_id.to_string(),
+            owner: owner.to_string(),
+            notification_type,
+            scheduled_at: Utc::now(),
+            status: DeliveryStatus::Pending,
+        });
+    }
+
+    pub fn get_pending_notifications(&self) -> Vec<ScheduledNotification> {
+        let now = Utc::now();
+        self.schedule
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|n| n.status == DeliveryStatus::Pending && n.scheduled_at <= now)
+            .cloned()
+            .collect()
+    }
+
+    // ── Delivery ─────────────────────────────────────────────────────────────
+
+    /// Send all due pending notifications. Called by the background scheduler loop.
+    pub async fn flush_pending(&self) {
+        let due = self.get_pending_notifications();
+        for notif in due {
+            self.deliver(&notif).await;
+        }
+    }
+
+    async fn deliver(&self, notif: &ScheduledNotification) {
+        let tokens = self.get_tokens(&notif.owner);
+        if tokens.is_empty() {
+            self.record(notif, DeliveryStatus::Failed, "no_tokens_registered");
+            self.mark_sent(&notif.id, DeliveryStatus::Failed);
+            return;
+        }
+
+        let (title, body, data) =
+            notification_content(&notif.notification_type, &notif.vault_id, None);
+
+        let mut last_err = String::new();
+        let mut any_ok = false;
+        for device in &tokens {
+            match self.fcm.send(&device.token, title, &body, data.clone()).await {
+                Ok(msg_id) => {
+                    self.record(notif, DeliveryStatus::Sent, &msg_id);
+                    any_ok = true;
+                }
+                Err(e) => {
+                    last_err = e;
+                }
+            }
+        }
+
+        let final_status = if any_ok { DeliveryStatus::Sent } else { DeliveryStatus::Failed };
+        if !any_ok {
+            self.record(notif, DeliveryStatus::Failed, &last_err);
+        }
+        self.mark_sent(&notif.id, final_status);
+    }
+
+    fn record(&self, notif: &ScheduledNotification, status: DeliveryStatus, response: &str) {
+        self.delivery.lock().unwrap().push(DeliveryRecord {
+            notification_id: notif.id.clone(),
+            vault_id: notif.vault_id.clone(),
+            owner: notif.owner.clone(),
+            notification_type: notif.notification_type.clone(),
+            status,
+            sent_at: Utc::now(),
+            provider_response: response.to_string(),
+        });
+    }
+
+    fn mark_sent(&self, id: &str, status: DeliveryStatus) {
+        let mut store = self.schedule.lock().unwrap();
+        if let Some(n) = store.iter_mut().find(|n| n.id == id) {
+            n.status = status;
+        }
+    }
+
+    pub fn get_delivery_log(&self, owner: &str) -> Vec<DeliveryRecord> {
+        self.delivery
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|r| r.owner == owner)
+            .cloned()
+            .collect()
+    }
+}
+
+// ── Background scheduler loop ────────────────────────────────────────────────
+
+/// Spawns a tokio task that flushes pending notifications every `interval_secs`.
+pub fn start_scheduler(service: Arc<NotificationService>, interval_secs: u64) {
+    tokio::spawn(async move {
+        let interval = std::time::Duration::from_secs(interval_secs);
+        loop {
+            tokio::time::sleep(interval).await;
+            service.flush_pending().await;
+        }
+    });
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{NotificationType, VaultStatus};
+    use chrono::Utc;
+
+    fn make_service() -> NotificationService {
+        // Use a dummy FcmClient — tests that call deliver() are skipped
+        let fcm = Arc::new(FcmClient::new("test-key".into(), "test-project".into()));
+        NotificationService::new(
+            fcm,
+            create_token_store(),
+            create_prefs_store(),
+            create_schedule_store(),
+            create_delivery_store(),
+        )
+    }
+
+    fn make_vault(ttl: Option<u64>) -> Vault {
+        crate::models::Vault {
+            id: "v1".into(),
+            owner: "owner1".into(),
+            beneficiary: "ben1".into(),
+            balance: 1_000_000,
+            check_in_interval: 86_400,
+            last_check_in: Utc::now(),
+            created_at: Utc::now(),
+            status: VaultStatus::Active,
+            ttl_remaining: ttl,
+        }
+    }
+
+    // Token management
+
+    #[test]
+    fn register_token_stores_entry() {
+        let svc = make_service();
+        svc.register_token(RegisterTokenRequest {
+            owner: "owner1".into(),
+            token: "tok-abc".into(),
+            platform: "android".into(),
+        });
+        let tokens = svc.get_tokens("owner1");
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens[0].token, "tok-abc");
+    }
+
+    #[test]
+    fn register_token_deduplicates() {
+        let svc = make_service();
+        for _ in 0..3 {
+            svc.register_token(RegisterTokenRequest {
+                owner: "owner1".into(),
+                token: "tok-abc".into(),
+                platform: "ios".into(),
+            });
+        }
+        assert_eq!(svc.get_tokens("owner1").len(), 1);
+    }
+
+    #[test]
+    fn unregister_token_removes_entry() {
+        let svc = make_service();
+        svc.register_token(RegisterTokenRequest {
+            owner: "owner1".into(),
+            token: "tok-abc".into(),
+            platform: "android".into(),
+        });
+        svc.unregister_token("owner1", "tok-abc");
+        assert!(svc.get_tokens("owner1").is_empty());
+    }
+
+    // Preferences
+
+    #[test]
+    fn default_preferences_are_all_enabled() {
+        let svc = make_service();
+        let prefs = svc.get_preferences("new-owner");
+        assert!(prefs.expiry_warning_enabled);
+        assert!(prefs.check_in_reminder_enabled);
+        assert!(prefs.vault_released_enabled);
+        assert_eq!(prefs.warning_hours_before, 24);
+    }
+
+    #[test]
+    fn update_preferences_persists_changes() {
+        let svc = make_service();
+        svc.update_preferences(UpdatePreferencesRequest {
+            owner: "owner1".into(),
+            expiry_warning_enabled: Some(false),
+            check_in_reminder_enabled: None,
+            vault_released_enabled: Some(true),
+            warning_hours_before: Some(48),
+        });
+        let prefs = svc.get_preferences("owner1");
+        assert!(!prefs.expiry_warning_enabled);
+        assert!(prefs.check_in_reminder_enabled); // unchanged default
+        assert_eq!(prefs.warning_hours_before, 48);
+    }
+
+    // Scheduling
+
+    #[test]
+    fn schedule_expiry_warning_creates_pending_notification() {
+        let svc = make_service();
+        let vault = make_vault(Some(172_800)); // 48h TTL, warning at 24h → fires in 24h
+        svc.schedule_expiry_warning(&vault);
+        let pending = svc.get_pending_notifications();
+        // Not due yet (fires in 24h), so pending list is empty
+        assert!(pending.is_empty());
+        // But it IS in the schedule store
+        let all = svc.schedule.lock().unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].notification_type, NotificationType::ExpiryWarning);
+        assert_eq!(all[0].status, DeliveryStatus::Pending);
+    }
+
+    #[test]
+    fn schedule_expiry_warning_skips_when_disabled() {
+        let svc = make_service();
+        svc.update_preferences(UpdatePreferencesRequest {
+            owner: "owner1".into(),
+            expiry_warning_enabled: Some(false),
+            check_in_reminder_enabled: None,
+            vault_released_enabled: None,
+            warning_hours_before: None,
+        });
+        svc.schedule_expiry_warning(&make_vault(Some(172_800)));
+        assert!(svc.schedule.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn schedule_expiry_warning_no_duplicate() {
+        let svc = make_service();
+        let vault = make_vault(Some(172_800));
+        svc.schedule_expiry_warning(&vault);
+        svc.schedule_expiry_warning(&vault); // second call should be ignored
+        assert_eq!(svc.schedule.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn schedule_immediate_creates_due_notification() {
+        let svc = make_service();
+        svc.schedule_immediate("v1", "owner1", NotificationType::VaultReleased);
+        let pending = svc.get_pending_notifications();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].notification_type, NotificationType::VaultReleased);
+    }
+
+    #[test]
+    fn schedule_immediate_skips_when_disabled() {
+        let svc = make_service();
+        svc.update_preferences(UpdatePreferencesRequest {
+            owner: "owner1".into(),
+            expiry_warning_enabled: None,
+            check_in_reminder_enabled: None,
+            vault_released_enabled: Some(false),
+            warning_hours_before: None,
+        });
+        svc.schedule_immediate("v1", "owner1", NotificationType::VaultReleased);
+        assert!(svc.schedule.lock().unwrap().is_empty());
+    }
+
+    // Delivery tracking
+
+    #[tokio::test]
+    async fn deliver_with_no_tokens_records_failed() {
+        let svc = make_service();
+        svc.schedule_immediate("v1", "owner1", NotificationType::CheckInReminder);
+        // No tokens registered → flush should record a failure
+        svc.flush_pending().await;
+        let log = svc.get_delivery_log("owner1");
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0].status, DeliveryStatus::Failed);
+        assert_eq!(log[0].provider_response, "no_tokens_registered");
+    }
+
+    #[test]
+    fn delivery_log_filters_by_owner() {
+        let svc = make_service();
+        svc.delivery.lock().unwrap().push(DeliveryRecord {
+            notification_id: "n1".into(),
+            vault_id: "v1".into(),
+            owner: "owner1".into(),
+            notification_type: NotificationType::CheckInReminder,
+            status: DeliveryStatus::Sent,
+            sent_at: Utc::now(),
+            provider_response: "msg/123".into(),
+        });
+        svc.delivery.lock().unwrap().push(DeliveryRecord {
+            notification_id: "n2".into(),
+            vault_id: "v2".into(),
+            owner: "owner2".into(),
+            notification_type: NotificationType::VaultReleased,
+            status: DeliveryStatus::Sent,
+            sent_at: Utc::now(),
+            provider_response: "msg/456".into(),
+        });
+        assert_eq!(svc.get_delivery_log("owner1").len(), 1);
+        assert_eq!(svc.get_delivery_log("owner2").len(), 1);
+        assert!(svc.get_delivery_log("owner3").is_empty());
+    }
+
+    // Notification content
+
+    #[test]
+    fn notification_content_expiry_warning_includes_hours() {
+        let (title, body, data) =
+            notification_content(&NotificationType::ExpiryWarning, "v1", Some(6));
+        assert!(title.contains("Expiring"));
+        assert!(body.contains("6h"));
+        assert_eq!(data["vault_id"], "v1");
+    }
+
+    #[test]
+    fn notification_content_vault_released() {
+        let (title, body, data) =
+            notification_content(&NotificationType::VaultReleased, "v2", None);
+        assert!(title.contains("Released"));
+        assert!(body.contains("beneficiary"));
+        assert_eq!(data["type"], "vault_released");
+    }
+}

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -1,0 +1,108 @@
+# Push Notification Setup
+
+TTL-Legacy uses **Firebase Cloud Messaging (FCM) HTTP v1 API** to deliver push notifications to iOS, Android, and web clients.
+
+## Environment Variables
+
+Add these to your `.env` (see `.env.example`):
+
+```env
+FCM_SERVER_KEY=<OAuth2 access token or legacy server key>
+FCM_PROJECT_ID=<your-firebase-project-id>
+NOTIFICATION_SCHEDULER_INTERVAL_SECS=60
+```
+
+Get your project ID from the [Firebase Console](https://console.firebase.google.com) → Project Settings.
+
+## Notification Types
+
+| Type | Trigger | Default |
+|---|---|---|
+| `expiry_warning` | TTL drops below `warning_hours_before` | enabled, 24h |
+| `check_in_reminder` | Scheduled by owner | enabled |
+| `vault_released` | Vault released to beneficiary | enabled |
+| `vault_paused` | Vault paused | enabled |
+
+## API Endpoints
+
+### Register device token
+```
+POST /notifications/register
+{ "owner": "<stellar-address>", "token": "<fcm-token>", "platform": "ios|android|web" }
+```
+
+### Unregister device token
+```
+DELETE /notifications/register
+{ "owner": "<stellar-address>", "token": "<fcm-token>", "platform": "ios|android|web" }
+```
+
+### Get notification preferences
+```
+GET /notifications/preferences?owner=<stellar-address>
+→ { "owner": "…", "expiry_warning_enabled": true, "check_in_reminder_enabled": true,
+    "vault_released_enabled": true, "warning_hours_before": 24 }
+```
+
+### Update notification preferences
+```
+PUT /notifications/preferences
+{ "owner": "…", "expiry_warning_enabled": false, "warning_hours_before": 48 }
+```
+All fields except `owner` are optional — only provided fields are updated.
+
+### Get delivery log
+```
+GET /notifications/delivery?owner=<stellar-address>
+→ [{ "notification_id": "…", "vault_id": "…", "status": "sent|failed",
+     "sent_at": "ISO8601", "provider_response": "projects/…/messages/…" }]
+```
+
+## Scheduling
+
+The background scheduler runs every `NOTIFICATION_SCHEDULER_INTERVAL_SECS` seconds and delivers all due pending notifications.
+
+**Expiry warnings** are scheduled automatically when a vault is loaded — they fire `warning_hours_before` hours before the vault's TTL expires.
+
+**Immediate notifications** (vault released, vault paused) are scheduled at the time of the event and delivered on the next scheduler tick.
+
+## Delivery Tracking
+
+Every send attempt (success or failure) is written to the `DeliveryStore` with:
+- `status`: `sent` or `failed`
+- `provider_response`: FCM message ID on success, error string on failure
+
+Query the delivery log via `GET /notifications/delivery?owner=…`.
+
+## Client Setup
+
+### Android (FCM)
+1. Add `google-services.json` to `app/`
+2. Implement `FirebaseMessagingService.onNewToken` → call `POST /notifications/register`
+3. Handle `onMessageReceived` for foreground messages
+
+### iOS (APNs via FCM)
+1. Upload APNs key in Firebase Console → Project Settings → Cloud Messaging
+2. Call `UIApplication.registerForRemoteNotifications()` on launch
+3. In `AppDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)` → call `POST /notifications/register`
+
+## Architecture
+
+```
+VaultEvent / TTL check
+        │
+        ▼
+NotificationService.schedule_expiry_warning()
+NotificationService.schedule_immediate()
+        │
+        ▼  (every NOTIFICATION_SCHEDULER_INTERVAL_SECS)
+NotificationService.flush_pending()
+        │
+        ├─ check NotificationPreferences (skip if disabled)
+        ├─ look up DeviceTokens for owner
+        ▼
+FcmClient.send() → FCM HTTP v1 API
+        │
+        ▼
+DeliveryRecord written (sent / failed)
+```


### PR DESCRIPTION
closes #361
backend/src/notifications.rs (new):
- FcmClient: sends to FCM HTTP v1 API (bearer auth, Android/APNs config)
- NotificationService: token registration/deregistration, preferences, scheduling (expiry warnings + immediate), delivery, flush_pending()
- start_scheduler(): background tokio task, configurable interval
- 15 unit tests: token mgmt, preferences, scheduling, delivery tracking, notification content

backend/src/models.rs:
- NotificationType, DeliveryStatus, DeviceToken, NotificationPreferences, ScheduledNotification, DeliveryRecord
- RegisterTokenRequest, UpdatePreferencesRequest

backend/src/handlers.rs:
- register_push_token_handler, unregister_push_token_handler
- get_preferences_handler, update_preferences_handler
- get_delivery_log_handler
- 5 handler-level tests

backend/Cargo.toml:
- reqwest 0.12 (json + rustls-tls)

.env.example:
- FCM_SERVER_KEY, FCM_PROJECT_ID, NOTIFICATION_SCHEDULER_INTERVAL_SECS

docs/push-notifications.md:
- Full setup guide: env vars, API endpoints, client setup (iOS/Android), architecture diagram, delivery tracking