### PR TITLE
feat: vesting count query, ownership decline/expiry, and AlreadyOwner guard

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -43,7 +43,7 @@ use types::{
     PASSKEY_RECOVERY_INITIATED_TOPIC, PASSKEY_RECOVERED_TOPIC,
     PASSKEY_LOCKOUT_TOPIC, PASSKEY_UNLOCKED_TOPIC,
     PASSKEY_ROTATION_REQUIRED_TOPIC, PASSKEY_ROTATION_ENFORCED_TOPIC,
-    OWNERSHIP_CANCELLED_TOPIC, MIN_THRESHOLD_SET_TOPIC, MIN_THRESHOLD_SKIP_TOPIC, MIN_THRESHOLD_REDISTRIBUTE_TOPIC,
+    OWNERSHIP_CANCELLED_TOPIC, OWNERSHIP_TRANSFER_EXPIRED_TOPIC, MIN_THRESHOLD_SET_TOPIC, MIN_THRESHOLD_SKIP_TOPIC, MIN_THRESHOLD_REDISTRIBUTE_TOPIC,
     DUPLICATE_VAULT_TOPIC,
     MetadataVersionEntry, META_VERSION_TOPIC, META_REVERT_TOPIC, VAULT_ARCHIVED_TOPIC,
     VAULT_CAP_TOPIC, BENEFICIARY_CAP_TOPIC,
@@ -5472,6 +5472,31 @@ impl TtlVaultContract {
         Self::log_audit_entry(&env, vault_id, "cancel_ownership_transfer", &caller, "");
         env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
         env.events().publish((OWNERSHIP_CANCELLED_TOPIC, vault_id), (caller, cancelled_new_owner, reason));
+        Ok(())
+    }
+
+    /// Expires a stale ownership transfer request after the 7-day expiry window.
+    ///
+    /// Callable by anyone once the request has passed its `expires_at` timestamp.
+    /// Emits `OWNERSHIP_TRANSFER_EXPIRED_TOPIC` and removes the pending request.
+    pub fn expire_ownership_transfer(env: Env, vault_id: u64) -> Result<(), ContractError> {
+        let key = DataKey::PendingOwnership(vault_id);
+        let request = env
+            .storage()
+            .persistent()
+            .get::<DataKey, OwnershipTransferRequest>(&key)
+            .ok_or(ContractError::NoPendingOwnershipTransfer)?;
+
+        if env.ledger().timestamp() <= request.expires_at {
+            return Err(ContractError::NotExpired);
+        }
+
+        env.storage().persistent().remove(&key);
+        env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events().publish(
+            (OWNERSHIP_TRANSFER_EXPIRED_TOPIC, vault_id),
+            (request.new_owner,),
+        );
         Ok(())
     }
 

--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -228,6 +228,7 @@ pub enum ContractError {
     AuctionAlreadyExists = 79,
     AuctionEnded = 80,
     AuctionNotEnded = 81,
+    AlreadyOwner = 82,
 }
 
 #[contract]
@@ -5329,6 +5330,9 @@ impl TtlVaultContract {
         }
         if new_owner == vault.beneficiary {
             return Err(ContractError::InvalidBeneficiary);
+        }
+        if new_owner == vault.owner {
+            return Err(ContractError::AlreadyOwner);
         }
 
         let now = env.ledger().timestamp();

--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -5447,9 +5447,6 @@ impl TtlVaultContract {
     ) -> Result<(), ContractError> {
         caller.require_auth();
         let vault = Self::load_vault(&env, vault_id);
-        if caller != vault.owner {
-            return Err(ContractError::NotOwner);
-        }
 
         let key = DataKey::PendingOwnership(vault_id);
         if !env.storage().persistent().has(&key) {
@@ -5460,12 +5457,21 @@ impl TtlVaultContract {
             .persistent()
             .get::<DataKey, OwnershipTransferRequest>(&key)
             .unwrap();
+
+        let reason = if caller == vault.owner {
+            String::from_str(&env, "cancelled")
+        } else if caller == request.new_owner {
+            String::from_str(&env, "declined")
+        } else {
+            return Err(ContractError::NotOwner);
+        };
+
         let cancelled_new_owner = request.new_owner.clone();
         env.storage().persistent().remove(&key);
 
         Self::log_audit_entry(&env, vault_id, "cancel_ownership_transfer", &caller, "");
         env.storage().instance().extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
-        env.events().publish((OWNERSHIP_CANCELLED_TOPIC, vault_id), (caller, cancelled_new_owner));
+        env.events().publish((OWNERSHIP_CANCELLED_TOPIC, vault_id), (caller, cancelled_new_owner, reason));
         Ok(())
     }
 

--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -2949,6 +2949,14 @@ impl TtlVaultContract {
         env.storage().persistent().get(&DataKey::VestingSchedule(vault_id))
     }
 
+    /// Returns the number of vesting schedules attached to a vault.
+    pub fn get_vesting_schedule_count(env: Env, vault_id: u64) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::VestingScheduleCount(vault_id))
+            .unwrap_or(0)
+    }
+
     /// Sets a late-claim penalty for a vault's vesting schedule.
     ///
     /// If a beneficiary claims an installment more than `grace_period_seconds` after

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -453,6 +453,15 @@ fn test_initiate_ownership_transfer_stores_pending_request() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #82)")]
+fn test_initiate_ownership_transfer_to_current_owner_fails() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+    // new_owner == current owner — should fail with AlreadyOwner (#82)
+    client.initiate_ownership_transfer(&vault_id, &owner, &owner);
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #36)")]
 fn test_accept_ownership_transfer_before_timelock_fails() {
     let (env, owner, beneficiary, _, _, client) = setup();

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -2421,6 +2421,36 @@ fn test_set_vesting_schedule_rejects_empty_vault() {
 }
 
 #[test]
+fn test_get_vesting_schedule_count_zero() {
+    let (_, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+    assert_eq!(client.get_vesting_schedule_count(&vault_id), 0u32);
+}
+
+#[test]
+fn test_get_vesting_schedule_count_one() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+    client.deposit(&vault_id, &owner, &1_000i128);
+    let start = env.ledger().timestamp() + 50;
+    client.set_vesting_schedule(&vault_id, &owner, &start, &100u64, &4u32, &0u64);
+    assert_eq!(client.get_vesting_schedule_count(&vault_id), 1u32);
+}
+
+#[test]
+fn test_get_vesting_schedule_count_max() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+    // MAX_VESTING_SCHEDULES = 20; deposit enough for 20 schedules of 1 each
+    client.deposit(&vault_id, &owner, &20i128);
+    let start = env.ledger().timestamp() + 50;
+    for _ in 0..20u32 {
+        client.set_vesting_schedule(&vault_id, &owner, &start, &100u64, &1u32, &0u64);
+    }
+    assert_eq!(client.get_vesting_schedule_count(&vault_id), 20u32);
+}
+
+#[test]
 fn test_trigger_release_with_vesting_keeps_balance() {
     let (env, owner, beneficiary, _, _, client) = setup();
     let vault_id = setup_vesting(&env, &owner, &beneficiary, &client, 1_000i128, 4, 100u64);

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -578,6 +578,32 @@ fn test_cancel_ownership_transfer_emits_cancelled_event() {
 }
 
 #[test]
+fn test_new_owner_can_decline_ownership_transfer() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_owner = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+
+    client.initiate_ownership_transfer(&vault_id, &owner, &new_owner);
+    client.cancel_ownership_transfer(&vault_id, &new_owner);
+
+    assert!(client.get_pending_ownership_transfer(&vault_id).is_none());
+    assert_eq!(client.get_vault(&vault_id).owner, owner);
+    assert!(find_event_by_topic(&env, types::OWNERSHIP_CANCELLED_TOPIC));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_unrelated_address_cannot_cancel_ownership_transfer() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_owner = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+
+    client.initiate_ownership_transfer(&vault_id, &owner, &new_owner);
+    client.cancel_ownership_transfer(&vault_id, &stranger);
+}
+
+#[test]
 fn test_accept_ownership_transfer_emits_accepted_event() {
     let (env, owner, beneficiary, _, _, client) = setup();
     let new_owner = Address::generate(&env);

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -616,6 +616,33 @@ fn test_accept_ownership_transfer_emits_accepted_event() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #16)")]
+fn test_expire_ownership_transfer_before_expiry_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_owner = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+
+    client.initiate_ownership_transfer(&vault_id, &owner, &new_owner);
+    // Not yet expired — should fail with NotExpired (#16)
+    client.expire_ownership_transfer(&vault_id);
+}
+
+#[test]
+fn test_expire_ownership_transfer_after_expiry_succeeds() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let new_owner = Address::generate(&env);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+
+    client.initiate_ownership_transfer(&vault_id, &owner, &new_owner);
+    // Advance past OWNERSHIP_TRANSFER_EXPIRY (604_800 seconds)
+    env.ledger().with_mut(|l| l.timestamp += 604_801);
+    client.expire_ownership_transfer(&vault_id);
+
+    assert!(client.get_pending_ownership_transfer(&vault_id).is_none());
+    assert!(find_event_by_topic(&env, types::OWNERSHIP_TRANSFER_EXPIRED_TOPIC));
+}
+
+#[test]
 fn test_cancel_vault_refunds_owner_and_marks_cancelled() {
     let (env, owner, beneficiary, _, token_address, client) = setup();
 

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -14,6 +14,7 @@ pub const OWNERSHIP_TOPIC: Symbol = symbol_short!("own_xfer");
 pub const OWNERSHIP_INITIATED_TOPIC: Symbol = symbol_short!("own_init");
 pub const OWNERSHIP_ACCEPTED_TOPIC: Symbol = symbol_short!("own_acc");
 pub const OWNERSHIP_CANCELLED_TOPIC: Symbol = symbol_short!("own_can");
+pub const OWNERSHIP_TRANSFER_EXPIRED_TOPIC: Symbol = symbol_short!("own_exp");
 pub const BENEFICIARY_UPDATED_TOPIC: Symbol = symbol_short!("ben_upd");
 pub const SET_BENEFICIARIES_TOPIC: Symbol = symbol_short!("set_bens");
 pub const UPDATE_INTERVAL_TOPIC: Symbol = symbol_short!("upd_intv");


### PR DESCRIPTION
closes #808 
closes #807 
closes #806 
closes #805 

## Summary

Four separate issues addressed in individual commits:

### 1. `get_vesting_schedule_count` (vesting, low)
Adds a count query that reads the existing `VestingScheduleCount` storage key — no schedule deserialization needed. Tests: 0, 1, and max (20) schedules.

### 2. Pending new owner can decline transfer (ownership, medium)
`cancel_ownership_transfer` now accepts the pending `new_owner` as caller (reason: `"declined"`), in addition to the current owner (reason: `"cancelled"`). `OWNERSHIP_CANCELLED_TOPIC` event gains a reason field. Tests: declination by new owner, rejection of unrelated address.

### 3. `expire_ownership_transfer` (ownership, low)
Adds `OWNERSHIP_TRANSFER_EXPIRED_TOPIC` (`"own_exp"`) and a permissionless `expire_ownership_transfer(env, vault_id)` callable by anyone after the 7-day window. Emits the event and cleans up storage so indexers don't need to poll. Tests: pre-expiry rejection (`NotExpired #16`), post-expiry success.

### 4. `AlreadyOwner` guard (ownership, low — bug)
`initiate_ownership_transfer` now rejects `new_owner == vault.owner` with `AlreadyOwner = 82`, preventing no-op transfers that waste gas and emit spurious events. Test: self-transfer panics with `Error(Contract, #82)`.