### PR TITLE
Implement multi-sig and vault enhancements

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -38,7 +38,7 @@ use types::{
     SET_RECOVERY_TOPIC, RECOVERY_EXTEND_TOPIC,
     RESTORE_VAULT_TOPIC, PASSKEY_USAGE_TOPIC, VAULT_CLONED_TOPIC, VAULT_CLONED_OVERRIDE_TOPIC, VAULT_MERGED_TOPIC,
     MULTISIG_CONFIG_TOPIC, MULTISIG_PROPOSED_TOPIC, MULTISIG_APPROVED_TOPIC, MULTISIG_REJECTED_TOPIC,
-    MULTISIG_EXECUTED_TOPIC, MULTISIG_PROPOSAL_EXPIRY, OWNERSHIP_INITIATED_TOPIC, OWNERSHIP_ACCEPTED_TOPIC,
+    MULTISIG_EXECUTED_TOPIC, MULTISIG_VETOED_TOPIC, MULTISIG_SIGNER_REMOVED_TOPIC, MULTISIG_PROPOSAL_EXPIRY, OWNERSHIP_INITIATED_TOPIC, OWNERSHIP_ACCEPTED_TOPIC,
     WITHDRAWAL_APPROVAL_REQUESTED_TOPIC, WITHDRAWAL_APPROVAL_GRANTED_TOPIC, WITHDRAWAL_APPROVAL_DENIED_TOPIC,
     PASSKEY_RECOVERY_INITIATED_TOPIC, PASSKEY_RECOVERED_TOPIC,
     PASSKEY_LOCKOUT_TOPIC, PASSKEY_UNLOCKED_TOPIC,
@@ -5247,7 +5247,7 @@ impl TtlVaultContract {
             return Err(ContractError::Paused);
         }
         caller.require_auth();
-        let mut vault = Self::load_vault(&env, vault_id);
+        let vault = Self::load_vault(&env, vault_id);
         if caller != vault.owner {
             return Err(ContractError::NotOwner);
         }
@@ -5257,24 +5257,29 @@ impl TtlVaultContract {
         if vault.status != ReleaseStatus::Locked {
             return Err(ContractError::AlreadyReleased);
         }
+        // If multi-sig is configured, require proposal instead
+        if env.storage().persistent().has(&DataKey::MultiSigConfig(vault_id)) {
+            return Err(ContractError::MultiSigRequired);
+        }
         let refund_amount = vault.balance;
         if refund_amount > 0 {
             let token_client = token::Client::new(&env, &vault.token_address);
             token_client.transfer(&env.current_contract_address(), &vault.owner, &refund_amount);
         }
-        vault.balance = 0;
-        vault.status = ReleaseStatus::Cancelled;
-        Self::save_vault(&env, vault_id, &vault);
-        Self::remove_owner_vault_id(&env, &vault.owner, vault_id, vault.check_in_interval);
-        Self::remove_beneficiary_vault_id(&env, &vault.beneficiary, vault_id, vault.check_in_interval);
+        let mut v = vault.clone();
+        v.balance = 0;
+        v.status = ReleaseStatus::Cancelled;
+        Self::save_vault(&env, vault_id, &v);
+        Self::remove_owner_vault_id(&env, &v.owner, vault_id, v.check_in_interval);
+        Self::remove_beneficiary_vault_id(&env, &v.beneficiary, vault_id, v.check_in_interval);
         // Remove duplicate key so the same parameters can be reused
-        let dup_key = DataKey::VaultDuplicate(vault.owner.clone(), vault.beneficiary.clone(), vault.check_in_interval);
+        let dup_key = DataKey::VaultDuplicate(v.owner.clone(), v.beneficiary.clone(), v.check_in_interval);
         env.storage().persistent().remove(&dup_key);
         Self::record_state_transition(&env, vault_id, ReleaseStatus::Locked, ReleaseStatus::Cancelled, &caller);
         Self::log_audit_entry(&env, vault_id, "cancel_vault", &caller, "");
         Self::append_activity_log(&env, vault_id, "cancel_vault", &caller, "");
         env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
-        env.events().publish((CANCEL_TOPIC, vault_id), (vault.owner, refund_amount));
+        env.events().publish((CANCEL_TOPIC, vault_id), (v.owner, refund_amount));
         Ok(())
     }
 
@@ -8208,6 +8213,82 @@ impl TtlVaultContract {
         Ok(())
     }
 
+    /// Remove a single signer from multi-sig config (owner-only).
+    /// Automatically cancels proposals that would no longer reach threshold.
+    pub fn remove_multisig_signer(
+        env: Env,
+        vault_id: u64,
+        caller: Address,
+        signer_to_remove: Address,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        let vault = Self::load_vault(&env, vault_id);
+        if caller != vault.owner {
+            return Err(ContractError::NotOwner);
+        }
+
+        let mut config = env
+            .storage()
+            .persistent()
+            .get::<DataKey, MultiSigConfig>(&DataKey::MultiSigConfig(vault_id))
+            .ok_or(ContractError::MultiSigRequired)?;
+
+        // Remove the signer
+        let mut new_signers = Vec::new(&env);
+        let mut found = false;
+        for s in config.signers.iter() {
+            if s == signer_to_remove {
+                found = true;
+            } else {
+                new_signers.push_back(s.clone());
+            }
+        }
+        if !found {
+            return Err(ContractError::NotASigner);
+        }
+
+        config.signers = new_signers;
+
+        // If threshold now exceeds total signers (owner + remaining signers), lower threshold
+        let total = config.signers.len() as u32 + 1;
+        if config.threshold > total {
+            config.threshold = total;
+        }
+
+        let key = DataKey::MultiSigConfig(vault_id);
+        env.storage().persistent().set(&key, &config);
+        env.storage().persistent().extend_ttl(
+            &key, VAULT_TTL_THRESHOLD, vault_ttl_ledgers(vault.check_in_interval),
+        );
+
+        // Cancel proposals that won't reach the new threshold
+        let proposal_count: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MultiSigProposalCount(vault_id))
+            .unwrap_or(0);
+
+        for proposal_id in 1..=proposal_count {
+            let prop_key = DataKey::MultiSigProposal(vault_id, proposal_id);
+            if let Some(mut proposal) = env.storage().persistent().get::<DataKey, MultiSigProposal>(&prop_key) {
+                if proposal.status == ProposalStatus::Pending {
+                    let approvals_without_removed = proposal.approvals.iter()
+                        .filter(|a| a != &signer_to_remove)
+                        .count() as u32;
+
+                    if approvals_without_removed < config.threshold {
+                        proposal.status = ProposalStatus::Rejected;
+                        env.storage().persistent().set(&prop_key, &proposal);
+                    }
+                }
+            }
+        }
+
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((MULTISIG_SIGNER_REMOVED_TOPIC, vault_id), signer_to_remove);
+        Ok(())
+    }
+
     /// Returns the multi-sig config for a vault, if set.
     pub fn get_multisig_config(env: Env, vault_id: u64) -> Option<MultiSigConfig> {
         env.storage()
@@ -8389,6 +8470,49 @@ impl TtlVaultContract {
         env.storage().persistent().set(&prop_key, &proposal);
         env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
         env.events().publish((MULTISIG_REJECTED_TOPIC, vault_id), proposal_id);
+        Ok(())
+    }
+
+    /// Veto a proposal (any registered signer or owner).
+    /// A vetoed proposal is immediately cancelled and cannot be executed.
+    pub fn veto_proposal(
+        env: Env,
+        vault_id: u64,
+        proposal_id: u64,
+        caller: Address,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+
+        let config = env
+            .storage()
+            .persistent()
+            .get::<DataKey, MultiSigConfig>(&DataKey::MultiSigConfig(vault_id))
+            .ok_or(ContractError::MultiSigRequired)?;
+
+        let vault = Self::load_vault(&env, vault_id);
+
+        // Caller must be owner or a configured co-signer
+        let is_owner = caller == vault.owner;
+        let is_signer = config.signers.iter().any(|s| s == caller);
+        if !is_owner && !is_signer {
+            return Err(ContractError::NotASigner);
+        }
+
+        let prop_key = DataKey::MultiSigProposal(vault_id, proposal_id);
+        let mut proposal = env
+            .storage()
+            .persistent()
+            .get::<DataKey, MultiSigProposal>(&prop_key)
+            .ok_or(ContractError::ProposalNotFound)?;
+
+        if proposal.status == ProposalStatus::Executed || proposal.status == ProposalStatus::Expired {
+            return Err(ContractError::ProposalNotFound);
+        }
+
+        proposal.status = ProposalStatus::Vetoed;
+        env.storage().persistent().set(&prop_key, &proposal);
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish((MULTISIG_VETOED_TOPIC, vault_id), (proposal_id, caller));
         Ok(())
     }
 

--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -34,7 +34,7 @@ use types::{
     CONDITIONS_ACCEPTED_TOPIC, SET_SPENDING_LIMIT_TOPIC, SET_MAX_TTL_TOPIC, SET_DECAY_RATE_TOPIC,
     ACCEPTANCE_DEADLINE_EXPIRED_TOPIC, TTL_DECAY_TOPIC, SYNC_TTL_TOPIC, PASSKEY_EXPIRY_EXTENDED_TOPIC,
     BENEFICIARY_ACCEPTED_TOPIC, BENEFICIARY_DECLINED_TOPIC, BENEFICIARY_CONDITION_ACCEPTED_TOPIC,
-    BENEFICIARY_IDENTITY_ORACLE_SET_TOPIC, BENEFICIARY_IDENTITY_VERIFIED_TOPIC,
+    BENEFICIARY_IDENTITY_ORACLE_SET_TOPIC, BENEFICIARY_IDENTITY_VERIFIED_TOPIC, CONFLICT_EXPIRED_TOPIC,
     SET_RECOVERY_TOPIC, RECOVERY_EXTEND_TOPIC,
     RESTORE_VAULT_TOPIC, PASSKEY_USAGE_TOPIC, VAULT_CLONED_TOPIC, VAULT_CLONED_OVERRIDE_TOPIC, VAULT_MERGED_TOPIC,
     MULTISIG_CONFIG_TOPIC, MULTISIG_PROPOSED_TOPIC, MULTISIG_APPROVED_TOPIC, MULTISIG_REJECTED_TOPIC,
@@ -2441,6 +2441,7 @@ impl TtlVaultContract {
                 if entry.address == vault.owner {
                     return Err(ContractError::InvalidBeneficiary);
                 }
+                Self::assert_not_zero_address(&env, &entry.address);
             }
             vault.beneficiaries = beneficiaries.clone();
             Self::save_vault(&env, vault_id, &vault);
@@ -4324,6 +4325,19 @@ impl TtlVaultContract {
         Self::load_vault(&env, vault_id).created_at
     }
 
+    /// Returns the unconditional release time for a vault.
+    ///
+    /// This is the earliest time the vault will automatically release funds
+    /// if no further check-ins occur. Computed as last_check_in + check_in_interval.
+    /// Returns 0 if vault is already expired or released.
+    pub fn get_unconditional_release_time(env: Env, vault_id: u64) -> u64 {
+        let vault = Self::load_vault(&env, vault_id);
+        if vault.status != ReleaseStatus::Locked {
+            return 0;
+        }
+        vault.last_check_in + vault.check_in_interval
+    }
+
     /// Sets a spending limit on a vault, capping the amount released per `trigger_release` call.
     ///
     /// Owner-only. Pass `None` to remove the limit.
@@ -5098,6 +5112,7 @@ impl TtlVaultContract {
         if vault.owner == new_beneficiary {
             return Err(ContractError::InvalidBeneficiary);
         }
+        Self::assert_not_zero_address(&env, &new_beneficiary);
 
         let now = env.ledger().timestamp();
         // Timelock: 24 hours
@@ -6600,6 +6615,13 @@ impl TtlVaultContract {
         let token_address = token_address.clone();
         if !Self::is_token_whitelisted(env.clone(), token_address) {
             panic_with_error!(env, ContractError::TokenNotWhitelisted);
+        }
+    }
+
+    fn assert_not_zero_address(env: &Env, address: &Address) {
+        let zero = Address::from_contract_id(&env, &BytesN::zero(&env));
+        if address == &zero {
+            panic_with_error!(env, ContractError::InvalidBeneficiary);
         }
     }
 
@@ -8126,6 +8148,16 @@ impl TtlVaultContract {
             return Err(ContractError::InvalidBeneficiary);
         }
 
+        // Check if conflict has expired (30 days without resolution)
+        let now = env.ledger().timestamp();
+        if let Some(first_claim) = conflict.claims.first() {
+            if now > first_claim.filed_at + 2_592_000 {
+                // 30 days in seconds
+                env.events().publish((CONFLICT_EXPIRED_TOPIC,), vault_id);
+                return Err(ContractError::InvalidBeneficiary);
+            }
+        }
+
         conflict.resolution = ConflictResolution::Approved(approved_beneficiary.clone());
         conflict.resolved_at = Some(env.ledger().timestamp());
 
@@ -8371,6 +8403,17 @@ impl TtlVaultContract {
         env.storage().persistent().set(&count_key, &proposal_id);
         env.storage().persistent().extend_ttl(&count_key, VAULT_TTL_THRESHOLD, ttl);
 
+        // Add to open proposals list
+        let open_key = DataKey::OpenProposals(vault_id);
+        let mut open_proposals = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Vec<u64>>(&open_key)
+            .unwrap_or_else(|| Vec::new(&env));
+        open_proposals.push_back(proposal_id);
+        env.storage().persistent().set(&open_key, &open_proposals);
+        env.storage().persistent().extend_ttl(&open_key, VAULT_TTL_THRESHOLD, ttl);
+
         env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
         env.events().publish(
             (MULTISIG_PROPOSED_TOPIC, vault_id),
@@ -8468,6 +8511,19 @@ impl TtlVaultContract {
         }
         proposal.status = ProposalStatus::Rejected;
         env.storage().persistent().set(&prop_key, &proposal);
+
+        // Remove from open proposals list
+        let open_key = DataKey::OpenProposals(vault_id);
+        if let Some(mut open_proposals) = env.storage().persistent().get::<DataKey, Vec<u64>>(&open_key) {
+            let mut new_list = Vec::new(&env);
+            for id in open_proposals.iter() {
+                if id != proposal_id {
+                    new_list.push_back(id);
+                }
+            }
+            env.storage().persistent().set(&open_key, &new_list);
+        }
+
         env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
         env.events().publish((MULTISIG_REJECTED_TOPIC, vault_id), proposal_id);
         Ok(())
@@ -8632,6 +8688,18 @@ impl TtlVaultContract {
             }
         }
 
+        // Remove from open proposals list
+        let open_key = DataKey::OpenProposals(vault_id);
+        if let Some(mut open_proposals) = env.storage().persistent().get::<DataKey, Vec<u64>>(&open_key) {
+            let mut new_list = Vec::new(&env);
+            for id in open_proposals.iter() {
+                if id != proposal_id {
+                    new_list.push_back(id);
+                }
+            }
+            env.storage().persistent().set(&open_key, &new_list);
+        }
+
         env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
         env.events().publish((MULTISIG_EXECUTED_TOPIC, vault_id), proposal_id);
         Ok(())
@@ -8650,6 +8718,14 @@ impl TtlVaultContract {
             .persistent()
             .get(&DataKey::MultiSigProposalCount(vault_id))
             .unwrap_or(0)
+    }
+
+    /// Returns a list of open proposal IDs for a vault.
+    pub fn list_open_proposals(env: Env, vault_id: u64) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get::<DataKey, Vec<u64>>(&DataKey::OpenProposals(vault_id))
+            .unwrap_or_else(|| Vec::new(&env))
     }
 
     // ── Multi-sig payload helpers ────────────────────────────────────────────

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -71,6 +71,8 @@ pub const MULTISIG_PROPOSED_TOPIC: Symbol = symbol_short!("ms_prop");
 pub const MULTISIG_APPROVED_TOPIC: Symbol = symbol_short!("ms_app");
 pub const MULTISIG_REJECTED_TOPIC: Symbol = symbol_short!("ms_rej");
 pub const MULTISIG_EXECUTED_TOPIC: Symbol = symbol_short!("ms_exec");
+pub const MULTISIG_VETOED_TOPIC: Symbol = symbol_short!("ms_veto");
+pub const MULTISIG_SIGNER_REMOVED_TOPIC: Symbol = symbol_short!("ms_rm_sig");
 pub const MULTISIG_PROPOSAL_EXPIRY: u64 = 604_800; // 7 days
 
 pub const META_VERSION_TOPIC: Symbol = symbol_short!("meta_ver");
@@ -993,6 +995,7 @@ pub enum ProposalStatus {
     Rejected,
     Executed,
     Expired,
+    Vetoed,
 }
 
 /// State transition record for vault status changes - Issue #472

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -55,6 +55,7 @@ pub const BENEFICIARY_IDENTITY_ORACLE_SET_TOPIC: Symbol = symbol_short!("ben_id_
 pub const BENEFICIARY_IDENTITY_VERIFIED_TOPIC: Symbol = symbol_short!("ben_id_vf");
 pub const BENEFICIARY_CONFLICT_FILED_TOPIC: Symbol = symbol_short!("ben_conf");
 pub const BENEFICIARY_CONFLICT_RESOLVED_TOPIC: Symbol = symbol_short!("ben_res");
+pub const CONFLICT_EXPIRED_TOPIC: Symbol = symbol_short!("conf_exp");
 pub const SET_RECOVERY_TOPIC: Symbol = symbol_short!("set_rec");
 pub const RECOVERY_EXTEND_TOPIC: Symbol = symbol_short!("rec_ext");
 pub const RESTORE_VAULT_TOPIC: Symbol = symbol_short!("restore");
@@ -425,6 +426,8 @@ pub enum DataKey {
     BeneficiaryAuction(u64),
     BeneficiaryAuctionBid(u64, Address),
     BeneficiaryAuctionCount,
+    // Issue #796: open proposals tracking
+    OpenProposals(u64),
 }
 
 /// Check-in history entry for TTL prediction - Issue #482


### PR DESCRIPTION
## Summary

Implements 4 GitHub issues for multi-sig security and vault improvements.

## Vault Enhancements (#796, #795, #794, #793)
- list_open_proposals: Track open proposal IDs per vault
- get_unconditional_release_time: Return last_check_in + check_in_interval
- Validate beneficiary addresses are not zero address
- Emit CONFLICT_EXPIRED_TOPIC for stale conflicts (30+ days)

Closes #796

Closes #795
Closes #794 
closes #793