### PR TITLE
feat: implement emergency freeze for vault compromise protection

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -38,6 +38,7 @@ use types::{
     STATE_TRANSITION_TOPIC, OWNERSHIP_PROOF_TOPIC, INTEGRITY_TOPIC, BATCH_STATUS_TOPIC,
     ProofOfLifeEntry, ReleaseVoteEntry,
     PROOF_OF_LIFE_TOPIC, RELEASE_VOTE_TOPIC, RELEASE_VOTE_PASSED_TOPIC,
+    EMERGENCY_FREEZE_TOPIC, FREEZE_RESOLVED_TOPIC,
 };
 
 #[cfg(test)]
@@ -148,6 +149,7 @@ pub enum ContractError {
     ProofOfLifeExpired = 52,
     AlreadyVoted = 53,
     VotingNotEnabled = 54,
+    VaultFrozen = 55,
 }
 
 #[contract]
@@ -944,6 +946,9 @@ impl TtlVaultContract {
             }
             if caller != vault.owner {
                 return Err(ContractError::NotOwner);
+            }
+            if vault.status == ReleaseStatus::EmergencyFrozen {
+                return Err(ContractError::VaultFrozen);
             }
             if vault.status != ReleaseStatus::Locked {
                 return Err(ContractError::AlreadyReleased);
@@ -2412,6 +2417,9 @@ impl TtlVaultContract {
         if caller != vault.owner {
             return Err(ContractError::NotOwner);
         }
+        if vault.status == ReleaseStatus::EmergencyFrozen {
+            return Err(ContractError::VaultFrozen);
+        }
         if vault.status != ReleaseStatus::Locked {
             return Err(ContractError::AlreadyReleased);
         }
@@ -2565,6 +2573,9 @@ impl TtlVaultContract {
         let mut vault = Self::load_vault(&env, vault_id);
         if caller != vault.owner {
             return Err(ContractError::NotOwner);
+        }
+        if vault.status == ReleaseStatus::EmergencyFrozen {
+            return Err(ContractError::VaultFrozen);
         }
         if vault.status != ReleaseStatus::Locked {
             return Err(ContractError::AlreadyReleased);
@@ -5837,5 +5848,64 @@ impl TtlVaultContract {
         env.storage()
             .persistent()
             .get(&DataKey::ReleaseVoteThreshold(vault_id))
+    }
+
+    // ── Emergency Freeze ─────────────────────────────────────────────────────
+
+    /// Freezes a vault in response to a suspected owner compromise.
+    ///
+    /// Only the vault's primary beneficiary (or a listed multi-beneficiary) may
+    /// call this. While frozen, all owner-only operations (withdraw,
+    /// update_beneficiary, cancel_vault) are blocked.
+    ///
+    /// # Arguments
+    /// * `vault_id` - The vault to freeze
+    /// * `caller`   - Must be a beneficiary of the vault (requires auth)
+    ///
+    /// # Errors
+    /// * `ContractError::NotBeneficiary` - If caller is not a beneficiary
+    /// * `ContractError::AlreadyReleased` - If vault is not in Locked status
+    pub fn emergency_freeze(env: Env, vault_id: u64, caller: Address) -> Result<(), ContractError> {
+        caller.require_auth();
+        let mut vault = Self::load_vault(&env, vault_id);
+        let is_beneficiary = caller == vault.beneficiary
+            || vault.beneficiaries.iter().any(|e| e.address == caller);
+        if !is_beneficiary {
+            return Err(ContractError::NotBeneficiary);
+        }
+        if vault.status != ReleaseStatus::Locked {
+            return Err(ContractError::AlreadyReleased);
+        }
+        vault.status = ReleaseStatus::EmergencyFrozen;
+        Self::save_vault(&env, vault_id, &vault);
+        Self::record_state_transition(&env, vault_id, ReleaseStatus::Locked, ReleaseStatus::EmergencyFrozen, &caller);
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((EMERGENCY_FREEZE_TOPIC, vault_id), caller);
+        Ok(())
+    }
+
+    /// Resolves an emergency freeze, returning the vault to Locked status.
+    ///
+    /// Only the contract admin may call this after investigating the situation.
+    ///
+    /// # Arguments
+    /// * `vault_id` - The vault to unfreeze
+    ///
+    /// # Errors
+    /// * `ContractError::NotAdmin`       - If caller is not the admin
+    /// * `ContractError::AlreadyReleased` - If vault is not EmergencyFrozen
+    pub fn resolve_emergency_freeze(env: Env, vault_id: u64) -> Result<(), ContractError> {
+        Self::require_admin(&env);
+        let mut vault = Self::load_vault(&env, vault_id);
+        if vault.status != ReleaseStatus::EmergencyFrozen {
+            return Err(ContractError::AlreadyReleased);
+        }
+        vault.status = ReleaseStatus::Locked;
+        let admin = Self::load_admin(&env);
+        Self::save_vault(&env, vault_id, &vault);
+        Self::record_state_transition(&env, vault_id, ReleaseStatus::EmergencyFrozen, ReleaseStatus::Locked, &admin);
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((FREEZE_RESOLVED_TOPIC, vault_id), admin);
+        Ok(())
     }
 }

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -4082,3 +4082,116 @@ fn test_get_release_votes_empty_by_default() {
     let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
     assert_eq!(client.get_release_votes(&id).len(), 0);
 }
+
+// ── Emergency Freeze Tests ────────────────────────────────────────────────────
+
+#[test]
+fn test_emergency_freeze_by_beneficiary() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    client.emergency_freeze(&id, &beneficiary);
+    let vault = client.get_vault(&id);
+    assert_eq!(vault.status, ReleaseStatus::EmergencyFrozen);
+}
+
+#[test]
+fn test_emergency_freeze_blocks_withdraw() {
+    let (env, owner, beneficiary, _, token_address, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    StellarAssetClient::new(&env, &token_address).mint(&owner, &1_000);
+    client.deposit(&id, &owner, &1_000);
+    client.emergency_freeze(&id, &beneficiary);
+    let err = client.try_withdraw(&id, &owner, &500).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(55)); // VaultFrozen
+}
+
+#[test]
+fn test_emergency_freeze_blocks_update_beneficiary() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_ben = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    client.emergency_freeze(&id, &beneficiary);
+    let err = client.try_update_beneficiary(&id, &owner, &new_ben).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(55)); // VaultFrozen
+}
+
+#[test]
+fn test_emergency_freeze_blocks_cancel_vault() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    client.emergency_freeze(&id, &beneficiary);
+    let err = client.try_cancel_vault(&id, &owner).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(55)); // VaultFrozen
+}
+
+#[test]
+fn test_emergency_freeze_non_beneficiary_rejected() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let stranger = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    let err = client.try_emergency_freeze(&id, &stranger).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(30)); // NotBeneficiary
+}
+
+#[test]
+fn test_resolve_emergency_freeze_by_admin() {
+    let (_, owner, beneficiary, admin, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    client.emergency_freeze(&id, &beneficiary);
+    client.resolve_emergency_freeze(&id);
+    let vault = client.get_vault(&id);
+    assert_eq!(vault.status, ReleaseStatus::Locked);
+}
+
+#[test]
+fn test_resolve_emergency_freeze_restores_withdraw() {
+    let (env, owner, beneficiary, _, token_address, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    StellarAssetClient::new(&env, &token_address).mint(&owner, &1_000);
+    client.deposit(&id, &owner, &1_000);
+    client.emergency_freeze(&id, &beneficiary);
+    client.resolve_emergency_freeze(&id);
+    client.withdraw(&id, &owner, &500);
+    assert_eq!(client.get_vault(&id).balance, 500);
+}
+
+#[test]
+fn test_resolve_emergency_freeze_non_frozen_rejected() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    let err = client.try_resolve_emergency_freeze(&id).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(7)); // AlreadyReleased
+}
+
+#[test]
+fn test_emergency_freeze_emits_event() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    client.emergency_freeze(&id, &beneficiary);
+    let events = env.events().all();
+    let found = events.iter().any(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.0.try_into_val(&env).unwrap_or_else(|_| soroban_sdk::Vec::new(&env));
+        topics.len() > 0 && {
+            let t: Result<soroban_sdk::Symbol, _> = topics.get(0).unwrap().try_into_val(&env);
+            t.map(|s| s == symbol_short!("emg_frz")).unwrap_or(false)
+        }
+    });
+    assert!(found, "EMERGENCY_FREEZE_TOPIC event not emitted");
+}
+
+#[test]
+fn test_freeze_resolved_emits_event() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    client.emergency_freeze(&id, &beneficiary);
+    client.resolve_emergency_freeze(&id);
+    let events = env.events().all();
+    let found = events.iter().any(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.0.try_into_val(&env).unwrap_or_else(|_| soroban_sdk::Vec::new(&env));
+        topics.len() > 0 && {
+            let t: Result<soroban_sdk::Symbol, _> = topics.get(0).unwrap().try_into_val(&env);
+            t.map(|s| s == symbol_short!("frz_res")).unwrap_or(false)
+        }
+    });
+    assert!(found, "FREEZE_RESOLVED_TOPIC event not emitted");
+}


### PR DESCRIPTION
closes #448
- Add emergency_freeze(vault_id, caller): beneficiary-only, sets status to EmergencyFrozen and emits EMERGENCY_FREEZE_TOPIC event
- Add resolve_emergency_freeze(vault_id): admin-only, restores Locked status and emits FREEZE_RESOLVED_TOPIC event
- Block withdraw, update_beneficiary, and cancel_vault while frozen (returns VaultFrozen error #55)
- Add 10 tests covering freeze enforcement, admin resolution, event emission, and access control