### PR TITLE
feat: vault hibernation — temporary check-in suspension

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The script will display the target network and identity, then require you to typ
 
 - [Architecture Overview](docs/architecture.md)
 - [TTL & State Archival Logic](docs/ttl-logic.md)
+- [Vault Hibernation](docs/hibernation.md)
 - [Passkey Integration](docs/passkeys.md)
 - [Threat Model & Security](docs/security.md)
 - [Security Policy & Vulnerability Disclosure](SECURITY.md)
@@ -156,6 +157,14 @@ update_beneficiary(vault_id: u64, new_beneficiary: Address)
 trigger_release(vault_id: u64)
 is_expired(vault_id: u64) -> bool
 get_release_status(vault_id: u64) -> ReleaseStatus
+```
+
+### Hibernation
+
+```rust
+enter_hibernation(vault_id: u64, caller: Address, duration_seconds: u64)
+exit_hibernation(vault_id: u64, caller: Address)
+get_hibernation(vault_id: u64) -> Option<HibernationEntry>
 ```
 
 ## 🧪 Testing

--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -38,6 +38,8 @@ use types::{
     STATE_TRANSITION_TOPIC, OWNERSHIP_PROOF_TOPIC, INTEGRITY_TOPIC, BATCH_STATUS_TOPIC,
     ProofOfLifeEntry, ReleaseVoteEntry,
     PROOF_OF_LIFE_TOPIC, RELEASE_VOTE_TOPIC, RELEASE_VOTE_PASSED_TOPIC,
+    HibernationEntry,
+    HIBERNATION_ENTERED_TOPIC, HIBERNATION_EXITED_TOPIC,
 };
 
 #[cfg(test)]
@@ -148,6 +150,8 @@ pub enum ContractError {
     ProofOfLifeExpired = 52,
     AlreadyVoted = 53,
     VotingNotEnabled = 54,
+    AlreadyHibernating = 55,
+    NotHibernating = 56,
 }
 
 #[contract]
@@ -2023,7 +2027,20 @@ impl TtlVaultContract {
     pub fn is_expired(env: Env, vault_id: u64) -> bool {
         let vault = Self::load_vault(&env, vault_id);
         let now = env.ledger().timestamp();
-        now >= vault.last_check_in + vault.check_in_interval
+        // Compute how many seconds of hibernation have elapsed (capped at duration).
+        let hibernated = if let Some(h) = env.storage().persistent()
+            .get::<DataKey, HibernationEntry>(&DataKey::Hibernation(vault_id))
+        {
+            let elapsed = now.saturating_sub(h.started_at).min(h.duration_seconds);
+            // If still inside the hibernation window, vault cannot expire.
+            if elapsed < h.duration_seconds {
+                return false;
+            }
+            h.duration_seconds
+        } else {
+            0u64
+        };
+        now >= vault.last_check_in + vault.check_in_interval + hibernated
     }
 
     /// Retrieves a vault by its unique identifier.
@@ -5837,5 +5854,109 @@ impl TtlVaultContract {
         env.storage()
             .persistent()
             .get(&DataKey::ReleaseVoteThreshold(vault_id))
+    }
+
+    // ── Hibernation ──────────────────────────────────────────────────────────
+
+    /// Puts a vault into hibernation for `duration_seconds`.
+    ///
+    /// During hibernation the owner is not required to check in — the vault's
+    /// expiry deadline is extended by the full hibernation duration, so
+    /// `is_expired` returns `false` until the hibernation window closes.
+    /// Normal operations (deposit, withdraw, check_in) remain available.
+    ///
+    /// # Arguments
+    /// * `vault_id`         - The vault to hibernate
+    /// * `caller`           - Must be the vault owner
+    /// * `duration_seconds` - How long (in seconds) the hibernation lasts (> 0)
+    ///
+    /// # Errors
+    /// * `ContractError::NotOwner`          - Caller is not the vault owner
+    /// * `ContractError::AlreadyReleased`   - Vault is not Locked
+    /// * `ContractError::AlreadyHibernating`- Vault is already hibernating
+    /// * `ContractError::InvalidInterval`   - `duration_seconds` is zero
+    pub fn enter_hibernation(
+        env: Env,
+        vault_id: u64,
+        caller: Address,
+        duration_seconds: u64,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        if duration_seconds == 0 {
+            return Err(ContractError::InvalidInterval);
+        }
+        let vault = Self::load_vault(&env, vault_id);
+        if caller != vault.owner {
+            return Err(ContractError::NotOwner);
+        }
+        if vault.status != ReleaseStatus::Locked {
+            return Err(ContractError::AlreadyReleased);
+        }
+        let hib_key = DataKey::Hibernation(vault_id);
+        if env.storage().persistent().has(&hib_key) {
+            return Err(ContractError::AlreadyHibernating);
+        }
+        let now = env.ledger().timestamp();
+        let entry = HibernationEntry { started_at: now, duration_seconds };
+        let ttl = vault_ttl_ledgers(vault.check_in_interval + duration_seconds);
+        env.storage().persistent().set(&hib_key, &entry);
+        env.storage().persistent().extend_ttl(&hib_key, VAULT_TTL_THRESHOLD, ttl);
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish(
+            (HIBERNATION_ENTERED_TOPIC, vault_id),
+            (caller, now, duration_seconds),
+        );
+        Ok(())
+    }
+
+    /// Exits hibernation early, resuming normal check-in requirements.
+    ///
+    /// The elapsed hibernation time is credited to the vault's `last_check_in`
+    /// so the remaining TTL countdown picks up from where it left off.
+    ///
+    /// # Arguments
+    /// * `vault_id` - The vault to wake from hibernation
+    /// * `caller`   - Must be the vault owner
+    ///
+    /// # Errors
+    /// * `ContractError::NotOwner`        - Caller is not the vault owner
+    /// * `ContractError::AlreadyReleased` - Vault is not Locked
+    /// * `ContractError::NotHibernating`  - Vault is not currently hibernating
+    pub fn exit_hibernation(
+        env: Env,
+        vault_id: u64,
+        caller: Address,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        let mut vault = Self::load_vault(&env, vault_id);
+        if caller != vault.owner {
+            return Err(ContractError::NotOwner);
+        }
+        if vault.status != ReleaseStatus::Locked {
+            return Err(ContractError::AlreadyReleased);
+        }
+        let hib_key = DataKey::Hibernation(vault_id);
+        let entry = env.storage().persistent()
+            .get::<DataKey, HibernationEntry>(&hib_key)
+            .ok_or(ContractError::NotHibernating)?;
+        let now = env.ledger().timestamp();
+        // Credit elapsed hibernation time so the TTL countdown resumes correctly.
+        let elapsed = now.saturating_sub(entry.started_at).min(entry.duration_seconds);
+        vault.last_check_in = vault.last_check_in.saturating_add(elapsed);
+        env.storage().persistent().remove(&hib_key);
+        Self::save_vault(&env, vault_id, &vault);
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish(
+            (HIBERNATION_EXITED_TOPIC, vault_id),
+            (caller, now, elapsed),
+        );
+        Ok(())
+    }
+
+    /// Returns the current hibernation entry for a vault, if it is hibernating.
+    pub fn get_hibernation(env: Env, vault_id: u64) -> Option<HibernationEntry> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Hibernation(vault_id))
     }
 }

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -4082,3 +4082,179 @@ fn test_get_release_votes_empty_by_default() {
     let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
     assert_eq!(client.get_release_votes(&id).len(), 0);
 }
+
+// ── Hibernation ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_enter_hibernation_success() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client.enter_hibernation(&id, &owner, &7200u64).unwrap();
+
+    let h = client.get_hibernation(&id).unwrap();
+    assert_eq!(h.duration_seconds, 7200u64);
+}
+
+#[test]
+fn test_enter_hibernation_non_owner_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let stranger = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    let err = client.try_enter_hibernation(&id, &stranger, &3600u64).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(6)); // NotOwner
+}
+
+#[test]
+fn test_enter_hibernation_zero_duration_fails() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    let err = client.try_enter_hibernation(&id, &owner, &0u64).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(2)); // InvalidInterval
+}
+
+#[test]
+fn test_enter_hibernation_already_hibernating_fails() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client.enter_hibernation(&id, &owner, &3600u64).unwrap();
+    let err = client.try_enter_hibernation(&id, &owner, &3600u64).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(55)); // AlreadyHibernating
+}
+
+#[test]
+fn test_vault_not_expired_during_hibernation() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let interval = 3600u64;
+    let id = client.create_vault(&owner, &beneficiary, &interval, &None);
+
+    client.enter_hibernation(&id, &owner, &7200u64).unwrap();
+
+    // Advance past the normal check-in interval — vault should NOT be expired
+    env.ledger().with_mut(|l| l.timestamp += interval + 1);
+    assert!(!client.is_expired(&id));
+}
+
+#[test]
+fn test_vault_expires_after_hibernation_window_closes() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let interval = 3600u64;
+    let hibernation = 7200u64;
+    let id = client.create_vault(&owner, &beneficiary, &interval, &None);
+
+    client.enter_hibernation(&id, &owner, &hibernation).unwrap();
+
+    // Advance past interval + hibernation — vault should now be expired
+    env.ledger().with_mut(|l| l.timestamp += interval + hibernation + 1);
+    assert!(client.is_expired(&id));
+}
+
+#[test]
+fn test_exit_hibernation_success() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client.enter_hibernation(&id, &owner, &7200u64).unwrap();
+    env.ledger().with_mut(|l| l.timestamp += 1000);
+    client.exit_hibernation(&id, &owner).unwrap();
+
+    // Hibernation entry should be gone
+    assert!(client.get_hibernation(&id).is_none());
+}
+
+#[test]
+fn test_exit_hibernation_non_owner_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let stranger = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client.enter_hibernation(&id, &owner, &7200u64).unwrap();
+    let err = client.try_exit_hibernation(&id, &stranger).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(6)); // NotOwner
+}
+
+#[test]
+fn test_exit_hibernation_not_hibernating_fails() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    let err = client.try_exit_hibernation(&id, &owner).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(56)); // NotHibernating
+}
+
+#[test]
+fn test_exit_hibernation_credits_elapsed_time() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let interval = 3600u64;
+    let id = client.create_vault(&owner, &beneficiary, &interval, &None);
+    let before = client.get_vault(&id).last_check_in;
+
+    client.enter_hibernation(&id, &owner, &7200u64).unwrap();
+    let elapsed = 1000u64;
+    env.ledger().with_mut(|l| l.timestamp += elapsed);
+    client.exit_hibernation(&id, &owner).unwrap();
+
+    let after = client.get_vault(&id).last_check_in;
+    assert_eq!(after, before + elapsed);
+}
+
+#[test]
+fn test_vault_not_expired_after_early_exit_within_interval() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let interval = 3600u64;
+    let id = client.create_vault(&owner, &beneficiary, &interval, &None);
+
+    client.enter_hibernation(&id, &owner, &7200u64).unwrap();
+    // Exit after 1000 s — last_check_in bumped by 1000
+    env.ledger().with_mut(|l| l.timestamp += 1000);
+    client.exit_hibernation(&id, &owner).unwrap();
+
+    // Total elapsed from original last_check_in = 1000 s, interval = 3600 s → not expired
+    assert!(!client.is_expired(&id));
+}
+
+#[test]
+fn test_hibernation_emits_entered_event() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client.enter_hibernation(&id, &owner, &7200u64).unwrap();
+
+    let events = env.events().all();
+    let found = events.iter().any(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.0.try_into_val(&env).unwrap_or_else(|_| soroban_sdk::Vec::new(&env));
+        if topics.is_empty() { return false; }
+        let first: Result<soroban_sdk::Symbol, _> = topics.get(0).unwrap().try_into_val(&env);
+        first.map(|s| s == soroban_sdk::Symbol::new(&env, "hib_ent")).unwrap_or(false)
+    });
+    assert!(found, "hibernation_entered event not emitted");
+}
+
+#[test]
+fn test_hibernation_emits_exited_event() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client.enter_hibernation(&id, &owner, &7200u64).unwrap();
+    env.ledger().with_mut(|l| l.timestamp += 500);
+    client.exit_hibernation(&id, &owner).unwrap();
+
+    let events = env.events().all();
+    let found = events.iter().any(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.0.try_into_val(&env).unwrap_or_else(|_| soroban_sdk::Vec::new(&env));
+        if topics.is_empty() { return false; }
+        let first: Result<soroban_sdk::Symbol, _> = topics.get(0).unwrap().try_into_val(&env);
+        first.map(|s| s == soroban_sdk::Symbol::new(&env, "hib_ext")).unwrap_or(false)
+    });
+    assert!(found, "hibernation_exited event not emitted");
+}
+
+#[test]
+fn test_get_hibernation_returns_none_when_not_hibernating() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    assert!(client.get_hibernation(&id).is_none());
+}

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -84,6 +84,9 @@ pub const PROOF_OF_LIFE_TOPIC: Symbol = symbol_short!("pol_sub");
 // Issue #499: beneficiary voting
 pub const RELEASE_VOTE_TOPIC: Symbol = symbol_short!("rel_vote");
 pub const RELEASE_VOTE_PASSED_TOPIC: Symbol = symbol_short!("vote_ok");
+// Hibernation events
+pub const HIBERNATION_ENTERED_TOPIC: Symbol = symbol_short!("hib_ent");
+pub const HIBERNATION_EXITED_TOPIC: Symbol = symbol_short!("hib_ext");
 
 // Previously missing — used by lib.rs internal helpers
 pub const STATE_TRANSITION_TOPIC: Symbol = symbol_short!("st_trans");
@@ -180,6 +183,8 @@ pub enum DataKey {
     // Issue #499: beneficiary release votes
     ReleaseVotes(u64),
     ReleaseVoteThreshold(u64),
+    // Hibernation: temporary suspension of check-in requirement
+    Hibernation(u64),
 }
 
 /// Check-in history entry for TTL prediction - Issue #482
@@ -536,4 +541,16 @@ pub struct TtlPool {
 pub struct BiometricEntry {
     pub credential_hash: BytesN<32>,
     pub added_at: u64,
+}
+
+/// Hibernation entry — records when a vault entered hibernation and for how long.
+/// While hibernating, the vault's expiry deadline is extended by `duration_seconds`,
+/// so no check-ins are required during that period.
+#[contracttype]
+#[derive(Clone)]
+pub struct HibernationEntry {
+    /// Ledger timestamp when hibernation started.
+    pub started_at: u64,
+    /// How many seconds the hibernation lasts.
+    pub duration_seconds: u64,
 }

--- a/docs/hibernation.md
+++ b/docs/hibernation.md
@@ -1,0 +1,97 @@
+# Vault Hibernation
+
+## Overview
+
+Hibernation lets a vault owner temporarily suspend the check-in requirement for a fixed period, then resume normal operation automatically. This is useful for planned absences (travel, medical leave, etc.) where the owner knows they will be unavailable but does not want the vault to expire.
+
+## How It Works
+
+1. The owner calls `enter_hibernation(vault_id, caller, duration_seconds)`.
+2. A `HibernationEntry` is stored on-chain recording `started_at` and `duration_seconds`.
+3. While the hibernation window is open (`now < started_at + duration_seconds`), `is_expired` always returns `false` — the vault cannot be released.
+4. Once the window closes, the vault's effective expiry deadline is extended by the full `duration_seconds`, so the owner has their normal `check_in_interval` remaining before the vault expires.
+5. The owner can exit hibernation early by calling `exit_hibernation(vault_id, caller)`. The elapsed hibernation time is credited to `last_check_in`, preserving the remaining TTL.
+
+## Expiry Logic
+
+```
+is_expired = now >= last_check_in + check_in_interval + hibernated_seconds
+```
+
+Where `hibernated_seconds` is:
+- `0` if no hibernation entry exists
+- `0` (and returns `false` immediately) if the hibernation window is still open
+- `duration_seconds` once the window has closed
+
+## API
+
+### Enter Hibernation
+
+```rust
+enter_hibernation(vault_id: u64, caller: Address, duration_seconds: u64) -> Result<(), ContractError>
+```
+
+| Condition | Error |
+|---|---|
+| `caller` is not the vault owner | `NotOwner` (6) |
+| Vault is not `Locked` | `AlreadyReleased` (7) |
+| Vault is already hibernating | `AlreadyHibernating` (55) |
+| `duration_seconds` is zero | `InvalidInterval` (2) |
+
+Emits event: `hib_ent` with `(caller, started_at, duration_seconds)`
+
+### Exit Hibernation (Early)
+
+```rust
+exit_hibernation(vault_id: u64, caller: Address) -> Result<(), ContractError>
+```
+
+| Condition | Error |
+|---|---|
+| `caller` is not the vault owner | `NotOwner` (6) |
+| Vault is not `Locked` | `AlreadyReleased` (7) |
+| Vault is not hibernating | `NotHibernating` (56) |
+
+Emits event: `hib_ext` with `(caller, exited_at, elapsed_seconds)`
+
+### Query Hibernation Status
+
+```rust
+get_hibernation(vault_id: u64) -> Option<HibernationEntry>
+```
+
+Returns `Some(HibernationEntry)` if the vault is currently hibernating, `None` otherwise.
+
+```rust
+pub struct HibernationEntry {
+    pub started_at: u64,        // Unix timestamp when hibernation started
+    pub duration_seconds: u64,  // Total hibernation duration
+}
+```
+
+## Example
+
+```rust
+// Owner plans a 30-day absence
+let thirty_days = 30 * 24 * 3600; // 2_592_000 seconds
+client.enter_hibernation(&vault_id, &owner, &thirty_days)?;
+
+// Vault will not expire for 30 days regardless of check-ins.
+// Owner returns early after 10 days:
+client.exit_hibernation(&vault_id, &owner)?;
+// last_check_in is bumped by 10 days; normal TTL countdown resumes.
+```
+
+## Events
+
+| Topic | Payload | Description |
+|---|---|---|
+| `hib_ent` | `(caller, started_at, duration_seconds)` | Vault entered hibernation |
+| `hib_ext` | `(caller, exited_at, elapsed_seconds)` | Vault exited hibernation (early or natural) |
+
+## Security Considerations
+
+- Only the vault owner can enter or exit hibernation.
+- Hibernation does not affect deposits, withdrawals, or check-ins — those remain available.
+- A vault cannot enter hibernation twice simultaneously; the existing entry must expire or be exited first.
+- Hibernation duration is bounded by the same `max_ttl_seconds` constraint applied to check-ins (the combined `check_in_interval + duration_seconds` is used when computing storage TTL).


### PR DESCRIPTION
closes #466
- Add HibernationEntry struct and DataKey::Hibernation(u64) to types.rs
- Add HIBERNATION_ENTERED_TOPIC and HIBERNATION_EXITED_TOPIC events
- Add ContractError::AlreadyHibernating (55) and NotHibernating (56)
- Implement enter_hibernation, exit_hibernation, get_hibernation in lib.rs
- Update is_expired to extend deadline by hibernation duration
- Add 13 comprehensive tests covering all paths and edge cases
- Add docs/hibernation.md with full API reference
- Update README with hibernation API and doc link