### PR TITLE
Feature/beneficiary rotation schedule

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -39,6 +39,7 @@ use types::{
     ProofOfLifeEntry, ReleaseVoteEntry,
     PROOF_OF_LIFE_TOPIC, RELEASE_VOTE_TOPIC, RELEASE_VOTE_PASSED_TOPIC,
     EMERGENCY_FREEZE_TOPIC, FREEZE_RESOLVED_TOPIC,
+    BeneficiaryRotationEntry, BEN_ROTATION_TOPIC,
 };
 
 #[cfg(test)]
@@ -1193,6 +1194,30 @@ impl TtlVaultContract {
                     env.events().publish((ACCEPTANCE_DEADLINE_EXPIRED_TOPIC,), (vault_id, vault.owner.clone(), total));
                     return;
                 }
+            }
+        }
+
+        // Apply scheduled beneficiary rotation if effective timestamp has passed
+        let rot_key = DataKey::BeneficiaryRotationSchedule(vault_id);
+        if let Some(mut schedule) = env.storage().persistent()
+            .get::<DataKey, Vec<BeneficiaryRotationEntry>>(&rot_key)
+        {
+            // Find the latest entry whose effective_timestamp <= now
+            let mut applied: Option<BeneficiaryRotationEntry> = None;
+            for entry in schedule.iter() {
+                if entry.effective_timestamp <= now {
+                    if applied.as_ref().map_or(true, |a: &BeneficiaryRotationEntry| entry.effective_timestamp > a.effective_timestamp) {
+                        applied = Some(entry.clone());
+                    }
+                }
+            }
+            if let Some(rotation) = applied {
+                if rotation.new_beneficiaries.is_empty() {
+                    // single-beneficiary rotation not supported via this path; skip
+                } else {
+                    vault.beneficiaries = rotation.new_beneficiaries.clone();
+                }
+                env.events().publish((BEN_ROTATION_TOPIC, vault_id), rotation.effective_timestamp);
             }
         }
 
@@ -5848,6 +5873,72 @@ impl TtlVaultContract {
         env.storage()
             .persistent()
             .get(&DataKey::ReleaseVoteThreshold(vault_id))
+    }
+
+    /// Returns the release vote threshold for a vault, if set.
+    pub fn get_release_vote_threshold(env: Env, vault_id: u64) -> Option<u32> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ReleaseVoteThreshold(vault_id))
+    }
+
+    // ── Beneficiary Rotation Schedule ────────────────────────────────────────
+
+    /// Schedules a future beneficiary rotation for a vault.
+    ///
+    /// At `trigger_release` time, if `effective_timestamp` has passed, the vault's
+    /// beneficiaries are replaced with the provided list before funds are distributed.
+    /// Multiple entries can be scheduled; the one with the latest effective timestamp
+    /// that has already passed is applied.
+    ///
+    /// # Arguments
+    /// * `vault_id`            - The vault to configure
+    /// * `caller`              - Must be the vault owner (requires auth)
+    /// * `effective_timestamp` - Unix timestamp when this rotation becomes active
+    /// * `new_beneficiaries`   - Replacement beneficiary list (must sum to 10 000 bps)
+    ///
+    /// # Errors
+    /// * `ContractError::NotOwner`    - If caller is not the vault owner
+    /// * `ContractError::InvalidBps`  - If bps do not sum to 10 000
+    pub fn schedule_beneficiary_rotation(
+        env: Env,
+        vault_id: u64,
+        caller: Address,
+        effective_timestamp: u64,
+        new_beneficiaries: Vec<BeneficiaryEntry>,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        let vault = Self::load_vault(&env, vault_id);
+        if caller != vault.owner {
+            return Err(ContractError::NotOwner);
+        }
+        // Validate bps sum to 10_000
+        let total_bps: u32 = new_beneficiaries.iter().map(|e| e.bps).sum();
+        if total_bps != 10_000 {
+            return Err(ContractError::InvalidBps);
+        }
+        let rot_key = DataKey::BeneficiaryRotationSchedule(vault_id);
+        let mut schedule: Vec<BeneficiaryRotationEntry> = env.storage().persistent()
+            .get(&rot_key)
+            .unwrap_or_else(|| Vec::new(&env));
+        schedule.push_back(BeneficiaryRotationEntry {
+            effective_timestamp,
+            new_beneficiaries,
+        });
+        let ttl = vault_ttl_ledgers(vault.check_in_interval);
+        env.storage().persistent().set(&rot_key, &schedule);
+        env.storage().persistent().extend_ttl(&rot_key, VAULT_TTL_THRESHOLD, ttl);
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((BEN_ROTATION_TOPIC, vault_id), effective_timestamp);
+        Ok(())
+    }
+
+    /// Returns all scheduled beneficiary rotations for a vault.
+    pub fn get_beneficiary_rotation_schedule(env: Env, vault_id: u64) -> Vec<BeneficiaryRotationEntry> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::BeneficiaryRotationSchedule(vault_id))
+            .unwrap_or_else(|| Vec::new(&env))
     }
 
     // ── Emergency Freeze ─────────────────────────────────────────────────────

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -4195,3 +4195,135 @@ fn test_freeze_resolved_emits_event() {
     });
     assert!(found, "FREEZE_RESOLVED_TOPIC event not emitted");
 }
