### PR TITLE
feat: WebSocket rate limiting, DB migration tracking, soft delete for reminders, and Android biometric check-in

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -480,62 +480,97 @@ impl Db {
 
 
     pub fn migrate(&self) -> Result<(), rusqlite::Error> {
+        // Bootstrap the migration tracking table before anything else.
         self.conn.lock().unwrap().execute_batch(
-            r#"
-            CREATE TABLE IF NOT EXISTS reminder_preferences (
-                vault_id              INTEGER PRIMARY KEY,
-                channels             TEXT NOT NULL,
-                hours_before_expiry  INTEGER NOT NULL,
-                frequency            TEXT NOT NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS ttl_insurance_policies (
-                vault_id                      INTEGER PRIMARY KEY,
-                extension_seconds            INTEGER NOT NULL,
-                inactivity_threshold_seconds INTEGER NOT NULL,
-                enabled                       INTEGER NOT NULL,
-                purchased_at                  TEXT NOT NULL,
-                last_extended_at              TEXT
-            );
-
-            CREATE TABLE IF NOT EXISTS owner_activity (
-                owner_id        INTEGER PRIMARY KEY,
-                last_active_at TEXT NOT NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS idempotency_keys (
-                key          TEXT PRIMARY KEY,
-                status_code  INTEGER NOT NULL,
-                response_body TEXT NOT NULL,
-                created_at   TEXT NOT NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS unsubscribe_tokens (
-                token      TEXT PRIMARY KEY,
-                owner      TEXT NOT NULL,
-                created_at TEXT NOT NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS unsubscribed_users (
-                owner TEXT PRIMARY KEY
-            );
-            "#,
+            "CREATE TABLE IF NOT EXISTS schema_migrations (
+                version    TEXT PRIMARY KEY,
+                applied_at TEXT NOT NULL
+            );",
         )?;
+
+        const MIGRATIONS: &[(&str, &str)] = &[
+            (
+                "1",
+                r#"
+                CREATE TABLE IF NOT EXISTS reminder_preferences (
+                    vault_id             INTEGER PRIMARY KEY,
+                    channels             TEXT NOT NULL,
+                    hours_before_expiry  INTEGER NOT NULL,
+                    frequency            TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS ttl_insurance_policies (
+                    vault_id                      INTEGER PRIMARY KEY,
+                    extension_seconds             INTEGER NOT NULL,
+                    inactivity_threshold_seconds  INTEGER NOT NULL,
+                    enabled                        INTEGER NOT NULL,
+                    purchased_at                   TEXT NOT NULL,
+                    last_extended_at               TEXT
+                );
+                CREATE TABLE IF NOT EXISTS owner_activity (
+                    owner_id       INTEGER PRIMARY KEY,
+                    last_active_at TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS idempotency_keys (
+                    key           TEXT PRIMARY KEY,
+                    status_code   INTEGER NOT NULL,
+                    response_body TEXT NOT NULL,
+                    created_at    TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS unsubscribe_tokens (
+                    token      TEXT PRIMARY KEY,
+                    owner      TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS unsubscribed_users (
+                    owner TEXT PRIMARY KEY
+                );
+                "#,
+            ),
+            (
+                "2",
+                "ALTER TABLE reminder_preferences ADD COLUMN deleted_at TEXT;",
+            ),
+        ];
+
+        for (version, sql) in MIGRATIONS {
+            let already_applied: bool = {
+                let conn = self.conn.lock().unwrap();
+                conn.query_row(
+                    "SELECT 1 FROM schema_migrations WHERE version = ?1",
+                    params![version],
+                    |_| Ok(true),
+                )
+                .unwrap_or(false)
+            };
+
+            if !already_applied {
+                tracing::info!(version = version, "applying migration");
+                self.conn.lock().unwrap().execute_batch(sql)?;
+                self.conn.lock().unwrap().execute(
+                    "INSERT INTO schema_migrations (version, applied_at) VALUES (?1, ?2)",
+                    params![version, chrono::Utc::now().to_rfc3339()],
+                )?;
+                tracing::info!(version = version, "migration applied successfully");
+            } else {
+                tracing::debug!(version = version, "migration already applied, skipping");
+            }
+        }
+
         Ok(())
     }
 
 
     pub fn upsert(&self, prefs: &ReminderPreferences) -> Result<(), rusqlite::Error> {
         let channels_json = serde_json::to_string(&prefs.channels).unwrap();
-self.conn.lock().unwrap().execute(
-
+        self.conn.lock().unwrap().execute(
             r#"
             INSERT INTO reminder_preferences (vault_id, channels, hours_before_expiry, frequency)
             VALUES (?1, ?2, ?3, ?4)
             ON CONFLICT(vault_id) DO UPDATE SET
               channels = excluded.channels,
               hours_before_expiry = excluded.hours_before_expiry,
-              frequency = excluded.frequency
+              frequency = excluded.frequency,
+              deleted_at = NULL
             "#,
             params![
                 prefs.vault_id as i64,
@@ -548,11 +583,11 @@ self.conn.lock().unwrap().execute(
     }
 
     pub fn get(&self, vault_id: u64) -> Result<ReminderPreferences, rusqlite::Error> {
-let binding = self.conn.lock().unwrap();
+        let binding = self.conn.lock().unwrap();
         let mut stmt = binding.prepare(
-            "SELECT vault_id, channels, hours_before_expiry, frequency FROM reminder_preferences WHERE vault_id = ?1",
-
-
+            r#"SELECT vault_id, channels, hours_before_expiry, frequency, deleted_at
+               FROM reminder_preferences
+               WHERE vault_id = ?1 AND deleted_at IS NULL"#,
         )?;
         let row = stmt.query_row(params![vault_id as i64], |r| {
             let channels_str: String = r.get(1)?;
@@ -564,6 +599,7 @@ let binding = self.conn.lock().unwrap();
                 channels,
                 hours_before_expiry: r.get::<_, i64>(2)? as u32,
                 frequency,
+                deleted_at: None,
             })
         })?;
         Ok(row)
@@ -572,7 +608,9 @@ let binding = self.conn.lock().unwrap();
     pub fn all(&self) -> Result<Vec<ReminderPreferences>, rusqlite::Error> {
         let binding = self.conn.lock().unwrap();
         let mut stmt = binding.prepare(
-            "SELECT vault_id, channels, hours_before_expiry, frequency FROM reminder_preferences",
+            r#"SELECT vault_id, channels, hours_before_expiry, frequency, deleted_at
+               FROM reminder_preferences
+               WHERE deleted_at IS NULL"#,
         )?;
         let iter = stmt.query_map([], |r| {
             let channels_str: String = r.get(1)?;
@@ -584,6 +622,52 @@ let binding = self.conn.lock().unwrap();
                 channels,
                 hours_before_expiry: r.get::<_, i64>(2)? as u32,
                 frequency,
+                deleted_at: None,
+            })
+        })?;
+
+        let mut out = Vec::new();
+        for item in iter {
+            out.push(item?);
+        }
+        Ok(out)
+    }
+
+    pub fn soft_delete_reminder(&self, vault_id: u64) -> Result<(), rusqlite::Error> {
+        self.conn.lock().unwrap().execute(
+            "UPDATE reminder_preferences SET deleted_at = ?1 WHERE vault_id = ?2 AND deleted_at IS NULL",
+            params![chrono::Utc::now().to_rfc3339(), vault_id as i64],
+        )?;
+        Ok(())
+    }
+
+    pub fn all_reminders_including_deleted(
+        &self,
+        vault_id: u64,
+    ) -> Result<Vec<ReminderPreferences>, rusqlite::Error> {
+        let binding = self.conn.lock().unwrap();
+        let mut stmt = binding.prepare(
+            r#"SELECT vault_id, channels, hours_before_expiry, frequency, deleted_at
+               FROM reminder_preferences
+               WHERE vault_id = ?1"#,
+        )?;
+        let iter = stmt.query_map(params![vault_id as i64], |r| {
+            let channels_str: String = r.get(1)?;
+            let frequency_str: String = r.get(3)?;
+            let channels: Vec<Channel> = serde_json::from_str(&channels_str).unwrap_or_default();
+            let frequency: Frequency = serde_json::from_str(&frequency_str).unwrap();
+            let deleted_at_str: Option<String> = r.get(4)?;
+            let deleted_at = deleted_at_str.and_then(|s| {
+                chrono::DateTime::parse_from_rfc3339(&s)
+                    .ok()
+                    .map(|dt| dt.with_timezone(&chrono::Utc))
+            });
+            Ok(ReminderPreferences {
+                vault_id: r.get::<_, i64>(0)? as u64,
+                channels,
+                hours_before_expiry: r.get::<_, i64>(2)? as u32,
+                frequency,
+                deleted_at,
             })
         })?;
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use axum::{
     extract::State,
     http::{HeaderValue, Method},
-    routing::{get, post},
+    routing::{delete, get, post},
     Json, Router,
 };
 use tower_http::cors::CorsLayer;
@@ -88,7 +88,13 @@ async fn main() {
         .route("/ready", get(ready_handler))
         .route(
             "/api/vaults/:vault_id/reminder-preferences",
-            post(routes::set_preferences).get(routes::get_preferences),
+            post(routes::set_preferences)
+                .get(routes::get_preferences)
+                .delete(routes::delete_preferences),
+        )
+        .route(
+            "/api/vaults/:vault_id/reminders",
+            get(routes::list_vault_reminders),
         )
         .layer(build_cors_layer())
         .with_state(db);

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -54,6 +54,8 @@ pub struct ReminderPreferences {
     pub channels: Vec<Channel>,
     pub hours_before_expiry: u32,
     pub frequency: Frequency,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deleted_at: Option<DateTime<Utc>>,
 }
 
 /// Request body for setting reminder preferences.

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -13,6 +13,35 @@ use crate::{
     models::{ReminderPreferences, SetPreferencesRequest},
 };
 
+#[derive(Deserialize)]
+pub struct RemindersQuery {
+    pub include_deleted: Option<bool>,
+}
+
+pub async fn list_vault_reminders(
+    State(db): State<Arc<Db>>,
+    Path(vault_id): Path<u64>,
+    Query(query): Query<RemindersQuery>,
+) -> Result<Json<Vec<ReminderPreferences>>, AppError> {
+    let records = if query.include_deleted.unwrap_or(false) {
+        db.all_reminders_including_deleted(vault_id)?
+    } else {
+        match db.get(vault_id) {
+            Ok(p) => vec![p],
+            Err(_) => vec![],
+        }
+    };
+    Ok(Json(records))
+}
+
+pub async fn delete_preferences(
+    State(db): State<Arc<Db>>,
+    Path(vault_id): Path<u64>,
+) -> Result<StatusCode, AppError> {
+    db.soft_delete_reminder(vault_id)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
 pub async fn set_preferences(
     State(db): State<Arc<Db>>,
     Path(vault_id): Path<u64>,
@@ -42,6 +71,7 @@ pub async fn set_preferences(
         channels: body.channels,
         hours_before_expiry: body.hours_before_expiry,
         frequency: body.frequency,
+        deleted_at: None,
     };
     db.upsert(&prefs)?;
 

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -4,7 +4,7 @@ use axum::{
     body::Body,
     extract::State,
     http::{HeaderValue, Method, Request, StatusCode},
-    routing::{get, post},
+    routing::{delete, get, post},
     Json, Router,
 };
 use serde_json::json;
@@ -24,7 +24,13 @@ fn test_app_with_db(db: Arc<Db>) -> Router {
         .route("/ready", get(ready_handler))
         .route(
             "/api/vaults/:vault_id/reminder-preferences",
-            post(routes::set_preferences).get(routes::get_preferences),
+            post(routes::set_preferences)
+                .get(routes::get_preferences)
+                .delete(routes::delete_preferences),
+        )
+        .route(
+            "/api/vaults/:vault_id/reminders",
+            get(routes::list_vault_reminders),
         )
         .route(
             "/notifications/unsubscribe",
@@ -90,6 +96,7 @@ async fn test_set_and_get_preferences() {
         channels: vec![crate::models::Channel::Email],
         hours_before_expiry: 24,
         frequency: crate::models::Frequency::Once,
+        deleted_at: None,
     };
     db.upsert(&prefs).unwrap();
     let fetched = db.get(1).unwrap();
@@ -141,6 +148,7 @@ async fn test_upsert_overwrites() {
         channels: vec![crate::models::Channel::Email],
         hours_before_expiry: 12,
         frequency: crate::models::Frequency::Once,
+        deleted_at: None,
     };
     db.upsert(&p1).unwrap();
 
@@ -149,6 +157,7 @@ async fn test_upsert_overwrites() {
         channels: vec![crate::models::Channel::Sms, crate::models::Channel::Push],
         hours_before_expiry: 6,
         frequency: crate::models::Frequency::Hourly,
+        deleted_at: None,
     };
     db.upsert(&p2).unwrap();
 

--- a/backend/src/websocket.rs
+++ b/backend/src/websocket.rs
@@ -6,11 +6,35 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 use tokio::time::{Duration, Instant, interval};
 use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::protocol::{CloseFrame, frame::coding::CloseCode};
 use tokio_tungstenite::WebSocketStream;
 use tokio::net::TcpStream;
 
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 const PONG_TIMEOUT: Duration = Duration::from_secs(10);
+const RATE_LIMIT_MSG_PER_SEC: u32 = 10;
+
+struct MessageRateLimiter {
+    count: u32,
+    window_start: Instant,
+}
+
+impl MessageRateLimiter {
+    fn new() -> Self {
+        Self { count: 0, window_start: Instant::now() }
+    }
+
+    /// Returns false when the per-second limit is exceeded.
+    fn check_and_count(&mut self) -> bool {
+        let now = Instant::now();
+        if now.duration_since(self.window_start) >= Duration::from_secs(1) {
+            self.count = 0;
+            self.window_start = now;
+        }
+        self.count += 1;
+        self.count <= RATE_LIMIT_MSG_PER_SEC
+    }
+}
 
 pub type WsStream = WebSocketStream<TcpStream>;
 pub type WsSink = SplitSink<WsStream, Message>;
@@ -105,14 +129,21 @@ pub async fn handle_authenticated_vault_stream(
 pub async fn read_client_frames(
     mut ws_source: WsSource,
     pong_notify: Arc<tokio::sync::Notify>,
+    rate_exceeded: Arc<tokio::sync::Notify>,
 ) {
+    let mut rate_limiter = MessageRateLimiter::new();
     while let Some(Ok(msg)) = ws_source.next().await {
         match msg {
             Message::Pong(_) => {
                 pong_notify.notify_one();
             }
             Message::Close(_) => break,
-            _ => {}
+            _ => {
+                if !rate_limiter.check_and_count() {
+                    rate_exceeded.notify_one();
+                    break;
+                }
+            }
         }
     }
 }
@@ -126,6 +157,7 @@ pub async fn handle_vault_stream_with_heartbeat(
     let mut heartbeat = interval(HEARTBEAT_INTERVAL);
     let mut last_pong = Instant::now();
     let mut awaiting_pong = false;
+    let mut rate_limiter = MessageRateLimiter::new();
 
     loop {
         tokio::select! {
@@ -153,6 +185,15 @@ pub async fn handle_vault_stream_with_heartbeat(
                         awaiting_pong = false;
                     }
                     Some(Ok(Message::Close(_))) | None => break,
+                    Some(Ok(_)) => {
+                        if !rate_limiter.check_and_count() {
+                            let _ = ws_sink.send(Message::Close(Some(CloseFrame {
+                                code: CloseCode::Policy,
+                                reason: "message rate limit exceeded".into(),
+                            }))).await;
+                            break;
+                        }
+                    }
                     _ => {}
                 }
             }

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -66,6 +66,9 @@ dependencies {
     // DataStore (offline)
     implementation(libs.datastore.preferences)
 
+    // Biometric authentication
+    implementation(libs.biometric)
+
     // Credentials (Passkey)
     implementation(libs.credentials)
     implementation(libs.credentials.play.services.auth)

--- a/mobile/android/app/src/main/java/com/ttllegacy/services/BiometricHelper.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/services/BiometricHelper.kt
@@ -1,0 +1,47 @@
+package com.ttllegacy.services
+
+import androidx.activity.ComponentActivity
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
+import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
+import androidx.biometric.BiometricPrompt
+
+class BiometricHelper(private val activity: ComponentActivity) {
+
+    fun isAvailable(): Boolean {
+        val mgr = BiometricManager.from(activity)
+        val result = mgr.canAuthenticate(BIOMETRIC_STRONG or DEVICE_CREDENTIAL)
+        return result == BiometricManager.BIOMETRIC_SUCCESS
+    }
+
+    fun authenticate(
+        title: String,
+        subtitle: String,
+        onSuccess: () -> Unit,
+        onError: (String) -> Unit,
+    ) {
+        val callback = object : BiometricPrompt.AuthenticationCallback() {
+            override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                onSuccess()
+            }
+
+            override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                onError(errString.toString())
+            }
+
+            override fun onAuthenticationFailed() {
+                onError("Biometric not recognised — please try again.")
+            }
+        }
+
+        val prompt = BiometricPrompt(activity, callback)
+
+        val promptInfo = BiometricPrompt.PromptInfo.Builder()
+            .setTitle(title)
+            .setSubtitle(subtitle)
+            .setAllowedAuthenticators(BIOMETRIC_STRONG or DEVICE_CREDENTIAL)
+            .build()
+
+        prompt.authenticate(promptInfo)
+    }
+}

--- a/mobile/android/app/src/main/java/com/ttllegacy/ui/screens/Screens.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/ui/screens/Screens.kt
@@ -1,5 +1,6 @@
 package com.ttllegacy.ui.screens
 
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -14,6 +15,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ttllegacy.models.Vault
+import com.ttllegacy.services.BiometricHelper
 import com.ttllegacy.ui.AuthViewModel
 import com.ttllegacy.ui.VaultViewModel
 
@@ -88,7 +90,10 @@ fun VaultListScreen(
     vm: VaultViewModel = hiltViewModel()
 ) {
     val state by vm.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
     var showCreate by remember { mutableStateOf(false) }
+    var pendingCheckIn by remember { mutableStateOf<Vault?>(null) }
+    var biometricError by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(Unit) { vm.load() }
 
@@ -96,6 +101,22 @@ fun VaultListScreen(
         CreateVaultDialog(
             onCreate = { ben, days -> vm.createVault(ben, days); showCreate = false },
             onDismiss = { showCreate = false }
+        )
+    }
+
+    pendingCheckIn?.let { vault ->
+        CheckInConfirmationDialog(
+            vault = vault,
+            onConfirm = {
+                pendingCheckIn = null
+                BiometricHelper(context as ComponentActivity).authenticate(
+                    title = "Confirm Check-In",
+                    subtitle = "Vault ${vault.id.take(12)}… will extend by ${formatInterval(vault.checkInInterval)}",
+                    onSuccess = { vm.checkIn(vault.id) },
+                    onError = { err -> biometricError = err },
+                )
+            },
+            onDismiss = { pendingCheckIn = null },
         )
     }
 
@@ -119,19 +140,56 @@ fun VaultListScreen(
                         if (state.isOffline) item {
                             OfflineBanner()
                         }
-                        state.error?.let { err -> item {
-                            Text(err, color = MaterialTheme.colorScheme.error,
-                                modifier = Modifier.padding(16.dp))
-                        }}
+                        val errorMsg = biometricError ?: state.error
+                        errorMsg?.let { err ->
+                            item {
+                                Text(err, color = MaterialTheme.colorScheme.error,
+                                    modifier = Modifier.padding(16.dp))
+                            }
+                        }
                         items(state.vaults, key = { it.id }) { vault ->
-                            VaultCard(vault = vault, onClick = { onVaultClick(vault.id) },
-                                onCheckIn = { vm.checkIn(vault.id) })
+                            VaultCard(
+                                vault = vault,
+                                onClick = { onVaultClick(vault.id) },
+                                onCheckIn = { pendingCheckIn = vault },
+                            )
                         }
                     }
                 }
             }
         }
     }
+}
+
+private fun formatInterval(seconds: Long): String {
+    val days = seconds / 86_400
+    return if (days > 0) "$days day${if (days == 1L) "" else "s"}" else "${seconds / 3_600}h"
+}
+
+@Composable
+private fun CheckInConfirmationDialog(vault: Vault, onConfirm: () -> Unit, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Confirm Check-In") },
+        text = {
+            Column {
+                Text("Vault: ${vault.id.take(12)}…",
+                    style = MaterialTheme.typography.bodyMedium)
+                Spacer(Modifier.height(4.dp))
+                Text("TTL will be extended by ${formatInterval(vault.checkInInterval)}.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Spacer(Modifier.height(4.dp))
+                Text("Biometric or PIN confirmation is required.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) { Text("Confirm") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
 }
 
 @Composable

--- a/mobile/android/gradle/libs.versions.toml
+++ b/mobile/android/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ kotlinx.serialization.json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 [versions]
 agp = "8.7.3"
 kotlin = "2.1.0"
+biometric = "1.2.0-alpha05"
 compose-bom = "2024.12.01"
 hilt = "2.53"
 ktor = "3.0.3"
@@ -34,6 +35,7 @@ ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serializatio
 ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
+biometric = { group = "androidx.biometric", name = "biometric", version.ref = "biometric" }
 credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
 credentials-play-services-auth = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentials" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }


### PR DESCRIPTION
## Summary

### #833 — WebSocket Message Rate Limiting
- Added `MessageRateLimiter` (sliding 1-second window, 10 msg/sec default) in `websocket.rs`
- `handle_vault_stream_with_heartbeat` sends WebSocket close code **1008 (Policy Violation)** when the limit is exceeded
- `read_client_frames` accepts a `rate_exceeded: Arc<Notify>` parameter to signal the owning loop to close the connection

### #834 — Database Migration Version Tracking Table
- `Db::migrate()` bootstraps a `schema_migrations` table before running any migrations
- Each numbered migration is only applied if its version row is absent from the tracking table, making re-runs on a partially-migrated DB safe
- Migration events (applied / skipped) are logged via `tracing` at startup

### #835 — Soft Delete for Vault Reminder Records
- Added `deleted_at TEXT` column to `reminder_preferences` via versioned migration "2"
- `Db::get()` and `Db::all()` filter `WHERE deleted_at IS NULL`; `Db::upsert()` resets `deleted_at = NULL` on conflict
- New `Db::soft_delete_reminder()` stamps the timestamp instead of removing the row
- New `DELETE /api/vaults/:id/reminder-preferences` → soft delete (204)
- New `GET /api/vaults/:id/reminders?include_deleted=true` → admin audit endpoint returning all records including soft-deleted ones
- `ReminderPreferences` model gains `deleted_at: Option<DateTime<Utc>>` (omitted from JSON when `None`)

### #836 — Biometric Prompt Before Check-In on Android
- Added `androidx.biometric:biometric:1.2.0-alpha05` to version catalog and `build.gradle.kts`
- New `BiometricHelper` service wraps `BiometricPrompt` for `ComponentActivity` with `BIOMETRIC_STRONG or DEVICE_CREDENTIAL` fallback to device PIN/pattern
- `VaultListScreen` gates the Check-In button behind a `CheckInConfirmationDialog` showing vault ID and expected TTL extension
- After confirmation, `BiometricHelper.authenticate()` is invoked; `vm.checkIn()` only fires on biometric success
- Auth errors surface in the vault list UI

## Test plan
- [ ] Backend: `cargo test` — existing tests pass; `ReminderPreferences` struct literals updated with `deleted_at: None`
- [ ] WebSocket: connect a client and send >10 messages/sec — verify server closes with code 1008
- [ ] Migration: run on a fresh DB and on an existing DB — confirm `schema_migrations` rows are created, no duplicate migrations
- [ ] Soft delete: POST then DELETE reminder prefs, verify GET returns 404; GET with `?include_deleted=true` returns the record with `deleted_at` set
- [ ] Android: tap Check-In → confirm dialog appears with vault ID + TTL info → confirm → biometric prompt → success triggers check-in; cancel or failure does not

Closes #833
Closes #834
Closes #835
Closes #836