### PR TITLE
contracts(ttl_vault): use panic_with_error! instead of panic! for saf…

### DIFF
--- a/contracts/ttl_vault/src/caps.rs
+++ b/contracts/ttl_vault/src/caps.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, symbol_short, Address, Env, Map};
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Map, panic_with_error};
 
 pub const CAP_SET_TOPIC: soroban_sdk::Symbol = symbol_short!("cap_set");
 pub const CAP_ENFORCED_TOPIC: soroban_sdk::Symbol = symbol_short!("cap_enf");
@@ -28,7 +28,7 @@ pub enum CapsKey {
 pub fn set_cap(env: &Env, caller: &Address, beneficiary: Address, cap: i128) {
     caller.require_auth();
     if cap <= 0 {
-        panic!("cap must be positive");
+        panic_with_error!(&env, crate::ContractError::InvalidAmount);
     }
 
     let mut caps: Map<Address, i128> = env

--- a/contracts/ttl_vault/src/floors.rs
+++ b/contracts/ttl_vault/src/floors.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, symbol_short, Address, Env, Map};
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Map, panic_with_error};
 
 pub const FLOOR_SET_TOPIC: soroban_sdk::Symbol = symbol_short!("floor_set");
 pub const FLOOR_ENFORCED_TOPIC: soroban_sdk::Symbol = symbol_short!("floor_enf");
@@ -28,7 +28,7 @@ pub enum FloorsKey {
 pub fn set_floor(env: &Env, caller: &Address, beneficiary: Address, floor: i128) {
     caller.require_auth();
     if floor <= 0 {
-        panic!("floor must be positive");
+        panic_with_error!(&env, crate::ContractError::InvalidAmount);
     }
 
     let mut floors: Map<Address, i128> = env

--- a/contracts/ttl_vault/src/matching.rs
+++ b/contracts/ttl_vault/src/matching.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, symbol_short, Address, Env, Map};
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Map, panic_with_error};
 
 pub const MATCH_SET_TOPIC: soroban_sdk::Symbol = symbol_short!("match_set");
 pub const MATCHED_DISTRIBUTION_TOPIC: soroban_sdk::Symbol = symbol_short!("match_dst");
@@ -43,7 +43,7 @@ pub fn set_match(
 ) {
     caller.require_auth();
     if match_bps > 10_000 {
-        panic!("match_bps cannot exceed 10000");
+        panic_with_error!(&env, crate::ContractError::InvalidBps);
     }
 
     let mut matches: Map<Address, MatchPair> = env


### PR DESCRIPTION
Closes #555 

Summary

Scanned repository for panic/TODO markers.
Found raw panic! uses in contracts/ttl_vault/src/caps.rs, contracts/ttl_vault/src/floors.rs, and contracts/ttl_vault/src/matching.rs.
Replaced those panic! calls with panic_with_error! and imported panic_with_error.
Mapped errors: caps/floors → ContractError::InvalidAmount; matching → ContractError::InvalidBps.
Updated the task TODOs to reflect progress.
