### PR TITLE
feat: Vesting Penalty, Vesting Reversal, Passkey Expiry Enforcement & Passkey Compromise Detection

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -744,12 +744,9 @@ impl TtlVaultContract {
             }
         }
 
-        if let Some(expiry) = Self::get_passkey_expiry(env.clone(), vault_id, passkey_hash.clone()) {
-            if now > expiry {
-                return Err(ContractError::InvalidPasskey);
-            }
-        }
-        
+        // Issue #549: enforce passkey registration and expiry.
+        Self::validate_passkey_for_checkin(&env, vault_id, &vault, &passkey_hash, now)?;
+
         vault.last_check_in = now;
         
         // Cap TTL at max_ttl_seconds
@@ -3946,6 +3943,57 @@ impl TtlVaultContract {
         }
     }
 
+    // --- Issue #549: Passkey Expiry Enforcement ---
+
+    /// Validates that `passkey_hash` is registered for `vault_id` and not expired.
+    ///
+    /// Registration rules (backwards-compatible):
+    /// - If `VaultPasskeys` list is non-empty, the hash must appear in that list.
+    /// - If the list is empty AND `vault.passkey_hash` is Some, the hash must match it.
+    /// - If both are empty/None, any passkey is accepted (no passkey configured yet).
+    ///
+    /// Expiry: if `PasskeyExpiry` is stored for this hash, it must not be in the past.
+    fn validate_passkey_for_checkin(
+        env: &Env,
+        vault_id: u64,
+        vault: &Vault,
+        passkey_hash: &BytesN<32>,
+        now: u64,
+    ) -> Result<(), ContractError> {
+        let pk_key = DataKey::VaultPasskeys(vault_id);
+        let passkeys: Vec<PasskeyHash> = env
+            .storage()
+            .persistent()
+            .get(&pk_key)
+            .unwrap_or_else(|| Vec::new(env));
+
+        if !passkeys.is_empty() {
+            // Multi-passkey list is configured — hash must be in it.
+            let registered = passkeys.iter().any(|p| &p.hash == passkey_hash);
+            if !registered {
+                return Err(ContractError::InvalidPasskey);
+            }
+        } else if let Some(ref primary) = vault.passkey_hash {
+            // Fallback: single primary passkey on vault struct.
+            if primary != passkey_hash {
+                return Err(ContractError::InvalidPasskey);
+            }
+        }
+        // else: no passkey configured — any hash accepted for backwards compat.
+
+        // Expiry check — applies regardless of registration path.
+        if let Some(expiry) = env.storage().persistent()
+            .get::<DataKey, u64>(&DataKey::PasskeyExpiry(vault_id, passkey_hash.clone()))
+        {
+            if now > expiry {
+                env.events().publish((PASSKEY_EXPIRED_TOPIC, vault_id), passkey_hash.clone());
+                return Err(ContractError::PasskeyExpired);
+            }
+        }
+
+        Ok(())
+    }
+
     // --- Issue #395: Passkey Usage Analytics ---
 
     /// Logs a passkey usage entry for a vault check-in
