### PR TITLE
implement merge_vaults for vault consolidation

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -19,7 +19,7 @@ use types::{
     INHERITANCE_TOPIC, ADD_PASSKEY_TOPIC, REMOVE_PASSKEY_TOPIC, ROTATE_PASSKEY_TOPIC,
     BACKUP_CODE_USED_TOPIC, BACKUP_CODES_GENERATED_TOPIC, DELEGATE_BENEFICIARY_TOPIC,
     DISPUTE_FILED_TOPIC, DISPUTE_RESOLVED_TOPIC, WITHDRAWAL_SCHEDULED_TOPIC, WITHDRAWAL_EXECUTED_TOPIC,
-    CONDITIONS_ACCEPTED_TOPIC, VAULT_CLONED_TOPIC,
+    CONDITIONS_ACCEPTED_TOPIC, VAULT_CLONED_TOPIC, VAULT_MERGED_TOPIC,
 };
 
 #[cfg(test)]
@@ -3033,6 +3033,65 @@ impl TtlVaultContract {
         Self::append_activity_log(&env, new_vault_id, "clone_vault", &new_owner, "");
         env.events().publish((VAULT_CLONED_TOPIC,), (source_vault_id, new_vault_id, new_beneficiary));
         new_vault_id
+    }
+
+    /// Merges multiple source vaults into a target vault.
+    ///
+    /// All vaults must share the same owner and token_address. Source vault balances
+    /// are transferred to the target vault and sources are marked Cancelled.
+    pub fn merge_vaults(
+        env: Env,
+        target_vault_id: u64,
+        source_vault_ids: Vec<u64>,
+        caller: Address,
+    ) -> Result<(), ContractError> {
+        Self::assert_not_paused(&env);
+        caller.require_auth();
+
+        let target = Self::load_vault(&env, target_vault_id);
+        if caller != target.owner {
+            return Err(ContractError::NotOwner);
+        }
+        if target.status != ReleaseStatus::Locked {
+            return Err(ContractError::AlreadyReleased);
+        }
+
+        // Validate all sources before mutating state
+        for source_id in source_vault_ids.iter() {
+            if source_id == target_vault_id {
+                return Err(ContractError::InvalidAmount);
+            }
+            let source = Self::load_vault(&env, source_id);
+            if source.owner != target.owner {
+                return Err(ContractError::NotOwner);
+            }
+            if source.token_address != target.token_address {
+                return Err(ContractError::InvalidAmount);
+            }
+            if source.status != ReleaseStatus::Locked {
+                return Err(ContractError::AlreadyReleased);
+            }
+        }
+
+        // Apply: transfer balances and cancel sources
+        let mut target_vault = Self::load_vault(&env, target_vault_id);
+        for source_id in source_vault_ids.iter() {
+            let mut source = Self::load_vault(&env, source_id);
+            target_vault.balance = target_vault.balance
+                .checked_add(source.balance)
+                .unwrap_or_else(|| panic_with_error!(&env, ContractError::BalanceOverflow));
+            source.balance = 0;
+            source.status = ReleaseStatus::Cancelled;
+            Self::save_vault(&env, source_id, &source);
+            Self::remove_owner_vault_id(&env, &source.owner, source_id, source.check_in_interval);
+            Self::remove_beneficiary_vault_id(&env, &source.beneficiary, source_id, source.check_in_interval);
+            Self::append_activity_log(&env, source_id, "merge_vaults_source", &caller, "");
+        }
+        Self::save_vault(&env, target_vault_id, &target_vault);
+        Self::append_activity_log(&env, target_vault_id, "merge_vaults_target", &caller, "");
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((VAULT_MERGED_TOPIC,), (target_vault_id, source_vault_ids));
+        Ok(())
     }
 
     // --- Issue #386: Vault Expiry Notification Events ---

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -3125,3 +3125,84 @@ fn test_clone_vault_emits_activity_log() {
     assert!(!log.is_empty());
     assert_eq!(log.get(0).unwrap().action, String::from_str(&env, "clone_vault"));
 }
+
+// ---- Task 2: merge_vaults tests ----
+
+#[test]
+fn test_merge_vaults_transfers_balance_and_cancels_sources() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+
+    let v1 = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    let v2 = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    let target = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client.deposit(&v1, &owner, &500_000i128);
+    client.deposit(&v2, &owner, &300_000i128);
+
+    let sources = vec![&env, v1, v2];
+    client.merge_vaults(&target, &sources, &owner);
+
+    let target_vault = client.get_vault(&target);
+    assert_eq!(target_vault.balance, 800_000i128);
+
+    let s1 = client.get_vault(&v1);
+    let s2 = client.get_vault(&v2);
+    assert_eq!(s1.status, ReleaseStatus::Cancelled);
+    assert_eq!(s2.status, ReleaseStatus::Cancelled);
+    assert_eq!(s1.balance, 0);
+    assert_eq!(s2.balance, 0);
+}
+
+#[test]
+fn test_merge_vaults_different_owner_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let other = Address::generate(&env);
+    let other_beneficiary = Address::generate(&env);
+
+    StellarAssetClient::new(&env, &client.get_contract_token()).mint(&other, &1_000_000);
+
+    let v2 = client.create_vault(&other, &other_beneficiary, &3600u64, &None);
+    let target = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    let sources = vec![&env, v2];
+    let result = client.try_merge_vaults(&target, &sources, &owner);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_merge_vaults_not_owner_of_target_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let other = Address::generate(&env);
+
+    let v1 = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    let target = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    let sources = vec![&env, v1];
+    let result = client.try_merge_vaults(&target, &sources, &other);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_merge_vaults_source_equals_target_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+
+    let target = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    let sources = vec![&env, target];
+    let result = client.try_merge_vaults(&target, &sources, &owner);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_merge_vaults_emits_activity_log() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+
+    let v1 = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    let target = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    let sources = vec![&env, v1];
+    client.merge_vaults(&target, &sources, &owner);
+
+    let log = client.get_vault_activity_log(&target);
+    let actions: Vec<String> = log.iter().map(|e| e.action).collect();
+    assert!(actions.iter().any(|a| *a == String::from_str(&env, "merge_vaults_target")));
+}


### PR DESCRIPTION
 closes #445

PR description:
  
  Adds merge_vaults(env, target_vault_id, source_vault_ids, caller). Validates all source vaults share the same owner and token_address as the target
  before mutating any state. Transfers all source balances to the target vault, marks sources as Cancelled with zero balance, and removes them from
  owner/beneficiary indexes. Emits VAULT_MERGED_TOPIC with target and source IDs. Adds VAULT_MERGED_TOPIC to types.rs. Tests cover successful merge,
  different-owner rejection, non-owner caller rejection, and source-equals-target rejection.
  