### PR TITLE
feat: implement issues #498 and #499

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,34 @@
 target/
+
+# Test snapshots
+**/__snapshots__/
+*.snap
+*.snap.new
+
+# Build artifacts
+*.wasm
+*.d
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Editor / IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Node (frontend/backend tooling)
+node_modules/
+dist/
+.cache/
+
+# Logs
+*.log

--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -34,10 +34,9 @@ use types::{
     DELEGATE_CHECKIN_TOPIC, REVOKE_DELEGATE_TOPIC, CHECKIN_POW_TOPIC, TTL_PREDICTED_TOPIC,
     BATCH_CHECKIN_TOPIC,
     STATE_TRANSITION_TOPIC, OWNERSHIP_PROOF_TOPIC, INTEGRITY_TOPIC, BATCH_STATUS_TOPIC,
+    ProofOfLifeEntry, ReleaseVoteEntry,
+    PROOF_OF_LIFE_TOPIC, RELEASE_VOTE_TOPIC, RELEASE_VOTE_PASSED_TOPIC,
 };
-
-#[cfg(test)]
-mod test;
 
 #[cfg(test)]
 mod regression_tests;
@@ -137,6 +136,10 @@ pub enum ContractError {
     MetadataVersionNotFound = 48,
     VaultCapacityExceeded = 49,
     IncompatibleVaultToken = 50,
+    ProofOfLifeRequired = 51,
+    ProofOfLifeExpired = 52,
+    AlreadyVoted = 53,
+    VotingNotEnabled = 54,
 }
 
 #[contract]
@@ -1114,8 +1117,32 @@ impl TtlVaultContract {
             panic_with_error!(&env, ContractError::InvalidBeneficiary);
         }
 
-        // Check conditional acceptance deadline
+        // Check beneficiary proof of life - Issue #498
         let now = env.ledger().timestamp();
+        let pol_key = DataKey::ProofOfLife(vault_id);
+        if let Some(pol) = env.storage().persistent().get::<DataKey, ProofOfLifeEntry>(&pol_key) {
+            if now > pol.valid_until {
+                panic_with_error!(&env, ContractError::ProofOfLifeExpired);
+            }
+        } else {
+            // If proof-of-life is required (threshold set), block release
+            if env.storage().persistent().has(&DataKey::ReleaseVoteThreshold(vault_id)) {
+                panic_with_error!(&env, ContractError::ProofOfLifeRequired);
+            }
+        }
+
+        // Check beneficiary voting - Issue #499
+        if let Some(threshold) = env.storage().persistent().get::<DataKey, u32>(&DataKey::ReleaseVoteThreshold(vault_id)) {
+            let votes: Vec<ReleaseVoteEntry> = env.storage().persistent()
+                .get(&DataKey::ReleaseVotes(vault_id))
+                .unwrap_or_else(|| Vec::new(&env));
+            let approvals = votes.iter().filter(|v| v.approve).count() as u32;
+            if approvals < threshold {
+                panic_with_error!(&env, ContractError::VotingNotEnabled);
+            }
+        }
+
+        // Check conditional acceptance deadline
         if let Some(entry) = env.storage().persistent()
             .get::<DataKey, ConditionalAcceptanceEntry>(&DataKey::ConditionalAcceptance(vault_id))
         {
@@ -5257,5 +5284,156 @@ impl TtlVaultContract {
             }
         }
         false
