### PR TITLE
Add get_beneficiary_count, get_streak_summary, get_next_check_in_dead…

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -2728,6 +2728,15 @@ impl TtlVaultContract {
         Self::try_load_vault(&env, vault_id).map(|vault| vault.beneficiaries.clone())
     }
 
+    /// Returns the number of multi-beneficiaries for a vault.
+    ///
+    /// Returns 0 if no multi-beneficiary list has been set.
+    pub fn get_beneficiary_count(env: Env, vault_id: u64) -> u32 {
+        Self::try_load_vault(&env, vault_id)
+            .map(|vault| vault.beneficiaries.len())
+            .unwrap_or(0)
+    }
+
     // --- Task 4: update_metadata ---
 
     /// Updates the metadata string associated with a vault.
@@ -9021,6 +9030,19 @@ impl TtlVaultContract {
             .unwrap_or(CheckInStreak { current: 0, best: 0, last_timestamp: 0 })
     }
 
+    /// Returns a summary of the check-in streak for a vault, or `None` if no streak record exists.
+    ///
+    /// # Arguments
+    /// * `vault_id` - The unique identifier of the vault
+    ///
+    /// # Returns
+    /// `Some(CheckInStreak)` if a streak record has been set, `None` otherwise
+    pub fn get_streak_summary(env: Env, vault_id: u64) -> Option<CheckInStreak> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CheckInStreak(vault_id))
+    }
+
     // ── Issue #481: Check-In Proof of Work ───────────────────────────────────
 
     /// Performs a check-in with proof-of-work validation.