@@ -5648,12 +5696,9 @@ impl TtlVaultContract {
             if vault.status != ReleaseStatus::Locked {
                 return Err(ContractError::AlreadyReleased);
             }
-            // Passkey expiry check
-            if let Some(expiry) = Self::get_passkey_expiry(env.clone(), vault_id, passkey_hash.clone()) {
-                if now > expiry {
-                    return Err(ContractError::InvalidPasskey);
-                }
-            }
+            // Issue #549: enforce passkey registration and expiry.
+            let vault_inner = Self::load_vault(&env, vault_id);
+            Self::validate_passkey_for_checkin(&env, vault_id, &vault_inner, &passkey_hash, now)?;
             // TTL cap check
             let deadline = now + vault.check_in_interval;
             let max_deadline = now + max_ttl;
@@ -5763,12 +5808,8 @@ impl TtlVaultContract {
 
         let now = env.ledger().timestamp();
 
-        // Passkey expiry check
-        if let Some(expiry) = Self::get_passkey_expiry(env.clone(), vault_id, passkey_hash.clone()) {
-            if now > expiry {
-                return Err(ContractError::InvalidPasskey);
-            }
-        }
+        // Issue #549: enforce passkey registration and expiry.
+        Self::validate_passkey_for_checkin(&env, vault_id, &vault, &passkey_hash, now)?;
 
         // Proof-of-work: hash(vault_id || last_check_in || nonce) must have `difficulty` leading zero bits
         let difficulty = difficulty.min(20); // cap at 20 bits

--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -1942,6 +1942,207 @@ impl TtlVaultContract {
         env.storage().persistent().get(&DataKey::VestingPenalty(vault_id))
     }
 
+    // --- Issue #548: Vesting Reversal ---
+
+    /// Initiates a reversible vesting claim, holding tokens in escrow for a grace period.
+    ///
+    /// Unlike `claim_vested_installment` (which transfers immediately), this function
+    /// calculates the claimable amount and stores a `VestingPendingClaim` record without
+    /// transferring any tokens. The vault owner may call `reverse_vesting_claim` within
+    /// `reversal_window_seconds` to cancel. After the window, anyone may call
+    /// `finalize_vesting_claim` to complete the transfer.
+    ///
+    /// Only one pending claim may exist per vault at a time; subsequent calls fail until
+    /// the pending claim is finalized or reversed.
+    ///
+    /// # Arguments
+    /// * `vault_id`               - The released vault with a vesting schedule
+    /// * `reversal_window_seconds`- Grace period in seconds (must be > 0)
+    ///
+    /// # Returns
+    /// The escrowed amount (not yet transferred).
+    ///
+    /// # Errors
+    /// * `ContractError::Paused`              - Contract is paused
+    /// * `ContractError::VestingNotFound`     - No schedule on this vault
+    /// * `ContractError::NothingToClaimYet`   - No installments available
+    /// * `ContractError::VestingAlreadyComplete` - All installments claimed
+    /// * `ContractError::InvalidInterval`     - reversal_window_seconds is 0
+    /// * `ContractError::InvalidAmount`       - A pending claim already exists
+    pub fn initiate_vesting_claim(
+        env: Env,
+        vault_id: u64,
+        reversal_window_seconds: u64,
+    ) -> Result<i128, ContractError> {
+        Self::assert_not_paused(&env);
+        if reversal_window_seconds == 0 {
+            return Err(ContractError::InvalidInterval);
+        }
+        // Block if a pending claim already exists.
+        if env.storage().persistent().has(&DataKey::VestingPendingClaim(vault_id)) {
+            return Err(ContractError::InvalidAmount);
+        }
+
+        let vault = Self::load_vault(&env, vault_id);
+        if vault.status != ReleaseStatus::Released {
+            return Err(ContractError::AlreadyReleased);
+        }
+
+        let mut schedule: VestingSchedule = env
+            .storage().persistent()
+            .get(&DataKey::VestingSchedule(vault_id))
+            .ok_or(ContractError::VestingNotFound)?;
+
+        if schedule.claimed_installments >= schedule.num_installments {
+            return Err(ContractError::VestingAlreadyComplete);
+        }
+
+        let now = env.ledger().timestamp();
+        if now < schedule.start_time {
+            return Err(ContractError::NothingToClaimYet);
+        }
+
+        let elapsed = now - schedule.start_time;
+        let unlocked = ((elapsed / schedule.interval) + 1)
+            .min(schedule.num_installments as u64) as u32;
+        let claimable = unlocked.saturating_sub(schedule.claimed_installments);
+        if claimable == 0 {
+            return Err(ContractError::NothingToClaimYet);
+        }
+
+        let per_installment = schedule.total_amount / schedule.num_installments as i128;
+        let amount = if unlocked >= schedule.num_installments {
+            vault.balance
+        } else {
+            per_installment * claimable as i128
+        };
+
+        let beneficiary = if vault.beneficiaries.is_empty() {
+            vault.beneficiary.clone()
+        } else {
+            vault.beneficiaries.get(0).unwrap().address.clone()
+        };
+
+        let prev_installments_claimed = schedule.claimed_installments;
+
+        // Advance the schedule counter so a second call is blocked until this claim
+        // is finalized or reversed.
+        schedule.claimed_installments = unlocked;
+        let sched_key = DataKey::VestingSchedule(vault_id);
+        let ttl = vault_ttl_ledgers(vault.check_in_interval);
+        env.storage().persistent().set(&sched_key, &schedule);
+        env.storage().persistent().extend_ttl(&sched_key, VAULT_TTL_THRESHOLD, ttl);
+
+        let pending = VestingPendingClaim {
+            amount,
+            beneficiary,
+            initiated_at: now,
+            reversal_deadline: now + reversal_window_seconds,
+            new_installments_claimed: unlocked,
+            prev_installments_claimed,
+        };
+        let pk = DataKey::VestingPendingClaim(vault_id);
+        env.storage().persistent().set(&pk, &pending);
+        env.storage().persistent().extend_ttl(&pk, VAULT_TTL_THRESHOLD, ttl);
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        Ok(amount)
+    }
+
+    /// Reverses a pending vesting claim within the reversal window.
+    ///
+    /// Only the vault owner may call this. The pending claim record is cleared and
+    /// the schedule counter is rolled back so the installments become claimable again.
+    ///
+    /// # Errors
+    /// * `ContractError::NotOwner`            - Caller is not the vault owner
+    /// * `ContractError::VestingReversalNotFound` - No pending claim on this vault
+    /// * `ContractError::VestingReversalExpired`  - Reversal window has closed
+    pub fn reverse_vesting_claim(
+        env: Env,
+        vault_id: u64,
+        caller: Address,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        let vault = Self::load_vault(&env, vault_id);
+        if caller != vault.owner {
+            return Err(ContractError::NotOwner);
+        }
+
+        let pk = DataKey::VestingPendingClaim(vault_id);
+        let pending: VestingPendingClaim = env
+            .storage().persistent()
+            .get(&pk)
+            .ok_or(ContractError::VestingReversalNotFound)?;
+
+        let now = env.ledger().timestamp();
+        if now > pending.reversal_deadline {
+            return Err(ContractError::VestingReversalExpired);
+        }
+
+        // Roll back the schedule counter so these installments can be claimed again.
+        let sched_key = DataKey::VestingSchedule(vault_id);
+        if let Some(mut schedule) = env.storage().persistent()
+            .get::<DataKey, VestingSchedule>(&sched_key)
+        {
+            schedule.claimed_installments = pending.prev_installments_claimed;
+            let ttl = vault_ttl_ledgers(vault.check_in_interval);
+            env.storage().persistent().set(&sched_key, &schedule);
+            env.storage().persistent().extend_ttl(&sched_key, VAULT_TTL_THRESHOLD, ttl);
+        }
+
+        env.storage().persistent().remove(&pk);
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((VESTING_REVERSED_TOPIC, vault_id), pending.amount);
+        Ok(())
+    }
+
+    /// Finalizes a pending vesting claim after the reversal window has closed.
+    ///
+    /// Anyone may call this. Transfers the escrowed amount to the beneficiary and
+    /// clears the pending claim record.
+    ///
+    /// # Errors
+    /// * `ContractError::VestingReversalNotFound` - No pending claim on this vault
+    /// * `ContractError::InvalidInterval`         - Reversal window has not yet closed
+    pub fn finalize_vesting_claim(env: Env, vault_id: u64) -> Result<i128, ContractError> {
+        Self::assert_not_paused(&env);
+
+        let pk = DataKey::VestingPendingClaim(vault_id);
+        let pending: VestingPendingClaim = env
+            .storage().persistent()
+            .get(&pk)
+            .ok_or(ContractError::VestingReversalNotFound)?;
+
+        let now = env.ledger().timestamp();
+        if now <= pending.reversal_deadline {
+            return Err(ContractError::InvalidInterval);
+        }
+
+        let mut vault = Self::load_vault(&env, vault_id);
+        if vault.balance < pending.amount {
+            return Err(ContractError::InsufficientBalance);
+        }
+
+        let token_client = token::Client::new(&env, &vault.token_address);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &pending.beneficiary,
+            &pending.amount,
+        );
+
+        vault.balance -= pending.amount;
+        Self::save_vault(&env, vault_id, &vault);
+        env.storage().persistent().remove(&pk);
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((VESTING_FINALIZED_TOPIC, vault_id), pending.amount);
+        Ok(pending.amount)
+    }
+
+    /// Returns the pending vesting claim for a vault, if one exists.
+    pub fn get_pending_vesting_claim(env: Env, vault_id: u64) -> Option<VestingPendingClaim> {
+        env.storage().persistent().get(&DataKey::VestingPendingClaim(vault_id))
+    }
+
     /// Claims all vested installments that have become available since the last claim.
     ///
     /// The vault must have been released (trigger_release called) and a vesting schedule

--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -3943,6 +3943,109 @@ impl TtlVaultContract {
         }
     }
 
