### PR TITLE
Add acceptance_deadline to ConditionalAcceptanceEntry with deadline enforcement

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -19,7 +19,7 @@ use types::{
     INHERITANCE_TOPIC, ADD_PASSKEY_TOPIC, REMOVE_PASSKEY_TOPIC, ROTATE_PASSKEY_TOPIC,
     BACKUP_CODE_USED_TOPIC, BACKUP_CODES_GENERATED_TOPIC, DELEGATE_BENEFICIARY_TOPIC,
     DISPUTE_FILED_TOPIC, DISPUTE_RESOLVED_TOPIC, WITHDRAWAL_SCHEDULED_TOPIC, WITHDRAWAL_EXECUTED_TOPIC,
-    CONDITIONS_ACCEPTED_TOPIC, VAULT_CLONED_TOPIC, VAULT_MERGED_TOPIC,
+    CONDITIONS_ACCEPTED_TOPIC, VAULT_CLONED_TOPIC, VAULT_MERGED_TOPIC, ACCEPTANCE_DEADLINE_EXPIRED_TOPIC,
 };
 
 #[cfg(test)]
@@ -1034,6 +1034,25 @@ impl TtlVaultContract {
         let beneficiary_status = Self::get_beneficiary_status(env.clone(), vault_id);
         if beneficiary_status == BeneficiaryStatus::Declined {
             panic_with_error!(&env, ContractError::InvalidBeneficiary);
+        }
+
+        // Check conditional acceptance deadline
+        let now = env.ledger().timestamp();
+        if let Some(entry) = env.storage().persistent()
+            .get::<DataKey, ConditionalAcceptanceEntry>(&DataKey::ConditionalAcceptance(vault_id))
+        {
+            if let Some(deadline) = entry.acceptance_deadline {
+                if now > deadline && !entry.approved_by_owner {
+                    let token_client = token::Client::new(&env, &vault.token_address);
+                    token_client.transfer(&env.current_contract_address(), &vault.owner, &total);
+                    vault.balance = 0;
+                    vault.status = ReleaseStatus::Cancelled;
+                    Self::save_vault(&env, vault_id, &vault);
+                    env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+                    env.events().publish((ACCEPTANCE_DEADLINE_EXPIRED_TOPIC,), (vault_id, vault.owner.clone(), total));
+                    return;
+                }
+            }
         }
 
         // Check if a vesting schedule is attached
@@ -3633,6 +3652,39 @@ impl TtlVaultContract {
         env.storage()
             .persistent()
             .get::<DataKey, ConditionalAcceptanceEntry>(&DataKey::ConditionalAcceptance(vault_id))
+    }
+
+    /// Sets an acceptance deadline on the conditional acceptance entry. Owner-only.
+    ///
+    /// If the deadline passes without owner approval, trigger_release reverts funds to the owner.
+    pub fn set_acceptance_deadline(
+        env: Env,
+        vault_id: u64,
+        deadline_timestamp: u64,
+    ) -> Result<(), ContractError> {
+        Self::assert_not_paused(&env);
+        let vault = Self::load_vault(&env, vault_id);
+        vault.owner.require_auth();
+        if vault.status != ReleaseStatus::Locked {
+            return Err(ContractError::AlreadyReleased);
+        }
+
+        let key = DataKey::ConditionalAcceptance(vault_id);
+        let mut entry = env
+            .storage()
+            .persistent()
+            .get::<DataKey, ConditionalAcceptanceEntry>(&key)
+            .ok_or(ContractError::InvalidBeneficiary)?;
+
+        entry.acceptance_deadline = Some(deadline_timestamp);
+        env.storage().persistent().set(&key, &entry);
+        env.storage().persistent().extend_ttl(
+            &key,
+            VAULT_TTL_THRESHOLD,
+            vault_ttl_ledgers(vault.check_in_interval),
+        );
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        Ok(())
     }
 
     // --- Issue #399: Dispute Resolution ---

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -3206,3 +3206,74 @@ fn test_merge_vaults_emits_activity_log() {
     let actions: Vec<String> = log.iter().map(|e| e.action).collect();
     assert!(actions.iter().any(|a| *a == String::from_str(&env, "merge_vaults_target")));
 }
+
+// ---- Task 3: acceptance_deadline tests ----
+
+#[test]
+fn test_set_acceptance_deadline_expired_reverts_to_owner() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+    client.deposit(&vault_id, &owner, &500_000i128);
+
+    let conditions = String::from_str(&env, "I accept");
+    client.accept_with_conditions(&vault_id, &conditions);
+
+    // Set deadline in the past
+    let past_deadline = env.ledger().timestamp() - 1;
+    client.set_acceptance_deadline(&vault_id, &past_deadline);
+
+    // Advance time past check_in_interval to expire vault
+    env.ledger().with_mut(|l| l.timestamp += 200);
+
+    client.trigger_release(&vault_id);
+
+    let vault = client.get_vault(&vault_id);
+    assert_eq!(vault.status, ReleaseStatus::Cancelled);
+    assert_eq!(vault.balance, 0);
+}
+
+#[test]
+fn test_set_acceptance_deadline_approved_releases_normally() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+    client.deposit(&vault_id, &owner, &500_000i128);
+
+    let conditions = String::from_str(&env, "I accept");
+    client.accept_with_conditions(&vault_id, &conditions);
+    client.approve_conditional_acceptance(&vault_id);
+
+    let future_deadline = env.ledger().timestamp() + 10_000;
+    client.set_acceptance_deadline(&vault_id, &future_deadline);
+
+    env.ledger().with_mut(|l| l.timestamp += 200);
+
+    client.trigger_release(&vault_id);
+    let vault = client.get_vault(&vault_id);
+    assert_eq!(vault.status, ReleaseStatus::Released);
+}
+
+#[test]
+fn test_set_acceptance_deadline_no_entry_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+    let result = client.try_set_acceptance_deadline(&vault_id, &(env.ledger().timestamp() + 1000));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_set_acceptance_deadline_released_vault_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+    client.deposit(&vault_id, &owner, &100_000i128);
+
+    let conditions = String::from_str(&env, "conditions");
+    client.accept_with_conditions(&vault_id, &conditions);
+
+    env.ledger().with_mut(|l| l.timestamp += 200);
+    client.trigger_release(&vault_id);
+
+    let result = client.try_set_acceptance_deadline(&vault_id, &(env.ledger().timestamp() + 1000));
+    assert!(result.is_err());
+}


### PR DESCRIPTION
closes #446
  
  PR description:
  
  Adds acceptance_deadline: Option<u64> to ConditionalAcceptanceEntry. Implements set_acceptance_deadline(env, vault_id, deadline_timestamp) (owner-only,
  requires an existing ConditionalAcceptanceEntry). Updates trigger_release to check the deadline: if the current time exceeds the deadline and the owner
  has not approved, funds are returned to the owner and the vault is marked Cancelled instead of releasing to the beneficiary. Emits
  ACCEPTANCE_DEADLINE_EXPIRED_TOPIC. Tests cover deadline-expired reversion, approved-before-deadline normal release, and missing-entry failure.
  