### PR TITLE
eat: add beneficiary capacity limits

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -31,7 +31,7 @@ use types::{
     MULTISIG_EXECUTED_TOPIC, MULTISIG_PROPOSAL_EXPIRY, OWNERSHIP_INITIATED_TOPIC, OWNERSHIP_ACCEPTED_TOPIC,
     OWNERSHIP_CANCELLED_TOPIC,
     MetadataVersionEntry, META_VERSION_TOPIC, META_REVERT_TOPIC, VAULT_ARCHIVED_TOPIC,
-    VAULT_CAP_TOPIC,
+    VAULT_CAP_TOPIC, BENEFICIARY_CAP_TOPIC,
     CheckInHistoryEntry, CheckInStreak,
     DELEGATE_CHECKIN_TOPIC, REVOKE_DELEGATE_TOPIC, CHECKIN_POW_TOPIC, TTL_PREDICTED_TOPIC,
     BATCH_CHECKIN_TOPIC,
@@ -148,6 +148,7 @@ pub enum ContractError {
     ProofOfLifeExpired = 52,
     AlreadyVoted = 53,
     VotingNotEnabled = 54,
+    BeneficiaryCapacityExceeded = 55,
 }
 
 #[contract]
@@ -613,6 +614,9 @@ impl TtlVaultContract {
                     panic_with_error!(&env, ContractError::VaultCapacityExceeded);
                 }
             }
+
+            // Enforce per-beneficiary vault capacity limit
+            Self::assert_beneficiary_capacity(&env, &beneficiary);
 
             // Use provided token or default to contract's XLM token
             let vault_token = match token_address {
@@ -2469,6 +2473,12 @@ impl TtlVaultContract {
 
         let old_beneficiary = vault.beneficiary.clone();
         let new_beneficiary = pending.new_beneficiary.clone();
+
+        // Enforce beneficiary capacity only when the beneficiary actually changes
+        if old_beneficiary != new_beneficiary {
+            Self::assert_beneficiary_capacity(&env, &new_beneficiary);
+        }
+
         vault.beneficiary = new_beneficiary.clone();
         Self::save_vault(&env, vault_id, &vault);
 
@@ -5303,6 +5313,39 @@ impl TtlVaultContract {
             .instance()
             .get(&DataKey::OwnerVaultCount(env.current_contract_address()))
             .unwrap_or(0u32)
+    }
+
+    // ── Beneficiary Capacity Limits ───────────────────────────────────────────
+
+    /// Sets the maximum number of vaults a single beneficiary may be assigned to.
+    ///
+    /// Admin-only. A value of 0 removes the limit.
+    pub fn set_beneficiary_vault_limit(env: Env, limit: u32) {
+        Self::require_admin(&env);
+        env.storage().instance().set(&DataKey::BeneficiaryVaultLimit, &limit);
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((BENEFICIARY_CAP_TOPIC,), limit);
+    }
+
+    /// Returns the configured per-beneficiary vault limit (0 = unlimited).
+    pub fn get_beneficiary_vault_limit(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::BeneficiaryVaultLimit)
+            .unwrap_or(0u32)
+    }
+
+    fn assert_beneficiary_capacity(env: &Env, beneficiary: &Address) {
+        let limit: u32 = env.storage()
+            .instance()
+            .get(&DataKey::BeneficiaryVaultLimit)
+            .unwrap_or(0u32);
+        if limit > 0 {
+            let count = Self::load_beneficiary_vault_ids(env, beneficiary).len() as u32;
+            if count >= limit {
+                panic_with_error!(env, ContractError::BeneficiaryCapacityExceeded);
+            }
+        }
     }
 
     // ── Issue #471: Vault Merge Validation ───────────────────────────────────

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -3700,6 +3700,72 @@ fn test_vault_capacity_zero_means_unlimited() {
     assert_eq!(client.vault_count(), 3u64);
 }
 
+// ---- Beneficiary Capacity Limits ----
+
+#[test]
+fn test_beneficiary_vault_limit_enforced() {
+    let (env, owner, beneficiary, _admin, _, client) = setup();
+    client.set_beneficiary_vault_limit(&2u32);
+    assert_eq!(client.get_beneficiary_vault_limit(), 2u32);
+
+    let owner2 = Address::generate(&env);
+    let owner3 = Address::generate(&env);
+    // Two vaults with the same beneficiary — should succeed
+    client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    client.create_vault(&owner2, &beneficiary, &3600u64, &None);
+
+    // Third vault with the same beneficiary should fail
+    let err = client.try_create_vault(&owner3, &beneficiary, &3600u64, &None).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(55)); // BeneficiaryCapacityExceeded
+}
+
+#[test]
+fn test_beneficiary_vault_limit_zero_means_unlimited() {
+    let (env, owner, beneficiary, _admin, _, client) = setup();
+    client.set_beneficiary_vault_limit(&0u32); // unlimited
+
+    let owner2 = Address::generate(&env);
+    let owner3 = Address::generate(&env);
+    client.create_vault(&owner, &beneficiary, &3600u64, &None);
+    client.create_vault(&owner2, &beneficiary, &3600u64, &None);
+    client.create_vault(&owner3, &beneficiary, &3600u64, &None);
+    assert_eq!(client.vault_count(), 3u64);
+}
+
+#[test]
+fn test_beneficiary_vault_limit_emits_event() {
+    let (env, _owner, _beneficiary, _admin, _, client) = setup();
+    client.set_beneficiary_vault_limit(&5u32);
+    let events = env.events().all();
+    let last = events.last().unwrap();
+    // topic is (BENEFICIARY_CAP_TOPIC,), data is 5u32
+    let data: u32 = last.1.try_into_val(&env).unwrap();
+    assert_eq!(data, 5u32);
+}
+
+#[test]
+fn test_apply_beneficiary_update_respects_limit() {
+    let (env, owner, beneficiary, _admin, _, client) = setup();
+    client.set_beneficiary_vault_limit(&1u32);
+
+    // beneficiary is already assigned to vault1
+    let vault1 = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    // Create vault2 with a different beneficiary, then try to update it to `beneficiary`
+    let other = Address::generate(&env);
+    let vault2 = client.create_vault(&owner, &other, &3600u64, &None);
+
+    // Initiate update — this just queues it (no cap check yet)
+    client.update_beneficiary(&vault2, &owner, &beneficiary).unwrap();
+
+    // Advance past the 24h timelock
+    env.ledger().with_mut(|l| l.timestamp = 90_000);
+
+    // Applying should fail — beneficiary already at limit
+    let err = client.try_apply_beneficiary_update(&vault2, &owner).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(55)); // BeneficiaryCapacityExceeded
+}
+
 // ---- Issue #471: Vault Merge Validation ----
 
 #[test]

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -98,6 +98,9 @@ pub const TTL_REPAY_TOPIC: Symbol = symbol_short!("ttl_rep");
 // Issue: Check-in Rate Limiting
 pub const CHECKIN_RATE_LIMITED_TOPIC: Symbol = symbol_short!("ci_rl");
 