+    // --- Issue #550: Passkey Compromise Detection ---
+
+    /// Reports a passkey as compromised. Subsequent check-ins using that hash
+    /// will be rejected with `PasskeyCompromised`.
+    ///
+    /// # Errors
+    /// * `ContractError::NotOwner` - Caller is not the vault owner
+    pub fn report_passkey_compromise(
+        env: Env,
+        vault_id: u64,
+        caller: Address,
+        passkey_hash: BytesN<32>,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        let vault = Self::load_vault(&env, vault_id);
+        if caller != vault.owner {
+            return Err(ContractError::NotOwner);
+        }
+        let key = DataKey::CompromisedPasskeys(vault_id);
+        let mut set: Vec<BytesN<32>> = env
+            .storage().persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(&env));
+        // Idempotent — don't add duplicates.
+        if !set.iter().any(|h| h == passkey_hash) {
+            set.push_back(passkey_hash.clone());
+            let ttl = vault_ttl_ledgers(vault.check_in_interval);
+            env.storage().persistent().set(&key, &set);
+            env.storage().persistent().extend_ttl(&key, VAULT_TTL_THRESHOLD, ttl);
+        }
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((PASSKEY_COMPROMISED_TOPIC, vault_id), passkey_hash);
+        Ok(())
+    }
+
+    /// Clears a previously reported passkey compromise, allowing the passkey to be used again.
+    ///
+    /// # Errors
+    /// * `ContractError::NotOwner` - Caller is not the vault owner
+    pub fn clear_passkey_compromise(
+        env: Env,
+        vault_id: u64,
+        caller: Address,
+        passkey_hash: BytesN<32>,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        let vault = Self::load_vault(&env, vault_id);
+        if caller != vault.owner {
+            return Err(ContractError::NotOwner);
+        }
+        let key = DataKey::CompromisedPasskeys(vault_id);
+        let set: Vec<BytesN<32>> = env
+            .storage().persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(&env));
+        let mut new_set: Vec<BytesN<32>> = Vec::new(&env);
+        for h in set.iter() {
+            if h != passkey_hash {
+                new_set.push_back(h);
+            }
+        }
+        let ttl = vault_ttl_ledgers(vault.check_in_interval);
+        env.storage().persistent().set(&key, &new_set);
+        env.storage().persistent().extend_ttl(&key, VAULT_TTL_THRESHOLD, ttl);
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        Ok(())
+    }
+
+    /// Returns whether a passkey has been flagged as compromised for a vault.
+    pub fn is_passkey_compromised(env: Env, vault_id: u64, passkey_hash: BytesN<32>) -> bool {
+        let key = DataKey::CompromisedPasskeys(vault_id);
+        let set: Vec<BytesN<32>> = env
+            .storage().persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(&env));
+        set.iter().any(|h| h == passkey_hash)
+    }
+
+    /// Inspects the recent passkey usage log and emits a `pk_comp` advisory event
+    /// if 3 or more of the last 5 entries used different passkey hashes.
+    fn detect_passkey_anomaly(env: &Env, vault_id: u64, current_hash: &BytesN<32>) {
+        let usage: Vec<PasskeyUsageEntry> = env
+            .storage().persistent()
+            .get(&DataKey::PasskeyUsage(vault_id))
+            .unwrap_or_else(|| Vec::new(env));
+        if usage.len() < 3 {
+            return;
+        }
+        let window_start = usage.len().saturating_sub(5);
+        let mut distinct = 0u32;
+        let mut prev: Option<BytesN<32>> = None;
+        for i in window_start..usage.len() {
+            let entry = usage.get(i as u32).unwrap();
+            if prev.as_ref() != Some(&entry.passkey_hash) {
+                distinct += 1;
+                prev = Some(entry.passkey_hash.clone());
+            }
+        }
+        if distinct >= 3 {
+            env.events().publish((PASSKEY_COMPROMISED_TOPIC, vault_id), current_hash.clone());
+        }
+    }
+
     // --- Issue #549: Passkey Expiry Enforcement ---
 
     /// Validates that `passkey_hash` is registered for `vault_id` and not expired.
@@ -3981,6 +4084,19 @@ impl TtlVaultContract {
         }
         // else: no passkey configured — any hash accepted for backwards compat.
 