@@ -9539,6 +9561,41 @@ impl TtlVaultContract {
         env.storage()
             .persistent()
             .get(&DataKey::Hibernation(vault_id))
+    }
+
+    /// Returns the absolute timestamp of the next required check-in for a vault.
+    ///
+    /// Returns `None` if the vault is currently hibernating or has already expired.
+    ///
+    /// # Arguments
+    /// * `vault_id` - The unique identifier of the vault
+    ///
+    /// # Returns
+    /// `Some(timestamp)` if the vault is active and within its check-in window,
+    /// `None` if hibernating or expired
+    pub fn get_next_check_in_deadline(env: Env, vault_id: u64) -> Option<u64> {
+        let vault = Self::load_vault(&env, vault_id);
+        let now = env.ledger().timestamp();
+
+        // If hibernating and still inside the hibernation window, return None
+        if let Some(h) = env.storage()
+            .persistent()
+            .get::<DataKey, HibernationEntry>(&DataKey::Hibernation(vault_id))
+        {
+            let elapsed = now.saturating_sub(h.started_at).min(h.duration_seconds);
+            if elapsed < h.duration_seconds {
+                return None;
+            }
+        }
+
+        let deadline = vault.last_check_in.saturating_add(vault.check_in_interval);
+
+        // If already expired, return None
+        if now >= deadline {
+            return None;
+        }
+
+        Some(deadline)
     }
 
     fn get_delegated_beneficiary(env: &Env, vault_id: u64) -> Option<Address> {

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -5826,3 +5826,191 @@ fn test_cannot_reverse_twice() {
     let result = client.try_reverse_withdrawal(&vault_id, &owner, &0u64);
     assert!(result.is_err(), "Cannot reverse the same withdrawal twice");
 }
+
+// ── Issue #787: set_beneficiaries must validate BPS on every call ────────────
+
+#[test]
+fn test_set_beneficiaries_validates_bps_on_second_call() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let b2 = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &1000u64, &None);
+
+    // First call with valid 10_000 BPS — succeeds
+    client.set_beneficiaries(
+        &vault_id,
+        &owner,
+        &vec![
+            &env,
+            BeneficiaryEntry { address: beneficiary.clone(), bps: 6_000 },
+            BeneficiaryEntry { address: b2.clone(), bps: 4_000 },
+        ],
+    );
+
+    // Second call with invalid BPS (8_000) — must be rejected
+    let err = client
+        .try_set_beneficiaries(
+            &vault_id,
+            &owner,
+            &vec![
+                &env,
+                BeneficiaryEntry { address: beneficiary.clone(), bps: 4_000 },
+                BeneficiaryEntry { address: b2.clone(), bps: 4_000 },
+            ],
+        )
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, ContractError::InvalidBps);
+}
+
+// ── Issue #786: get_beneficiary_count ────────────────────────────────────────
+
+#[test]
+fn test_get_beneficiary_count_no_multi_beneficiaries() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &1000u64, &None);
+    assert_eq!(client.get_beneficiary_count(&vault_id), 0);
+}
+
+#[test]
+fn test_get_beneficiary_count_one_beneficiary() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &1000u64, &None);
+    client.set_beneficiaries(
+        &vault_id,
+        &owner,
+        &vec![&env, BeneficiaryEntry { address: beneficiary.clone(), bps: 10_000 }],
+    );
+    assert_eq!(client.get_beneficiary_count(&vault_id), 1);
+}
+
+#[test]
+fn test_get_beneficiary_count_multiple_beneficiaries() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let b2 = Address::generate(&env);
+    let b3 = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &1000u64, &None);
+    client.set_beneficiaries(
+        &vault_id,
+        &owner,
+        &vec![
+            &env,
+            BeneficiaryEntry { address: beneficiary.clone(), bps: 5_000 },
+            BeneficiaryEntry { address: b2.clone(), bps: 3_000 },
+            BeneficiaryEntry { address: b3.clone(), bps: 2_000 },
+        ],
+    );
+    assert_eq!(client.get_beneficiary_count(&vault_id), 3);
+}
+
+// ── Issue #781: get_streak_summary ───────────────────────────────────────────
+
+#[test]
+fn test_get_streak_summary_none_when_no_streak() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &1000u64, &None);
+    let summary = client.get_streak_summary(&vault_id);
+    assert!(summary.is_none());
+}
+
+#[test]
+fn test_get_streak_summary_active_after_check_in() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &1000u64, &None);
+
+    env.ledger().with_mut(|l| l.timestamp += 10);
+    let hash = BytesN::from_array(&env, &[0u8; 32]);
+    client.check_in(&vault_id, &owner, &hash);
+
+    let summary = client.get_streak_summary(&vault_id);
+    assert!(summary.is_some());
+    let streak = summary.unwrap();
+    assert_eq!(streak.current, 1);
+    assert_eq!(streak.best, 1);
+    assert!(streak.last_timestamp > 0);
+}
+
+#[test]
+fn test_get_streak_summary_broken_streak() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let interval = 100u64;
+    let vault_id = client.create_vault(&owner, &beneficiary, &interval, &None);
+
+    // First check-in on time
+    env.ledger().with_mut(|l| l.timestamp += 10);
+    let hash = BytesN::from_array(&env, &[0u8; 32]);
+    client.check_in(&vault_id, &owner, &hash);
+
+    // Second check-in after interval — still on time (streak = 2)
+    env.ledger().with_mut(|l| l.timestamp += interval - 10);
+    client.check_in(&vault_id, &owner, &hash);
+
+    let summary = client.get_streak_summary(&vault_id);
+    assert!(summary.is_some());
+    assert_eq!(summary.unwrap().current, 2);
+
+    // Third check-in well after deadline — streak broken
+    env.ledger().with_mut(|l| l.timestamp += interval * 3);
+    client.check_in(&vault_id, &owner, &hash);
+
+    let summary = client.get_streak_summary(&vault_id);
+    assert!(summary.is_some());
+    let streak = summary.unwrap();
+    assert_eq!(streak.current, 1); // reset
+    assert_eq!(streak.best, 2);    // best preserved
+}
+
+// ── Issue #777: get_next_check_in_deadline ───────────────────────────────────
+
+#[test]
+fn test_get_next_check_in_deadline_returns_deadline_for_active_vault() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let interval = 86_400u64; // 1 day
+    let vault_id = client.create_vault(&owner, &beneficiary, &interval, &None);
+
+    let deadline = client.get_next_check_in_deadline(&vault_id);
+    // last_check_in = 0 (epoch), interval = 86_400, now = 0
+    // deadline = 0 + 86_400 = 86_400, not expired
+    assert!(deadline.is_some());
+    assert_eq!(deadline.unwrap(), interval);
+}
+
+#[test]
+fn test_get_next_check_in_deadline_none_when_expired() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let interval = 100u64;
+    let vault_id = client.create_vault(&owner, &beneficiary, &interval, &None);
+
+    // Advance time past the deadline
+    env.ledger().with_mut(|l| l.timestamp = interval + 1);
+
+    let deadline = client.get_next_check_in_deadline(&vault_id);
+    assert!(deadline.is_none());
+}
+
+#[test]
+fn test_get_next_check_in_deadline_none_when_hibernating() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let interval = 86_400u64;
+    let vault_id = client.create_vault(&owner, &beneficiary, &interval, &None);
+
+    // Enter hibernation
+    client.enter_hibernation(&vault_id, &owner, &100_000u64);
+
+    let deadline = client.get_next_check_in_deadline(&vault_id);
+    assert!(deadline.is_none());
+}
+
+#[test]
+fn test_get_next_check_in_deadline_returns_after_hibernation_ends() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let interval = 86_400u64;
+    let vault_id = client.create_vault(&owner, &beneficiary, &interval, &None);
+
+    // Enter hibernation and then exit
+    client.enter_hibernation(&vault_id, &owner, &100_000u64);
+    client.exit_hibernation(&vault_id, &owner);
+
+    // After exiting hibernation, deadline should be available again
+    let deadline = client.get_next_check_in_deadline(&vault_id);
+    assert!(deadline.is_some());
+}


