### PR TITLE
Feature/inactivity penalty

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -40,6 +40,7 @@ use types::{
     PROOF_OF_LIFE_TOPIC, RELEASE_VOTE_TOPIC, RELEASE_VOTE_PASSED_TOPIC,
     EMERGENCY_FREEZE_TOPIC, FREEZE_RESOLVED_TOPIC,
     BeneficiaryRotationEntry, BEN_ROTATION_TOPIC,
+    INACTIVITY_PENALTY_TOPIC,
 };
 
 #[cfg(test)]
@@ -650,6 +651,8 @@ impl TtlVaultContract {
                 max_deposit_amount: None,
                 withdrawal_approval_threshold: None,
                 spending_limit: None,
+                inactivity_penalty_bps: None,
+                penalty_recipient: None,
             };
             Self::save_vault(&env, vault_id, &vault);
             Self::add_owner_vault_id(&env, &owner, vault_id, check_in_interval);
@@ -746,6 +749,22 @@ impl TtlVaultContract {
         
         vault.last_check_in = now;
         
+        // Inactivity penalty: deduct per missed check-in interval
+        if let (Some(penalty_bps), Some(recipient)) = (vault.inactivity_penalty_bps, vault.penalty_recipient.clone()) {
+            let elapsed = now.saturating_sub(original_last_check_in);
+            let missed = (elapsed / vault.check_in_interval).saturating_sub(1);
+            if missed > 0 && vault.balance > 0 {
+                let penalty_per = vault.balance * (penalty_bps as i128) / 10_000;
+                let total_penalty = (penalty_per * missed as i128).min(vault.balance);
+                if total_penalty > 0 {
+                    let token_client = token::Client::new(&env, &vault.token_address);
+                    token_client.transfer(&env.current_contract_address(), &recipient, &total_penalty);
+                    vault.balance -= total_penalty;
+                    env.events().publish((INACTIVITY_PENALTY_TOPIC, vault_id), (total_penalty, recipient));
+                }
+            }
+        }
+
         // Cap TTL at max_ttl_seconds
         let max_ttl = Self::get_max_ttl_seconds(env.clone());
         let deadline = now + vault.check_in_interval;
@@ -3077,6 +3096,8 @@ impl TtlVaultContract {
             max_deposit_amount: None,
             withdrawal_approval_threshold: None,
             spending_limit: None,
+            inactivity_penalty_bps: None,
+            penalty_recipient: None,
         };
         
         Self::save_vault(&env, vault_id, &new_vault);
@@ -5880,6 +5901,51 @@ impl TtlVaultContract {
         env.storage()
             .persistent()
             .get(&DataKey::ReleaseVoteThreshold(vault_id))
+    }
+
+    // ── Inactivity Penalty ───────────────────────────────────────────────────
+
+    /// Configures an inactivity penalty for a vault.
+    ///
+    /// When the owner checks in after missing one or more full intervals, a penalty
+    /// of `penalty_bps` basis points of the current balance is deducted per missed
+    /// interval and transferred to `recipient`.
+    ///
+    /// # Arguments
+    /// * `vault_id`    - The vault to configure
+    /// * `caller`      - Must be the vault owner (requires auth)
+    /// * `penalty_bps` - Penalty per missed interval in basis points (0 = disable)
+    /// * `recipient`   - Address that receives the penalty
+    ///
+    /// # Errors
+    /// * `ContractError::NotOwner`      - If caller is not the vault owner
+    /// * `ContractError::InvalidAmount` - If penalty_bps > 10_000
+    pub fn set_inactivity_penalty(
+        env: Env,
+        vault_id: u64,
+        caller: Address,
+        penalty_bps: u32,
+        recipient: Address,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        let mut vault = Self::load_vault(&env, vault_id);
+        if caller != vault.owner {
+            return Err(ContractError::NotOwner);
+        }
+        if penalty_bps > 10_000 {
+            return Err(ContractError::InvalidAmount);
+        }
+        if penalty_bps == 0 {
+            vault.inactivity_penalty_bps = None;
+            vault.penalty_recipient = None;
+        } else {
+            vault.inactivity_penalty_bps = Some(penalty_bps);
+            vault.penalty_recipient = Some(recipient.clone());
+        }
+        Self::save_vault(&env, vault_id, &vault);
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((INACTIVITY_PENALTY_TOPIC, vault_id), (penalty_bps, recipient));
+        Ok(())
     }
 
     // ── Beneficiary Rotation Schedule ────────────────────────────────────────

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -4327,3 +4327,115 @@ fn test_trigger_release_future_rotation_not_applied() {
     assert_eq!(token.balance(&beneficiary), 1_000);
     assert_eq!(token.balance(&new_ben), 0);
 }
+
+// ── Inactivity Penalty Tests ──────────────────────────────────────────────────
+
+#[test]
+fn test_set_inactivity_penalty_stores_config() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let recipient = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    client.set_inactivity_penalty(&id, &owner, &500u32, &recipient);
+    let vault = client.get_vault(&id);
+    assert_eq!(vault.inactivity_penalty_bps, Some(500));
+    assert_eq!(vault.penalty_recipient, Some(recipient));
+}
+
+#[test]
+fn test_set_inactivity_penalty_non_owner_rejected() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let stranger = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    let err = client.try_set_inactivity_penalty(&id, &stranger, &500u32, &stranger)
+        .unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(6)); // NotOwner
+}
+
+#[test]
+fn test_set_inactivity_penalty_over_10000_rejected() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let recipient = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    let err = client.try_set_inactivity_penalty(&id, &owner, &10_001u32, &recipient)
+        .unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(5)); // InvalidAmount
+}
+
+#[test]
+fn test_set_inactivity_penalty_zero_disables() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let recipient = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    client.set_inactivity_penalty(&id, &owner, &500u32, &recipient);
+    client.set_inactivity_penalty(&id, &owner, &0u32, &recipient);
+    let vault = client.get_vault(&id);
+    assert_eq!(vault.inactivity_penalty_bps, None);
+    assert_eq!(vault.penalty_recipient, None);
+}
+
+#[test]
+fn test_check_in_deducts_penalty_for_missed_intervals() {
+    let (env, owner, beneficiary, _, token_address, client) = setup();
+    let recipient = Address::generate(&env);
+    let interval = 1000u64;
+    let id = client.create_vault(&owner, &beneficiary, &interval, &None);
+    StellarAssetClient::new(&env, &token_address).mint(&owner, &10_000);
+    client.deposit(&id, &owner, &10_000);
+    // 500 bps = 5% per missed interval
+    client.set_inactivity_penalty(&id, &owner, &500u32, &recipient);
+
+    // Advance 3 intervals (2 missed = 3 elapsed - 1 current)
+    env.ledger().with_mut(|l| { l.timestamp = interval * 3; });
+
+    let dummy_hash = BytesN::from_array(&env, &[0u8; 32]);
+    client.check_in(&id, &owner, &dummy_hash);
+
+    let token = token::Client::new(&env, &token_address);
+    // 2 missed intervals × 5% of 10_000 = 1_000 penalty
+    assert_eq!(token.balance(&recipient), 1_000);
+    assert_eq!(client.get_vault(&id).balance, 9_000);
+}
+
+#[test]
+fn test_check_in_no_penalty_when_on_time() {
+    let (env, owner, beneficiary, _, token_address, client) = setup();
+    let recipient = Address::generate(&env);
+    let interval = 1000u64;
+    let id = client.create_vault(&owner, &beneficiary, &interval, &None);
+    StellarAssetClient::new(&env, &token_address).mint(&owner, &10_000);
+    client.deposit(&id, &owner, &10_000);
+    client.set_inactivity_penalty(&id, &owner, &500u32, &recipient);
+
+    // Advance less than one interval (no missed intervals)
+    env.ledger().with_mut(|l| { l.timestamp = interval / 2; });
+
+    let dummy_hash = BytesN::from_array(&env, &[0u8; 32]);
+    client.check_in(&id, &owner, &dummy_hash);
+
+    let token = token::Client::new(&env, &token_address);
+    assert_eq!(token.balance(&recipient), 0);
+    assert_eq!(client.get_vault(&id).balance, 10_000);
+}
+
+#[test]
+fn test_check_in_penalty_capped_at_balance() {
+    let (env, owner, beneficiary, _, token_address, client) = setup();
+    let recipient = Address::generate(&env);
+    let interval = 100u64;
+    let id = client.create_vault(&owner, &beneficiary, &interval, &None);
+    StellarAssetClient::new(&env, &token_address).mint(&owner, &100);
+    client.deposit(&id, &owner, &100);
+    // 5000 bps = 50% per missed interval, many missed → would exceed balance
+    client.set_inactivity_penalty(&id, &owner, &5_000u32, &recipient);
+
+    // Advance 100 intervals (99 missed)
+    env.ledger().with_mut(|l| { l.timestamp = interval * 100; });
+
+    let dummy_hash = BytesN::from_array(&env, &[0u8; 32]);
+    client.check_in(&id, &owner, &dummy_hash);
+
+    let token = token::Client::new(&env, &token_address);
+    // Penalty capped at full balance
+    assert_eq!(token.balance(&recipient), 100);
+    assert_eq!(client.get_vault(&id).balance, 0);
+}

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -108,6 +108,9 @@ pub const FREEZE_RESOLVED_TOPIC: Symbol = symbol_short!("frz_res");
 // Beneficiary rotation
 pub const BEN_ROTATION_TOPIC: Symbol = symbol_short!("ben_rot");
 