+        // Issue #550: block check-in if passkey is flagged as compromised.
+        {
+            let comp_key = DataKey::CompromisedPasskeys(vault_id);
+            let compromised: Vec<BytesN<32>> = env
+                .storage().persistent()
+                .get(&comp_key)
+                .unwrap_or_else(|| Vec::new(env));
+            if compromised.iter().any(|h| &h == passkey_hash) {
+                env.events().publish((PASSKEY_COMPROMISED_TOPIC, vault_id), passkey_hash.clone());
+                return Err(ContractError::PasskeyCompromised);
+            }
+        }
+
         // Expiry check — applies regardless of registration path.
         if let Some(expiry) = env.storage().persistent()
             .get::<DataKey, u64>(&DataKey::PasskeyExpiry(vault_id, passkey_hash.clone()))
@@ -3996,19 +4112,22 @@ impl TtlVaultContract {
 
     // --- Issue #395: Passkey Usage Analytics ---
 
-    /// Logs a passkey usage entry for a vault check-in
+    /// Logs a passkey usage entry for a vault check-in and runs anomaly detection.
     fn log_passkey_usage(env: &Env, vault_id: u64, passkey_hash: &BytesN<32>, timestamp: u64) {
         let mut usage: Vec<PasskeyUsageEntry> = env
             .storage()
             .persistent()
             .get(&DataKey::PasskeyUsage(vault_id))
             .unwrap_or(Vec::new(env));
-        
+
+        // Issue #550: detect anomalous passkey switching before appending this entry.
+        Self::detect_passkey_anomaly(env, vault_id, passkey_hash);
+
         usage.push_back(PasskeyUsageEntry {
             passkey_hash: passkey_hash.clone(),
             timestamp,
         });
-        
+
         let key = DataKey::PasskeyUsage(vault_id);
         env.storage().persistent().set(&key, &usage);
         let ttl = vault_ttl_ledgers(Self::load_vault(env, vault_id).check_in_interval);

--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -12,8 +12,8 @@ use types::{
     ArchivedVaultInfo, OwnershipTransferRequest, PendingBeneficiaryUpdate, AuditEntry, MultiSigConfig, MultiSigProposal,
     MultiSigOperation, ProposalStatus, PasskeyUsageEntry, BeneficiaryStatus, BridgeConfig,
     StateTransitionEntry, OwnershipProof, IntegrityReport, VaultStatusSummary,
-    TtlBorrowRecord,
-    GeoCheckInEntry,
+    TtlBorrowRecord, GeoCheckInEntry, ProofOfLifeEntry, ReleaseVoteEntry,
+    VestingPenaltyConfig, VestingPendingClaim,
     EXPIRY_WARNING_THRESHOLD, BENEFICIARY_UPDATED_TOPIC, CANCEL_TOPIC, CHECK_IN_TOPIC,
     CLAIM_VEST_TOPIC, DEPOSIT_TOPIC, OWNERSHIP_TOPIC, PAUSE_TOPIC, PING_EXPIRY_TOPIC,
     RELEASE_TOPIC, SET_BENEFICIARIES_TOPIC, SET_MAX_INTERVAL_TOPIC, SET_MIN_INTERVAL_TOPIC,
@@ -36,8 +36,9 @@ use types::{
     DELEGATE_CHECKIN_TOPIC, REVOKE_DELEGATE_TOPIC, CHECKIN_POW_TOPIC, TTL_PREDICTED_TOPIC,
     BATCH_CHECKIN_TOPIC,
     STATE_TRANSITION_TOPIC, OWNERSHIP_PROOF_TOPIC, INTEGRITY_TOPIC, BATCH_STATUS_TOPIC,
-    ProofOfLifeEntry, ReleaseVoteEntry,
     PROOF_OF_LIFE_TOPIC, RELEASE_VOTE_TOPIC, RELEASE_VOTE_PASSED_TOPIC,
+    VESTING_PENALTY_TOPIC, VESTING_REVERSED_TOPIC, VESTING_FINALIZED_TOPIC,
+    PASSKEY_EXPIRED_TOPIC, PASSKEY_COMPROMISED_TOPIC,
 };
 
 #[cfg(test)]
@@ -148,6 +149,14 @@ pub enum ContractError {
     ProofOfLifeExpired = 52,
     AlreadyVoted = 53,
     VotingNotEnabled = 54,
+    CheckInTooFrequent = 55,
+    TtlBorrowNotFound = 56,
+    TtlBorrowAlreadyRepaid = 57,
+    InsufficientTtlToAccelerate = 58,
+    PasskeyExpired = 59,
+    VestingReversalExpired = 60,
+    VestingReversalNotFound = 61,
+    PasskeyCompromised = 62,
 }
 
 #[contract]
@@ -1885,6 +1894,54 @@ impl TtlVaultContract {
         env.storage().persistent().get(&DataKey::VestingSchedule(vault_id))
     }
 
+    /// Sets a late-claim penalty for a vault's vesting schedule.
+    ///
+    /// If a beneficiary claims an installment more than `grace_period_seconds` after
+    /// it unlocked, the payout is reduced by `penalty_bps` basis points (e.g. 500 = 5%).
+    ///
+    /// # Arguments
+    /// * `vault_id`             - The vault with an attached vesting schedule
+    /// * `caller`               - Must be the vault owner
+    /// * `penalty_bps`          - Penalty in basis points (1–10000)
+    /// * `grace_period_seconds` - Seconds after unlock before the penalty applies
+    ///
+    /// # Errors
+    /// * `ContractError::NotOwner`         - Caller is not the vault owner
+    /// * `ContractError::VestingNotFound`  - No vesting schedule exists
+    /// * `ContractError::InvalidBps`       - penalty_bps is 0 or > 10000
+    pub fn set_vesting_penalty(
+        env: Env,
+        vault_id: u64,
+        caller: Address,
+        penalty_bps: u32,
+        grace_period_seconds: u64,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        let vault = Self::load_vault(&env, vault_id);
+        if caller != vault.owner {
+            return Err(ContractError::NotOwner);
+        }
+        if !env.storage().persistent().has(&DataKey::VestingSchedule(vault_id)) {
+            return Err(ContractError::VestingNotFound);
+        }
+        if penalty_bps == 0 || penalty_bps > 10_000 {
+            return Err(ContractError::InvalidBps);
+        }
+        let config = VestingPenaltyConfig { penalty_bps, grace_period_seconds };
+        let key = DataKey::VestingPenalty(vault_id);
+        let ttl = vault_ttl_ledgers(vault.check_in_interval);
+        env.storage().persistent().set(&key, &config);
+        env.storage().persistent().extend_ttl(&key, VAULT_TTL_THRESHOLD, ttl);
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((VESTING_PENALTY_TOPIC, vault_id), (penalty_bps, grace_period_seconds));
+        Ok(())
+    }
+
+    /// Returns the vesting penalty config for a vault, if one has been set.
+    pub fn get_vesting_penalty(env: Env, vault_id: u64) -> Option<VestingPenaltyConfig> {
+        env.storage().persistent().get(&DataKey::VestingPenalty(vault_id))
+    }
+
     /// Claims all vested installments that have become available since the last claim.
     ///
     /// The vault must have been released (trigger_release called) and a vesting schedule
@@ -1942,11 +1999,44 @@ impl TtlVaultContract {
         // Calculate payout: each installment = total / num_installments,
         // last installment absorbs remainder.
         let per_installment = schedule.total_amount / schedule.num_installments as i128;
-        let amount = if unlocked >= schedule.num_installments {
-            // Final batch: pay out everything remaining in the vault
+        let base_amount = if unlocked >= schedule.num_installments {
             vault.balance
         } else {
             per_installment * claimable as i128
+        };
+
+        // Issue #547: apply late-claim penalty to installments claimed after grace period.
+        let amount = if let Some(penalty_cfg) = env.storage().persistent()
+            .get::<DataKey, VestingPenaltyConfig>(&DataKey::VestingPenalty(vault_id))
+        {
+            // Count how many of the claimable installments are "late".
+            // Installment i (1-based) unlocks at start_time + (i-1)*interval.
+            let late_cutoff = now.saturating_sub(penalty_cfg.grace_period_seconds);
+            let mut late_count = 0u32;
+            for i in (schedule.claimed_installments + 1)..=unlocked {
+                let unlock_time = schedule.start_time
+                    .saturating_add((i as u64 - 1).saturating_mul(schedule.interval));
+                if unlock_time < late_cutoff {
+                    late_count += 1;
+                }
+            }
+            if late_count > 0 {
+                let on_time_count = claimable.saturating_sub(late_count);
+                let on_time_amount = per_installment * on_time_count as i128;
+                let late_amount = per_installment * late_count as i128;
+                let penalty = late_amount * penalty_cfg.penalty_bps as i128 / 10_000;
+                let penalized = on_time_amount + late_amount - penalty;
+                // For the final batch keep vault.balance as ceiling to avoid dust mismatch.
+                if unlocked >= schedule.num_installments {
+                    penalized.min(vault.balance)
+                } else {
+                    penalized
+                }
+            } else {
+                base_amount
+            }
+        } else {
+            base_amount
         };
 
         if vault.balance < amount {
@@ -1984,6 +2074,14 @@ impl TtlVaultContract {
         vault.balance -= amount;
         schedule.claimed_installments = unlocked;
         Self::save_vault(&env, vault_id, &vault);
+
+        // Emit penalty event if the payout was reduced.
+        if amount < base_amount {
+            env.events().publish(
+                (VESTING_PENALTY_TOPIC, vault_id),
+                (base_amount - amount, amount),
+            );
+        }
 
         let sched_key = DataKey::VestingSchedule(vault_id);
         let ttl = vault_ttl_ledgers(vault.check_in_interval);
@@ -3144,12 +3242,6 @@ impl TtlVaultContract {
         env.storage().persistent().extend_ttl(&key, VAULT_TTL_THRESHOLD, ttl);
     }
 
-    /// Stub: records check-in timestamp for adaptive interval logic.
-    fn record_check_in_history(_env: &Env, _vault_id: u64, _timestamp: u64) {}
-
-    /// Stub: updates check-in streak counter.
-    fn update_check_in_streak(_env: &Env, _vault_id: u64, _vault: &Vault, _now: u64) {}
-
     /// Returns the vault activity log (alias for get_vault_audit_log).
     pub fn get_vault_activity_log(env: Env, vault_id: u64) -> Vec<AuditEntry> {
         Self::get_vault_audit_log(env, vault_id)
@@ -4299,6 +4391,18 @@ impl TtlVaultContract {
                 v.push_back(vault.beneficiary);
                 v
             })
+    }
+
+    /// Returns the current active delegate (last in the chain) or None if no delegation.
+    fn get_delegated_beneficiary(env: Env, vault_id: u64) -> Option<Address> {
+        let chain: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::BeneficiaryDelegationChain(vault_id))?;
+        if chain.len() <= 1 {
+            return None;
+        }
+        chain.get(chain.len() - 1)
     }
 
     // --- Issue #402: Withdrawal Scheduling ---

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -606,7 +606,7 @@ pub struct VestingPenaltyConfig {
 }
 
 /// Pending vesting claim — Issue #548.
-/// Created by `claim_vested_installment`; tokens remain escrowed until
+/// Created by `initiate_vesting_claim`; tokens remain escrowed until
 /// `finalize_vesting_claim` is called or the owner calls `reverse_vesting_claim`.
 #[contracttype]
 #[derive(Clone)]
@@ -617,6 +617,8 @@ pub struct VestingPendingClaim {
     pub initiated_at: u64,
     /// Timestamp after which only finalization is possible (reversal window closed).
     pub reversal_deadline: u64,
-    /// Schedule counter position at the time of this claim (for idempotency).
-    pub installments_claimed: u32,
+    /// New schedule counter value set when this claim was initiated.
+    pub new_installments_claimed: u32,
+    /// Previous schedule counter value (restored on reversal).
+    pub prev_installments_claimed: u32,
 }

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -85,11 +85,15 @@ pub const PROOF_OF_LIFE_TOPIC: Symbol = symbol_short!("pol_sub");
 pub const RELEASE_VOTE_TOPIC: Symbol = symbol_short!("rel_vote");
 pub const RELEASE_VOTE_PASSED_TOPIC: Symbol = symbol_short!("vote_ok");
 
-// Previously missing — used by lib.rs internal helpers
-pub const STATE_TRANSITION_TOPIC: Symbol = symbol_short!("st_trans");
-pub const OWNERSHIP_PROOF_TOPIC: Symbol = symbol_short!("own_prf");
-pub const INTEGRITY_TOPIC: Symbol = symbol_short!("integ");
-pub const BATCH_STATUS_TOPIC: Symbol = symbol_short!("bat_stat");
+// Issue #547: vesting penalty applied
+pub const VESTING_PENALTY_TOPIC: Symbol = symbol_short!("vest_pen");
+// Issue #548: vesting claim reversed / finalized
+pub const VESTING_REVERSED_TOPIC: Symbol = symbol_short!("vest_rev");
+pub const VESTING_FINALIZED_TOPIC: Symbol = symbol_short!("vest_fin");
+// Issue #549: passkey expired during check-in
+pub const PASSKEY_EXPIRED_TOPIC: Symbol = symbol_short!("pk_expd");
+// Issue #550: passkey compromise detected or reported
+pub const PASSKEY_COMPROMISED_TOPIC: Symbol = symbol_short!("pk_comp");
 
 // Issue: TTL Borrowing
 pub const TTL_BORROW_TOPIC: Symbol = symbol_short!("ttl_bor");
@@ -180,6 +184,19 @@ pub enum DataKey {
     // Issue #499: beneficiary release votes
     ReleaseVotes(u64),
     ReleaseVoteThreshold(u64),
+    // TTL Borrowing
+    TtlBorrow(u64),
+    // Check-in rate limiting
+    MinCheckInCooldown,
+    LastCheckInTime(u64),
+    // Geographic check-in tracking
+    CheckInGeoLog(u64),
+    // Issue #547: vesting penalty config per vault
+    VestingPenalty(u64),
+    // Issue #548: pending vesting claim awaiting finalization or reversal
+    VestingPendingClaim(u64),
+    // Issue #550: set of passkeys flagged as compromised
+    CompromisedPasskeys(u64),
 }
 
 /// Check-in history entry for TTL prediction - Issue #482
@@ -536,4 +553,70 @@ pub struct TtlPool {
 pub struct BiometricEntry {
     pub credential_hash: BytesN<32>,
     pub added_at: u64,
+}
+
+/// TTL borrow record — tracks temporary TTL transfers between vaults.
+#[contracttype]
+#[derive(Clone)]
+pub struct TtlBorrowRecord {
+    pub lender_vault_id: u64,
+    pub borrower_vault_id: u64,
+    pub borrowed_seconds: u64,
+    pub borrowed_at: u64,
+    pub repaid: bool,
+}
+
+/// Geographic check-in entry — stores location metadata for a check-in.
+#[contracttype]
+#[derive(Clone)]
+pub struct GeoCheckInEntry {
+    pub latitude_micro: i64,
+    pub longitude_micro: i64,
+    pub country_code: String,
+    pub timestamp: u64,
+}
+
+/// Beneficiary proof-of-life entry — confirms beneficiary is reachable.
+#[contracttype]
+#[derive(Clone)]
+pub struct ProofOfLifeEntry {
+    pub beneficiary: Address,
+    pub submitted_at: u64,
+    pub valid_until: u64,
+}
+
+/// Beneficiary release vote — records an approval or rejection vote.
+#[contracttype]
+#[derive(Clone)]
+pub struct ReleaseVoteEntry {
+    pub voter: Address,
+    pub approve: bool,
+    pub voted_at: u64,
+}
+
+/// Vesting penalty config — Issue #547.
+/// Applied to installments claimed after `grace_period_seconds` past their unlock time.
+#[contracttype]
+#[derive(Clone)]
+pub struct VestingPenaltyConfig {
+    /// Penalty in basis points applied to each late installment (e.g. 500 = 5%).
+    pub penalty_bps: u32,
+    /// Seconds after an installment's unlock time before the penalty kicks in.
+    pub grace_period_seconds: u64,
+}
+
+/// Pending vesting claim — Issue #548.
+/// Created by `claim_vested_installment`; tokens remain escrowed until
+/// `finalize_vesting_claim` is called or the owner calls `reverse_vesting_claim`.
+#[contracttype]
+#[derive(Clone)]
+pub struct VestingPendingClaim {
+    /// Escrowed token amount (not yet transferred to beneficiary).
+    pub amount: i128,
+    pub beneficiary: Address,
+    pub initiated_at: u64,
+    /// Timestamp after which only finalization is possible (reversal window closed).
+    pub reversal_deadline: u64,
+    /// Schedule counter position at the time of this claim (for idempotency).
+    pub installments_claimed: u32,
 }

--- a/docs/passkeys.md
+++ b/docs/passkeys.md
@@ -67,3 +67,82 @@ is_valid_biometric(vault_id: u64, credential_hash: BytesN<32>) -> bool
 - Biometric check-in respects contract and vault pause state
 - Raw biometric data is never stored on-chain — only the hash commitment
 - Check-in on a Released vault is rejected with `AlreadyReleased`
+
+## Passkey Expiry Enforcement (Issue #549)
+
+Every call to `check_in`, `check_in_with_pow`, and `batch_check_in_v2` now
+enforces two sequential validations before updating `last_check_in`:
+
+### 1. Registration Check
+
+| Passkey state | Behaviour |
+|---|---|
+| `VaultPasskeys` list non-empty | Hash **must** appear in the list; otherwise `InvalidPasskey` |
+| List empty, `vault.passkey_hash` is `Some` | Hash **must** match the primary passkey; otherwise `InvalidPasskey` |
+| Both empty/None | Any hash accepted (no passkey configured — backwards compatible) |
+
+### 2. Expiry Check
+
+If `extend_passkey_expiry` was previously called for this hash, the stored expiry
+timestamp is compared with the current ledger time.  If `now > expiry`:
+
+- A `pk_expd` event is emitted with the passkey hash.
+- The call returns `PasskeyExpired` (error code 59) — distinct from `InvalidPasskey`.
+
+### Errors
+
+| Code | Name | Meaning |
+|------|------|---------|
+| 26 | `InvalidPasskey` | Passkey not registered for this vault |
+| 59 | `PasskeyExpired`  | Passkey registration has expired |
+
+## Passkey Compromise Detection (Issue #550)
+
+See the dedicated compromise detection section below.
+
+### `report_passkey_compromise`
+
+```rust
+fn report_passkey_compromise(
+    env: Env,
+    vault_id: u64,
+    caller: Address,    // must be vault owner
+    passkey_hash: BytesN<32>,
+) -> Result<(), ContractError>
+```
+
+Manually flags a passkey as compromised. Subsequent `check_in` calls using that
+hash return `PasskeyCompromised` (error 62).
+
+### `clear_passkey_compromise`
+
+```rust
+fn clear_passkey_compromise(
+    env: Env,
+    vault_id: u64,
+    caller: Address,    // must be vault owner
+    passkey_hash: BytesN<32>,
+) -> Result<(), ContractError>
+```
+
+Removes the compromise flag, allowing the passkey to be used again.
+
+### `is_passkey_compromised`
+
+```rust
+fn is_passkey_compromised(env: Env, vault_id: u64, passkey_hash: BytesN<32>) -> bool
+```
+
+### Automatic Detection
+
+During every `check_in`, the contract inspects the last 5 passkey usage entries.
+If 3 or more **consecutive** entries used **different** passkey hashes, a
+`pk_comp` event is emitted as an advisory alert (the check-in is not blocked).
+Owners should monitor for this event and rotate or revoke suspected passkeys.
+
+### Events
+
+| Topic | Data | Emitted when |
+|---|---|---|
+| `pk_expd` | `passkey_hash` | Expired passkey used in check-in |
+| `pk_comp` | `(vault_id, passkey_hash)` | Compromise detected or reported |

--- a/docs/vesting-schedules.md
+++ b/docs/vesting-schedules.md
@@ -112,6 +112,31 @@ client.set_vesting_schedule(&vault_id, &owner, &start, &interval, &4u32);
 client.claim_vested_installment(&vault_id);
 ```
 
+## Vesting Reversal (Issue #548)
+
+The vault owner may configure a reversal grace period on a per-claim basis. Instead of calling `claim_vested_installment` (which transfers immediately), use the 2-phase flow:
+
+1. **`initiate_vesting_claim(vault_id, reversal_window_seconds)`** — calculates the claimable amount and holds it in escrow inside the contract. The schedule counter is advanced to block double-initiation. Returns the escrowed amount.
+
+2. **`reverse_vesting_claim(vault_id, caller)`** (owner only) — cancels the pending claim within the reversal window. The schedule counter is rolled back so the installments become claimable again.
+
+3. **`finalize_vesting_claim(vault_id)`** (anyone) — after the reversal window closes, completes the token transfer to the beneficiary.
+
+### API Reference
+
+```rust
+fn initiate_vesting_claim(env: Env, vault_id: u64, reversal_window_seconds: u64) -> Result<i128, ContractError>
+fn reverse_vesting_claim(env: Env, vault_id: u64, caller: Address) -> Result<(), ContractError>
+fn finalize_vesting_claim(env: Env, vault_id: u64) -> Result<i128, ContractError>
+fn get_pending_vesting_claim(env: Env, vault_id: u64) -> Option<VestingPendingClaim>
+```
+
+| Error | Code | Meaning |
+|-------|------|---------|
+| `VestingReversalNotFound` | 61 | No pending claim on this vault |
+| `VestingReversalExpired`  | 60 | Reversal window has already closed |
+| `InvalidAmount`           |  5 | A pending claim already exists (call finalize first) |
+
 ## Late-Claim Penalty (Issue #547)
 
 The vault owner may attach a penalty config to a vesting schedule. If a beneficiary claims an installment more than `grace_period_seconds` after it unlocked, the payout for that installment is reduced by `penalty_bps` basis points.

--- a/docs/vesting-schedules.md
+++ b/docs/vesting-schedules.md
@@ -112,9 +112,45 @@ client.set_vesting_schedule(&vault_id, &owner, &start, &interval, &4u32);
 client.claim_vested_installment(&vault_id);
 ```
 
+## Late-Claim Penalty (Issue #547)
+
+The vault owner may attach a penalty config to a vesting schedule. If a beneficiary claims an installment more than `grace_period_seconds` after it unlocked, the payout for that installment is reduced by `penalty_bps` basis points.
+
+### `set_vesting_penalty`
+
+```rust
+fn set_vesting_penalty(
+    env: Env,
+    vault_id: u64,
+    caller: Address,           // must be vault owner
+    penalty_bps: u32,          // 1–10000 (e.g. 500 = 5%)
+    grace_period_seconds: u64, // seconds after unlock before penalty applies
+) -> Result<(), ContractError>
+```
+
+### `get_vesting_penalty`
+
+```rust
+fn get_vesting_penalty(env: Env, vault_id: u64) -> Option<VestingPenaltyConfig>
+```
+
+### Penalty Calculation
+
+For each claimable installment:
+- If `now > unlock_time + grace_period_seconds`, the installment is "late".
+- Late installment payout = `per_installment * (1 - penalty_bps / 10_000)`.
+- On-time installments receive the full `per_installment` amount.
+
+Example: 5% penalty, no grace period, 3 late installments of 100 each:
+- Full payout would be 300.
+- Penalized payout: 300 - 15 = 285.
+
 ## Events
 
 | Topic | Data | Emitted when |
 |-------|------|--------------|
 | `set_vest` | `(start_time, interval, num_installments, total_amount)` | Schedule attached |
 | `clm_vest` | `(beneficiary, amount, installments_unlocked)` | Installment claimed (one event per beneficiary) |
+| `vest_pen` | `(penalty_amount, net_payout)` | Late penalty applied during claim |
+| `vest_rev` | `(vault_id, amount)` | Vesting claim reversed by owner within grace period |
+| `vest_fin` | `(vault_id, amount)` | Pending vesting claim finalized after reversal window |


### PR DESCRIPTION
## Summary

Implements four linked issues that harden vesting controls and passkey security across the TTL-Vault contract.

---

### #547 — Add Vesting Penalty for Late Claims

- Added `VestingPenaltyConfig` type (`penalty_bps` + `grace_period_seconds`)
- Added `set_vesting_penalty` (owner-only) and `get_vesting_penalty` contract functions
- Modified `claim_vested_installment` to compute a per-installment late penalty: for each claimable installment whose unlock time + grace period has passed, the payout is reduced by `penalty_bps` basis points
- Emits `vest_pen` event with `(penalty_amount, net_payout)` whenever a deduction is applied
- Updated `docs/vesting-schedules.md` with penalty API reference and calculation example

Closes #547

---

### #548 — Implement Vesting Reversal within Grace Period

Introduces a 2-phase vesting claim flow so the vault owner can cancel a claim before tokens leave the contract:

- Added `VestingPendingClaim` type tracking `amount`, `beneficiary`, `reversal_deadline`, `new_installments_claimed`, and `prev_installments_claimed` (for clean rollback)
- **`initiate_vesting_claim(vault_id, reversal_window_seconds)`** — calculates the claimable amount, escrows tokens inside the contract (no transfer yet), and advances the schedule counter to block double-initiation. Returns the escrowed amount.
- **`reverse_vesting_claim(vault_id, caller)`** (owner-only) — cancels within the window; rolls `claimed_installments` back to `prev_installments_claimed` so the installments become claimable again. Emits `vest_rev`.
- **`finalize_vesting_claim(vault_id)`** (anyone, after window) — completes the transfer to the beneficiary and clears the record. Emits `vest_fin`.
- **`get_pending_vesting_claim`** view
- Updated `docs/vesting-schedules.md` with 2-phase API, error table, and flow description

Closes #548

---

### #549 — Implement Passkey Expiry Enforcement in `check_in`

- Added `validate_passkey_for_checkin` private helper that enforces two rules before any check-in succeeds:
  1. **Registration**: if the `VaultPasskeys` list is non-empty, the supplied hash must appear in it; if only `vault.passkey_hash` is set, the hash must match it; both empty means no passkey configured (backwards compatible — any hash accepted)
  2. **Expiry**: if `PasskeyExpiry` is stored for this hash and `now > expiry`, emits `pk_expd` event and returns `PasskeyExpired` (error 59) — a distinct, descriptive error separate from the generic `InvalidPasskey`
- Replaced the ad-hoc expiry-only check in `check_in`, `check_in_with_pow`, and `batch_check_in_v2` with the unified `validate_passkey_for_checkin` call
- Updated `docs/passkeys.md` with enforcement rules, error table, and a registration-check matrix

Closes #549

---

### #550 — Add Passkey Compromise Detection

- **`report_passkey_compromise(vault_id, caller, passkey_hash)`** (owner-only) — flags a passkey hash in a per-vault `CompromisedPasskeys` set. Subsequent `check_in` calls with that hash are blocked with `PasskeyCompromised` (error 62) and emit a `pk_comp` event
- **`clear_passkey_compromise(vault_id, caller, passkey_hash)`** (owner-only) — removes the flag so the passkey can be used again
- **`is_passkey_compromised(vault_id, passkey_hash)`** view
- **`detect_passkey_anomaly`** private helper — inspects the last 5 passkey usage log entries; if 3 or more consecutive entries used **distinct** hashes (attacker cycling through keys), emits an advisory `pk_comp` event without blocking the check-in
- Anomaly detection is wired into `log_passkey_usage` so it runs automatically on every `check_in`, `check_in_with_pow`, and `batch_check_in_v2` call
- Added `CompromisedPasskeys(u64)` `DataKey` variant
- Updated `docs/passkeys.md` with compromise detection API and event table

Closes #550

---

## Foundation fixes (bundled with #547)

The contract had several missing pieces that caused compilation errors; fixed as part of this PR:

- Removed duplicate `STATE_TRANSITION_TOPIC`, `OWNERSHIP_PROOF_TOPIC`, `INTEGRITY_TOPIC`, `BATCH_STATUS_TOPIC` constant definitions
- Added missing `DataKey` variants: `TtlBorrow(u64)`, `MinCheckInCooldown`, `LastCheckInTime(u64)`, `CheckInGeoLog(u64)`
- Added missing struct types: `TtlBorrowRecord`, `GeoCheckInEntry`, `ProofOfLifeEntry`, `ReleaseVoteEntry`
- Added missing `ContractError` variants (55–58): `CheckInTooFrequent`, `TtlBorrowNotFound`, `TtlBorrowAlreadyRepaid`, `InsufficientTtlToAccelerate`
- Added `get_delegated_beneficiary` helper (used by `execute_scheduled_withdrawal`)
- Removed duplicate stub `record_check_in_history` / `update_check_in_streak` function definitions

## Files Changed

| File | Changes |
|------|---------|
| `contracts/ttl_vault/src/types.rs` | New types, DataKey variants, topic constants |
| `contracts/ttl_vault/src/lib.rs` | All contract logic for all 4 issues + foundation fixes |
| `docs/vesting-schedules.md` | Penalty + reversal API docs, updated event table |
| `docs/passkeys.md` | Expiry enforcement + compromise detection docs, event table |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)