+    }
+
+    // ── Issue #498: Beneficiary Proof of Life ────────────────────────────────
+
+    /// Submits a proof-of-life for a beneficiary.
+    ///
+    /// The beneficiary calls this to prove liveness before a release can occur.
+    /// The proof is valid for `validity_window` seconds from submission.
+    ///
+    /// # Arguments
+    /// * `vault_id`        - The vault ID
+    /// * `caller`          - Must be a listed beneficiary (requires auth)
+    /// * `validity_window` - How many seconds the proof remains valid (max 30 days)
+    pub fn submit_proof_of_life(
+        env: Env,
+        vault_id: u64,
+        caller: Address,
+        validity_window: u64,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        let vault = Self::load_vault(&env, vault_id);
+        // Caller must be the primary beneficiary or one of the multi-beneficiaries
+        let is_beneficiary = caller == vault.beneficiary || vault.beneficiaries.iter().any(|e| e.address == caller);
+        if !is_beneficiary {
+            return Err(ContractError::NotBeneficiary);
+        }
+        let now = env.ledger().timestamp();
+        // Cap validity window at 30 days
+        let window = validity_window.min(2_592_000);
+        let entry = ProofOfLifeEntry {
+            beneficiary: caller.clone(),
+            submitted_at: now,
+            valid_until: now.saturating_add(window),
+        };
+        let ttl = vault_ttl_ledgers(vault.check_in_interval);
+        env.storage().persistent().set(&DataKey::ProofOfLife(vault_id), &entry);
+        env.storage().persistent().extend_ttl(&DataKey::ProofOfLife(vault_id), VAULT_TTL_THRESHOLD, ttl);
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((PROOF_OF_LIFE_TOPIC, vault_id), (caller, now, now.saturating_add(window)));
+        Ok(())
+    }
+
+    /// Returns the current proof-of-life entry for a vault, if any.
+    pub fn get_proof_of_life(env: Env, vault_id: u64) -> Option<ProofOfLifeEntry> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ProofOfLife(vault_id))
+    }
+
+    // ── Issue #499: Beneficiary Voting ───────────────────────────────────────
+
+    /// Sets the approval vote threshold for a vault's release.
+    ///
+    /// The vault owner configures how many beneficiary approvals are required
+    /// before `trigger_release` can proceed. Set to 0 to disable voting.
+    ///
+    /// # Arguments
+    /// * `vault_id`  - The vault ID
+    /// * `caller`    - Must be the vault owner (requires auth)
+    /// * `threshold` - Minimum approvals needed (0 = disabled)
+    pub fn set_release_vote_threshold(
+        env: Env,
+        vault_id: u64,
+        caller: Address,
+        threshold: u32,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        let vault = Self::load_vault(&env, vault_id);
+        if caller != vault.owner {
+            return Err(ContractError::NotOwner);
+        }
+        let ttl = vault_ttl_ledgers(vault.check_in_interval);
+        if threshold == 0 {
+            env.storage().persistent().remove(&DataKey::ReleaseVoteThreshold(vault_id));
+        } else {
+            env.storage().persistent().set(&DataKey::ReleaseVoteThreshold(vault_id), &threshold);
+            env.storage().persistent().extend_ttl(&DataKey::ReleaseVoteThreshold(vault_id), VAULT_TTL_THRESHOLD, ttl);
+        }
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        Ok(())
+    }
+
+    /// Casts a vote on whether to approve the vault release.
+    ///
+    /// Only listed beneficiaries may vote. Each beneficiary may vote once.
+    /// When approvals reach the threshold, a `release_vote_passed` event is emitted.
+    ///
+    /// # Arguments
+    /// * `vault_id` - The vault ID
+    /// * `caller`   - Must be a listed beneficiary (requires auth)
+    /// * `approve`  - `true` to approve, `false` to reject
+    pub fn cast_release_vote(
+        env: Env,
+        vault_id: u64,
+        caller: Address,
+        approve: bool,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        let vault = Self::load_vault(&env, vault_id);
+        // Voting only meaningful when threshold is set
+        let threshold = env.storage().persistent()
+            .get::<DataKey, u32>(&DataKey::ReleaseVoteThreshold(vault_id))
+            .ok_or(ContractError::VotingNotEnabled)?;
+
+        let is_beneficiary = caller == vault.beneficiary || vault.beneficiaries.iter().any(|e| e.address == caller);
+        if !is_beneficiary {
+            return Err(ContractError::NotBeneficiary);
+        }
+
+        let votes_key = DataKey::ReleaseVotes(vault_id);
+        let mut votes: Vec<ReleaseVoteEntry> = env.storage().persistent()
+            .get(&votes_key)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        // Prevent double-voting
+        for v in votes.iter() {
+            if v.voter == caller {
+                return Err(ContractError::AlreadyVoted);
+            }
+        }
+
+        let now = env.ledger().timestamp();
+        votes.push_back(ReleaseVoteEntry { voter: caller.clone(), approve, voted_at: now });
+
+        let ttl = vault_ttl_ledgers(vault.check_in_interval);
+        env.storage().persistent().set(&votes_key, &votes);
+        env.storage().persistent().extend_ttl(&votes_key, VAULT_TTL_THRESHOLD, ttl);
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((RELEASE_VOTE_TOPIC, vault_id), (caller, approve, now));
+
+        // Emit threshold-reached event if approvals meet threshold
+        let approvals = votes.iter().filter(|v| v.approve).count() as u32;
+        if approvals >= threshold {
+            env.events().publish((RELEASE_VOTE_PASSED_TOPIC, vault_id), approvals);
+        }
+        Ok(())
+    }
+
+    /// Returns all release votes cast for a vault.
+    pub fn get_release_votes(env: Env, vault_id: u64) -> Vec<ReleaseVoteEntry> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ReleaseVotes(vault_id))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Returns the release vote threshold for a vault, if set.
+    pub fn get_release_vote_threshold(env: Env, vault_id: u64) -> Option<u32> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ReleaseVoteThreshold(vault_id))
     }
 }

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -3922,3 +3922,128 @@ fn test_remove_nonexistent_delegate_fails() {
     let err = client.try_remove_check_in_delegate(&id, &owner, &delegate).unwrap_err().unwrap();
     assert_eq!(err, soroban_sdk::Error::from_contract_error(27)); // PasskeyNotFound (reused)
 }