### PR DESCRIPTION
## Summary

Implements 3 new query functions and 1 additional validation test across 4 issues:

| Issue | Description |
|-------|-------------|
| **#787** | Validate BPS sum on every `set_beneficiaries` call (not just the first) |
| **#786** | Add `get_beneficiary_count` query |
| **#781** | Add `get_streak_summary` query |
| **#777** | Add `get_next_check_in_deadline` query |

---

## Changes

### Closes #— Validate BPS on every `set_beneficiaries` call

The function already summed BPS and returned `InvalidBps` on mismatch, but there was no regression test proving it works on subsequent calls. Added `test_set_beneficiaries_validates_bps_on_second_call` which sets valid beneficiaries (6k+4k), then calls again with invalid BPS (4k+4k) and asserts `InvalidBps`.

### Closes #— `get_beneficiary_count(env, vault_id) -> u32`

Returns the number of entries in the multi-beneficiary list, or `0` if no list has been set (or the vault doesn't exist). Cheaper than fetching the full `Vec` via `get_bens_with_thresholds`.

Tests: 0 beneficiaries (default), 1 beneficiary, 3 beneficiaries.

### Closes # — `get_streak_summary(env, vault_id) -> Option<CheckInStreak>`

Unlike `get_check_in_streak` (which returns a zeroed default), this returns `None` when no streak record exists. Makes it possible to distinguish "never checked in" from "streak is 0".

Tests: no streak (`None`), active streak after check-in (`Some` with `current=1`), broken streak (current resets to 1, best holds at 2).

### Closes # — `get_next_check_in_deadline(env, vault_id) -> Option<u64>`

Returns `last_check_in + check_in_interval` as the absolute timestamp of the next required check-in. Returns `None` if the vault is currently hibernating (inside its hibernation window) or already expired. Reduces off-chain logic and correctly accounts for hibernation.

Tests: active vault (returns deadline), expired vault (`None`), hibernating vault (`None`), vault after hibernation exit (returns deadline).

---

## Files Changed

| File | Additions |
|------|-----------|
| `contracts/ttl_vault/src/lib.rs` | 3 new public functions (+57 lines) |
| `contracts/ttl_vault/src/test.rs` | 11 new test functions (+188 lines) |