+
+// ── Beneficiary Rotation Schedule Tests ──────────────────────────────────────
+
+fn make_beneficiary_entry(env: &Env, addr: Address, bps: u32) -> BeneficiaryEntry {
+    BeneficiaryEntry { address: addr, bps }
+}
+
+#[test]
+fn test_schedule_beneficiary_rotation_stores_entry() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    let new_ben = Address::generate(&env);
+    let entries = soroban_sdk::vec![&env, make_beneficiary_entry(&env, new_ben.clone(), 10_000)];
+    client.schedule_beneficiary_rotation(&id, &owner, &9999u64, &entries);
+    let schedule = client.get_beneficiary_rotation_schedule(&id);
+    assert_eq!(schedule.len(), 1);
+    assert_eq!(schedule.get(0).unwrap().effective_timestamp, 9999u64);
+}
+
+#[test]
+fn test_schedule_beneficiary_rotation_non_owner_rejected() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    let stranger = Address::generate(&env);
+    let entries = soroban_sdk::vec![&env, make_beneficiary_entry(&env, stranger.clone(), 10_000)];
+    let err = client.try_schedule_beneficiary_rotation(&id, &stranger, &9999u64, &entries)
+        .unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(6)); // NotOwner
+}
+
+#[test]
+fn test_schedule_beneficiary_rotation_invalid_bps_rejected() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    let new_ben = Address::generate(&env);
+    // bps = 5000, not 10_000
+    let entries = soroban_sdk::vec![&env, make_beneficiary_entry(&env, new_ben.clone(), 5_000)];
+    let err = client.try_schedule_beneficiary_rotation(&id, &owner, &9999u64, &entries)
+        .unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(12)); // InvalidBps
+}
+
+#[test]
+fn test_get_beneficiary_rotation_schedule_empty_by_default() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    assert_eq!(client.get_beneficiary_rotation_schedule(&id).len(), 0);
+}
+
+#[test]
+fn test_multiple_rotation_entries_stored() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    let ben_a = Address::generate(&env);
+    let ben_b = Address::generate(&env);
+    let entries_a = soroban_sdk::vec![&env, make_beneficiary_entry(&env, ben_a.clone(), 10_000)];
+    let entries_b = soroban_sdk::vec![&env, make_beneficiary_entry(&env, ben_b.clone(), 10_000)];
+    client.schedule_beneficiary_rotation(&id, &owner, &1000u64, &entries_a);
+    client.schedule_beneficiary_rotation(&id, &owner, &2000u64, &entries_b);
+    assert_eq!(client.get_beneficiary_rotation_schedule(&id).len(), 2);
+}
+
+#[test]
+fn test_trigger_release_applies_rotation() {
+    let (env, owner, beneficiary, _, token_address, client) = setup();
+    // Use a short interval so expiry is easy to simulate
+    let id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+    StellarAssetClient::new(&env, &token_address).mint(&owner, &1_000);
+    client.deposit(&id, &owner, &1_000);
+
+    let new_ben = Address::generate(&env);
+    // Schedule rotation at timestamp 0 (always in the past)
+    let entries = soroban_sdk::vec![&env, make_beneficiary_entry(&env, new_ben.clone(), 10_000)];
+    client.schedule_beneficiary_rotation(&id, &owner, &0u64, &entries);
+
+    // Advance ledger past check-in interval to expire the vault
+    env.ledger().with_mut(|l| {
+        l.timestamp = 200;
+    });
+
+    client.trigger_release(&id);
+
+    // new_ben should have received the funds
+    let token = token::Client::new(&env, &token_address);
+    assert_eq!(token.balance(&new_ben), 1_000);
+}
+
+#[test]
+fn test_trigger_release_picks_latest_applicable_rotation() {
+    let (env, owner, beneficiary, _, token_address, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+    StellarAssetClient::new(&env, &token_address).mint(&owner, &1_000);
+    client.deposit(&id, &owner, &1_000);
+
+    let ben_early = Address::generate(&env);
+    let ben_late = Address::generate(&env);
+
+    // Two rotations: timestamp 1 (earlier) and timestamp 50 (later, still past)
+    let entries_early = soroban_sdk::vec![&env, make_beneficiary_entry(&env, ben_early.clone(), 10_000)];
+    let entries_late = soroban_sdk::vec![&env, make_beneficiary_entry(&env, ben_late.clone(), 10_000)];
+    client.schedule_beneficiary_rotation(&id, &owner, &1u64, &entries_early);
+    client.schedule_beneficiary_rotation(&id, &owner, &50u64, &entries_late);
+
+    env.ledger().with_mut(|l| { l.timestamp = 200; });
+    client.trigger_release(&id);
+
+    let token = token::Client::new(&env, &token_address);
+    // The later rotation (timestamp 50) should win
+    assert_eq!(token.balance(&ben_late), 1_000);
+    assert_eq!(token.balance(&ben_early), 0);
+}
+
+#[test]
+fn test_trigger_release_future_rotation_not_applied() {
+    let (env, owner, beneficiary, _, token_address, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+    StellarAssetClient::new(&env, &token_address).mint(&owner, &1_000);
+    client.deposit(&id, &owner, &1_000);
+
+    let new_ben = Address::generate(&env);
+    // Schedule rotation far in the future
+    let entries = soroban_sdk::vec![&env, make_beneficiary_entry(&env, new_ben.clone(), 10_000)];
+    client.schedule_beneficiary_rotation(&id, &owner, &99999u64, &entries);
+
+    env.ledger().with_mut(|l| { l.timestamp = 200; });
+    client.trigger_release(&id);
+
+    let token = token::Client::new(&env, &token_address);
+    // Original beneficiary should receive funds, not new_ben
+    assert_eq!(token.balance(&beneficiary), 1_000);
+    assert_eq!(token.balance(&new_ben), 0);
+}

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -101,6 +101,13 @@ pub const CHECKIN_RATE_LIMITED_TOPIC: Symbol = symbol_short!("ci_rl");
 // Issue: Accelerated TTL Decay
 pub const TTL_ACCELERATE_TOPIC: Symbol = symbol_short!("ttl_acc");
 
+// Emergency freeze events
+pub const EMERGENCY_FREEZE_TOPIC: Symbol = symbol_short!("emg_frz");
+pub const FREEZE_RESOLVED_TOPIC: Symbol = symbol_short!("frz_res");
+
+// Beneficiary rotation
+pub const BEN_ROTATION_TOPIC: Symbol = symbol_short!("ben_rot");
+
 // Issue: Geographic Check-in Tracking
 pub const CHECKIN_GEO_TOPIC: Symbol = symbol_short!("ci_geo");
 
@@ -180,6 +187,8 @@ pub enum DataKey {
     // Issue #499: beneficiary release votes
     ReleaseVotes(u64),
     ReleaseVoteThreshold(u64),
+    // Beneficiary rotation schedule
+    BeneficiaryRotationSchedule(u64),
 }
 
 /// Check-in history entry for TTL prediction - Issue #482
@@ -223,6 +232,7 @@ pub enum ReleaseStatus {
     Locked,
     Released,
     Cancelled,
+    EmergencyFrozen,
 }
 
 #[contracttype]
@@ -536,4 +546,14 @@ pub struct TtlPool {
 pub struct BiometricEntry {
     pub credential_hash: BytesN<32>,
     pub added_at: u64,
+}
+
+/// A scheduled beneficiary rotation entry.
+/// When `effective_timestamp` is reached at release time, the vault's
+/// beneficiaries are replaced with `new_beneficiaries`.
+#[contracttype]
+#[derive(Clone)]
+pub struct BeneficiaryRotationEntry {
+    pub effective_timestamp: u64,
+    pub new_beneficiaries: Vec<BeneficiaryEntry>,
 }


### PR DESCRIPTION
closes #449 

types.rs
- BeneficiaryRotationEntry struct — effective_timestamp: u64 + new_beneficiaries: Vec<BeneficiaryEntry>
- DataKey::BeneficiaryRotationSchedule(u64) variant
- BEN_ROTATION_TOPIC event constant ("ben_rot")

lib.rs
- schedule_beneficiary_rotation — owner-only, validates bps sum to 10 000, appends to the stored Vec, emits BEN_ROTATION_TOPIC
- get_beneficiary_rotation_schedule — plain view returning the stored Vec
- trigger_release — before payout, scans the schedule and applies the entry with the highest effective_timestamp ≤ now, replacing vault.beneficiaries in-memory before the transfer loop

8 tests — schedule stores correctly, non-owner rejected, invalid bps rejected, empty by default, multiple entries stored, release applies rotation, latest-wins when multiple entries are past
-due, future rotation not applied.