+// Inactivity penalty
+pub const INACTIVITY_PENALTY_TOPIC: Symbol = symbol_short!("inact_pen");
+
 // Issue: Geographic Check-in Tracking
 pub const CHECKIN_GEO_TOPIC: Symbol = symbol_short!("ci_geo");
 
@@ -339,6 +342,10 @@ pub struct Vault {
     pub withdrawal_approval_threshold: Option<i128>,
     /// Maximum amount releasable per trigger_release call - Issue #382
     pub spending_limit: Option<i128>,
+    /// Penalty in basis points deducted per missed check-in interval
+    pub inactivity_penalty_bps: Option<u32>,
+    /// Address that receives inactivity penalty transfers
+    pub penalty_recipient: Option<Address>,
 }
 
 /// Passkey usage entry for tracking check-ins - Issue #395


### PR DESCRIPTION
closes #450 
types.rs
- Two new Vault fields: inactivity_penalty_bps: Option<u32> and penalty_recipient: Option<Address>
- INACTIVITY_PENALTY_TOPIC constant ("inact_pen")

lib.rs
- Both Vault constructors initialise the new fields to None
- set_inactivity_penalty(vault_id, caller, penalty_bps, recipient) — owner-only, rejects penalty_bps > 10_000, sets None when 0 to disable
- check_in — after recording last_check_in, calculates missed = elapsed / interval - 1, deducts penalty_bps * missed from balance (capped at balance), transfers to recipient, emits 
INACTIVITY_PENALTY_TOPIC

7 tests — config stored, non-owner rejected, >10 000 bps rejected, zero disables, penalty deducted for 2 missed intervals, no penalty when on time, penalty capped at full balance.