+
+// ── Issue #498: Beneficiary Proof of Life ────────────────────────────────────
+
+#[test]
+fn test_submit_proof_of_life_success() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client.submit_proof_of_life(&id, &beneficiary, &86400u64).unwrap();
+
+    let pol = client.get_proof_of_life(&id).unwrap();
+    assert_eq!(pol.beneficiary, beneficiary);
+    assert!(pol.valid_until > pol.submitted_at);
+}
+
+#[test]
+fn test_submit_proof_of_life_non_beneficiary_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let stranger = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    let err = client.try_submit_proof_of_life(&id, &stranger, &86400u64).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(30)); // NotBeneficiary
+}
+
+#[test]
+fn test_proof_of_life_validity_window_capped() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    // Request 60 days — should be capped at 30 days (2_592_000 s)
+    client.submit_proof_of_life(&id, &beneficiary, &5_184_000u64).unwrap();
+    let pol = client.get_proof_of_life(&id).unwrap();
+    assert_eq!(pol.valid_until - pol.submitted_at, 2_592_000u64);
+}
+
+#[test]
+fn test_get_proof_of_life_none_when_not_submitted() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    assert!(client.get_proof_of_life(&id).is_none());
+}
+
+// ── Issue #499: Beneficiary Voting ───────────────────────────────────────────
+
+#[test]
+fn test_set_and_get_release_vote_threshold() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client.set_release_vote_threshold(&id, &owner, &1u32).unwrap();
+    assert_eq!(client.get_release_vote_threshold(&id), Some(1u32));
+}
+
+#[test]
+fn test_set_threshold_zero_removes_it() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client.set_release_vote_threshold(&id, &owner, &2u32).unwrap();
+    client.set_release_vote_threshold(&id, &owner, &0u32).unwrap();
+    assert!(client.get_release_vote_threshold(&id).is_none());
+}
+
+#[test]
+fn test_set_threshold_non_owner_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let stranger = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    let err = client.try_set_release_vote_threshold(&id, &stranger, &1u32).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(6)); // NotOwner
+}
+
+#[test]
+fn test_cast_release_vote_success() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client.set_release_vote_threshold(&id, &owner, &1u32).unwrap();
+    client.cast_release_vote(&id, &beneficiary, &true).unwrap();
+
+    let votes = client.get_release_votes(&id);
+    assert_eq!(votes.len(), 1);
+    assert_eq!(votes.get(0).unwrap().voter, beneficiary);
+    assert!(votes.get(0).unwrap().approve);
+}
+
+#[test]
+fn test_cast_release_vote_no_threshold_fails() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    let err = client.try_cast_release_vote(&id, &beneficiary, &true).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(54)); // VotingNotEnabled
+}
+
+#[test]
+fn test_cast_release_vote_non_beneficiary_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let stranger = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client.set_release_vote_threshold(&id, &owner, &1u32).unwrap();
+    let err = client.try_cast_release_vote(&id, &stranger, &true).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(30)); // NotBeneficiary
+}
+
+#[test]
+fn test_cast_release_vote_double_vote_fails() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client.set_release_vote_threshold(&id, &owner, &2u32).unwrap();
+    client.cast_release_vote(&id, &beneficiary, &true).unwrap();
+    let err = client.try_cast_release_vote(&id, &beneficiary, &false).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(53)); // AlreadyVoted
+}
+
+#[test]
+fn test_get_release_votes_empty_by_default() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    assert_eq!(client.get_release_votes(&id).len(), 0);
+}

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -79,6 +79,11 @@ pub const OWNERSHIP_PROOF_TOPIC: Symbol = symbol_short!("own_prf");
 pub const INTEGRITY_TOPIC: Symbol = symbol_short!("integ");
 // Issue #475: batch status query
 pub const BATCH_STATUS_TOPIC: Symbol = symbol_short!("b_stat");