+// Beneficiary capacity limit
+pub const BENEFICIARY_CAP_TOPIC: Symbol = symbol_short!("ben_cap");
+
 // Issue: Accelerated TTL Decay
 pub const TTL_ACCELERATE_TOPIC: Symbol = symbol_short!("ttl_acc");
 
@@ -180,6 +183,8 @@ pub enum DataKey {
     // Issue #499: beneficiary release votes
     ReleaseVotes(u64),
     ReleaseVoteThreshold(u64),
+    // Beneficiary capacity limit
+    BeneficiaryVaultLimit,
 }
 
 /// Check-in history entry for TTL prediction - Issue #482


### PR DESCRIPTION
closes #500 

- Add BeneficiaryVaultLimit DataKey (instance storage)
- Add BENEFICIARY_CAP_TOPIC event symbol
- Add BeneficiaryCapacityExceeded = 55 error variant
- Add set_beneficiary_vault_limit / get_beneficiary_vault_limit (admin-only)
- Add assert_beneficiary_capacity helper, enforced in create_vault and apply_beneficiary_update
- Add 4 tests covering: limit enforced, zero = unlimited, event emission, apply_beneficiary_update blocked


Summary

Limits the number of vaults a single beneficiary address can be assigned to, preventing concentration risk.

Changes
- types.rs: new BeneficiaryVaultLimit DataKey variant and BENEFICIARY_CAP_TOPIC event symbol
- lib.rs: new BeneficiaryCapacityExceeded = 55 error; set_beneficiary_vault_limit / get_beneficiary_vault_limit admin functions; assert_beneficiary_capacity private helper enforced in create_vault and 
apply_beneficiary_update; emits BENEFICIARY_CAP_TOPIC event on limit change
- test.rs: 4 new tests — limit enforced on vault creation, zero means unlimited, event emitted on limit set, apply_beneficiary_update blocked when beneficiary is at capacity

Behaviour
- Default limit is 0 (unlimited, no breaking change)
- Admin sets limit via set_beneficiary_vault_limit(limit); 0 removes the limit
- Exceeding the limit panics with BeneficiaryCapacityExceeded (error code 55)