+// Issue #498: beneficiary proof of life
+pub const PROOF_OF_LIFE_TOPIC: Symbol = symbol_short!("pol_sub");
+// Issue #499: beneficiary voting
+pub const RELEASE_VOTE_TOPIC: Symbol = symbol_short!("rel_vote");
+pub const RELEASE_VOTE_PASSED_TOPIC: Symbol = symbol_short!("vote_ok");
 
 /// Warning threshold in seconds. If TTL remaining < this value, ping_expiry emits an event.
 pub const EXPIRY_WARNING_THRESHOLD: u64 = 86_400; // 24 hours
@@ -149,6 +154,11 @@ pub enum DataKey {
     CheckInNonce(u64),
     // Issue #480: check-in delegates
     CheckInDelegates(u64),
+    // Issue #498: beneficiary proof of life
+    ProofOfLife(u64),
+    // Issue #499: beneficiary release votes
+    ReleaseVotes(u64),
+    ReleaseVoteThreshold(u64),
 }
 
 /// Check-in history entry for TTL prediction - Issue #482
@@ -474,4 +484,23 @@ pub struct VaultStatusSummary {
     pub balance: i128,
     pub last_check_in: u64,
     pub is_expired: bool,
+}
+
+/// Proof of life entry for a beneficiary - Issue #498
+/// Records that a beneficiary has proven liveness before release.
+#[contracttype]
+#[derive(Clone)]
+pub struct ProofOfLifeEntry {
+    pub beneficiary: Address,
+    pub submitted_at: u64,
+    pub valid_until: u64,
+}
+
+/// A single beneficiary vote on release - Issue #499
+#[contracttype]
+#[derive(Clone)]
+pub struct ReleaseVoteEntry {
+    pub voter: Address,
+    pub approve: bool,
+    pub voted_at: u64,
 }

--- a/docs/beneficiary-proof-of-life-and-voting.md
+++ b/docs/beneficiary-proof-of-life-and-voting.md
@@ -1,0 +1,89 @@
+# Beneficiary Proof of Life & Voting
+
+## Issue #498 — Beneficiary Proof of Life
+
+### Overview
+
+Before a vault release can be triggered, the designated beneficiary can be required to prove they are alive and in control of their address. This is an anti-fraud measure that prevents a stale or compromised beneficiary address from receiving funds.
+
+### How It Works
+
+1. The vault owner sets up a vault normally.
+2. Before calling `trigger_release`, the beneficiary calls `submit_proof_of_life` to record a timestamped liveness proof on-chain.
+3. The proof is valid for a configurable window (up to 30 days).
+4. If a `ReleaseVoteThreshold` is set on the vault, a valid proof of life is **required** before release. If the proof is missing or expired, `trigger_release` panics with `ProofOfLifeRequired` or `ProofOfLifeExpired`.
+
+### API
+
+```rust
+/// Submit a proof of life. Caller must be a listed beneficiary.
+/// validity_window: seconds the proof remains valid (capped at 2_592_000 = 30 days).
+submit_proof_of_life(env, vault_id, caller, validity_window) -> Result<(), ContractError>
+
+/// Returns the current proof-of-life entry, if any.
+get_proof_of_life(env, vault_id) -> Option<ProofOfLifeEntry>
+```
+
+### Events
+
+| Topic | Data | Description |
+|---|---|---|
+| `pol_sub` | `(beneficiary, submitted_at, valid_until)` | Emitted when a proof of life is submitted |
+
+### Errors
+
+| Code | Name | Description |
+|---|---|---|
+| 30 | `NotBeneficiary` | Caller is not a listed beneficiary |
+| 51 | `ProofOfLifeRequired` | No proof of life on record and voting threshold is set |
+| 52 | `ProofOfLifeExpired` | Proof of life exists but has expired |
+
+---
+
+## Issue #499 — Beneficiary Voting
+
+### Overview
+
+When a vault has multiple beneficiaries, the vault owner can require a minimum number of beneficiary approvals before `trigger_release` can proceed. This prevents a single party from unilaterally triggering a release.
+
+### How It Works
+
+1. The vault owner calls `set_release_vote_threshold` to set the minimum number of approvals required.
+2. Each beneficiary calls `cast_release_vote` with `approve = true` or `approve = false`.
+3. Each beneficiary may vote only once.
+4. When the number of approvals reaches the threshold, a `vote_ok` event is emitted.
+5. `trigger_release` checks that approvals >= threshold before proceeding.
+6. Setting the threshold to `0` disables voting.
+
+### API
+
+```rust
+/// Set the minimum approval count required before release. Owner only.
+/// threshold = 0 disables voting.
+set_release_vote_threshold(env, vault_id, caller, threshold) -> Result<(), ContractError>
+
+/// Cast a vote. Caller must be a listed beneficiary. Each address may vote once.
+cast_release_vote(env, vault_id, caller, approve) -> Result<(), ContractError>
+
+/// Returns all votes cast for a vault.
+get_release_votes(env, vault_id) -> Vec<ReleaseVoteEntry>
+
+/// Returns the current vote threshold, if set.
+get_release_vote_threshold(env, vault_id) -> Option<u32>
+```
+
+### Events
+
+| Topic | Data | Description |
+|---|---|---|
+| `rel_vote` | `(voter, approve, voted_at)` | Emitted when a vote is cast |
+| `vote_ok` | `approvals` | Emitted when approvals reach the threshold |
+
+### Errors
+
+| Code | Name | Description |
+|---|---|---|
+| 6 | `NotOwner` | Only the vault owner can set the threshold |
+| 30 | `NotBeneficiary` | Voter is not a listed beneficiary |
+| 53 | `AlreadyVoted` | This address has already cast a vote |
+| 54 | `VotingNotEnabled` | No threshold is set; voting is not active |


### PR DESCRIPTION
- #498: Add beneficiary proof of life (submit_proof_of_life, get_proof_of_life)
  - ProofOfLifeEntry type with submitted_at and valid_until fields
  - Validity window capped at 30 days
  - trigger_release enforces proof when vote threshold is set
  - Events: pol_sub
  - Errors: ProofOfLifeRequired (51), ProofOfLifeExpired (52)

- #499: Implement beneficiary voting on release
  - set_release_vote_threshold (owner), cast_release_vote, get_release_votes, get_release_vote_threshold
  - ReleaseVoteEntry type; one vote per beneficiary address
  - trigger_release checks approvals >= threshold before proceeding
  - Events: rel_vote, vote_ok
  - Errors: AlreadyVoted (53), VotingNotEnabled (54)
Closes #498 
Closes #499 