### PR TITLE
feat(android): deep links, notification permissions, offline check-in queue, vault widget

### DIFF
--- a/backend/.well-known/assetlinks.json
+++ b/backend/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.ttllegacy",
+      "sha256_cert_fingerprints": [
+        "REPLACE_WITH_PRODUCTION_SHA256_CERT_FINGERPRINT"
+      ]
+    }
+  }
+]

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -74,6 +74,18 @@ dependencies {
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.messaging)
 
+    // Room (offline check-in queue)
+    implementation(libs.room.runtime)
+    implementation(libs.room.ktx)
+    ksp(libs.room.compiler)
+
+    // WorkManager
+    implementation(libs.work.runtime.ktx)
+
+    // Hilt WorkManager integration
+    implementation(libs.hilt.work)
+    ksp(libs.hilt.work.compiler)
+
     // Testing
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -15,11 +15,26 @@
         <activity
             android:name=".ui.MainActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:windowSoftInputMode="adjustResize">
+
+            <!-- Launcher -->
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <!-- Deep link: https://ttl-legacy.app/accept?vault_id=... (#838) -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="ttl-legacy.app"
+                    android:pathPrefix="/accept" />
+            </intent-filter>
+
         </activity>
 
         <service
@@ -29,6 +44,19 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+
+        <!-- Vault status home screen widget (#840) -->
+        <receiver
+            android:name=".widget.VaultStatusWidget"
+            android:exported="true"
+            android:label="Vault Status">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/vault_widget_info" />
+        </receiver>
 
         <!-- Passkey / Digital Asset Links -->
         <meta-data

--- a/mobile/android/app/src/main/java/com/ttllegacy/TTLLegacyApplication.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/TTLLegacyApplication.kt
@@ -1,7 +1,24 @@
 package com.ttllegacy
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
+import com.ttllegacy.widget.VaultWidgetUpdateWorker
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
-class TTLLegacyApplication : Application()
+class TTLLegacyApplication : Application(), Configuration.Provider {
+
+    @Inject lateinit var workerFactory: HiltWorkerFactory
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+
+    override fun onCreate() {
+        super.onCreate()
+        VaultWidgetUpdateWorker.schedule(this)
+    }
+}

--- a/mobile/android/app/src/main/java/com/ttllegacy/api/ApiClient.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/api/ApiClient.kt
@@ -48,6 +48,10 @@ class ApiClient @Inject constructor(
     suspend fun withdraw(vaultId: String, amount: Long): ApiResult<Vault> =
         post("/vaults/$vaultId/withdraw", mapOf("amount" to amount))
 
+    // Beneficiary
+    suspend fun acceptBeneficiary(vaultId: String): ApiResult<Unit> =
+        post("/vaults/$vaultId/accept", Unit)
+
     // Push
     suspend fun registerPushToken(token: String): ApiResult<Unit> =
         post("/notifications/register", PushRegistration(token = token))

--- a/mobile/android/app/src/main/java/com/ttllegacy/di/AppModule.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/di/AppModule.kt
@@ -1,11 +1,14 @@
 package com.ttllegacy.di
 
 import android.content.Context
+import androidx.work.WorkManager
 import com.ttllegacy.BuildConfig
 import com.ttllegacy.api.ApiClient
 import com.ttllegacy.api.NetworkMonitor
 import com.ttllegacy.api.OfflineCache
 import com.ttllegacy.api.TokenProvider
+import com.ttllegacy.services.CheckInDatabase
+import com.ttllegacy.services.PendingCheckInDao
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -23,4 +26,16 @@ object AppModule {
         networkMonitor: NetworkMonitor,
         offlineCache: OfflineCache
     ): ApiClient = ApiClient(tokenProvider, networkMonitor, offlineCache, BuildConfig.API_BASE_URL)
+
+    @Provides @Singleton
+    fun provideCheckInDatabase(@ApplicationContext context: Context): CheckInDatabase =
+        CheckInDatabase.create(context)
+
+    @Provides @Singleton
+    fun providePendingCheckInDao(db: CheckInDatabase): PendingCheckInDao =
+        db.pendingCheckInDao()
+
+    @Provides @Singleton
+    fun provideWorkManager(@ApplicationContext context: Context): WorkManager =
+        WorkManager.getInstance(context)
 }

--- a/mobile/android/app/src/main/java/com/ttllegacy/services/CheckInDatabase.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/services/CheckInDatabase.kt
@@ -1,0 +1,18 @@
+package com.ttllegacy.services
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(entities = [PendingCheckIn::class], version = 1, exportSchema = false)
+abstract class CheckInDatabase : RoomDatabase() {
+    abstract fun pendingCheckInDao(): PendingCheckInDao
+
+    companion object {
+        fun create(context: Context): CheckInDatabase =
+            Room.databaseBuilder(context, CheckInDatabase::class.java, "checkin_queue.db")
+                .fallbackToDestructiveMigration()
+                .build()
+    }
+}

--- a/mobile/android/app/src/main/java/com/ttllegacy/services/CheckInQueue.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/services/CheckInQueue.kt
@@ -1,0 +1,28 @@
+package com.ttllegacy.services
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+
+@Entity(tableName = "pending_checkins")
+data class PendingCheckIn(
+    @PrimaryKey val vaultId: String,
+    val queuedAt: Long
+)
+
+@Dao
+interface PendingCheckInDao {
+    @Query("SELECT * FROM pending_checkins ORDER BY queuedAt ASC")
+    suspend fun getAll(): List<PendingCheckIn>
+
+    @Query("SELECT COUNT(*) FROM pending_checkins")
+    fun observeCount(): Flow<Int>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(item: PendingCheckIn)
+
+    @Delete
+    suspend fun delete(item: PendingCheckIn)
+
+    @Query("DELETE FROM pending_checkins")
+    suspend fun deleteAll()
+}

--- a/mobile/android/app/src/main/java/com/ttllegacy/services/CheckInSyncWorker.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/services/CheckInSyncWorker.kt
@@ -1,0 +1,60 @@
+package com.ttllegacy.services
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.*
+import com.ttllegacy.api.ApiClient
+import com.ttllegacy.api.ApiResult
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import java.util.concurrent.TimeUnit
+
+@HiltWorker
+class CheckInSyncWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters,
+    private val apiClient: ApiClient,
+    private val dao: PendingCheckInDao,
+    private val notificationHelper: NotificationHelper
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        val pending = dao.getAll()
+        if (pending.isEmpty()) return Result.success()
+
+        var hasNetworkFailure = false
+        for (item in pending) {
+            when (apiClient.checkIn(item.vaultId)) {
+                is ApiResult.Success -> dao.delete(item)
+                ApiResult.NetworkUnavailable -> hasNetworkFailure = true
+                is ApiResult.Error -> dao.delete(item)
+            }
+        }
+
+        if (dao.getAll().isEmpty()) {
+            notificationHelper.cancelQueuedCheckIn()
+        }
+
+        return if (hasNetworkFailure) Result.retry() else Result.success()
+    }
+
+    companion object {
+        const val WORK_NAME = "checkin_sync"
+
+        fun schedule(context: Context) {
+            val request = OneTimeWorkRequestBuilder<CheckInSyncWorker>()
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build()
+                )
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                WORK_NAME,
+                ExistingWorkPolicy.KEEP,
+                request
+            )
+        }
+    }
+}

--- a/mobile/android/app/src/main/java/com/ttllegacy/services/NotificationHelper.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/services/NotificationHelper.kt
@@ -17,9 +17,15 @@ class NotificationHelper @Inject constructor(@ApplicationContext private val con
     companion object {
         const val CHANNEL_ID = "ttl_reminders"
         const val CHANNEL_NAME = "Check-in Reminders"
+        const val QUEUED_CHANNEL_ID = "ttl_queued"
+        const val QUEUED_CHANNEL_NAME = "Queued Check-ins"
+        const val QUEUED_NOTIFICATION_ID = 9_001
     }
 
-    init { createChannel() }
+    init {
+        createChannel(CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_HIGH)
+        createChannel(QUEUED_CHANNEL_ID, QUEUED_CHANNEL_NAME, NotificationManager.IMPORTANCE_DEFAULT)
+    }
 
     fun show(title: String, body: String, vaultId: String?) {
         val intent = Intent(context, MainActivity::class.java).apply {
@@ -42,8 +48,36 @@ class NotificationHelper @Inject constructor(@ApplicationContext private val con
         nm.notify(vaultId.hashCode(), notification)
     }
 
-    private fun createChannel() {
-        val channel = NotificationChannel(CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_HIGH)
+    fun showQueuedCheckIn(count: Int) {
+        val intent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        val pi = PendingIntent.getActivity(context, QUEUED_NOTIFICATION_ID, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+
+        val body = if (count == 1) "1 check-in will be submitted when back online"
+                   else "$count check-ins will be submitted when back online"
+
+        val notification = NotificationCompat.Builder(context, QUEUED_CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_lock_idle_lock)
+            .setContentTitle("Check-in queued")
+            .setContentText(body)
+            .setOngoing(true)
+            .setAutoCancel(false)
+            .setContentIntent(pi)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .build()
+
+        context.getSystemService(NotificationManager::class.java)
+            .notify(QUEUED_NOTIFICATION_ID, notification)
+    }
+
+    fun cancelQueuedCheckIn() {
+        context.getSystemService(NotificationManager::class.java).cancel(QUEUED_NOTIFICATION_ID)
+    }
+
+    private fun createChannel(id: String, name: String, importance: Int) {
+        val channel = NotificationChannel(id, name, importance)
         context.getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
     }
 }

--- a/mobile/android/app/src/main/java/com/ttllegacy/ui/MainActivity.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/ui/MainActivity.kt
@@ -1,35 +1,124 @@
 package com.ttllegacy.ui
 
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.ttllegacy.ui.screens.AuthScreen
+import com.ttllegacy.ui.screens.BeneficiaryAcceptanceScreen
 import com.ttllegacy.ui.screens.VaultListScreen
 import com.ttllegacy.ui.theme.TTLLegacyTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    private var pendingDeepLinkVaultId by mutableStateOf<String?>(null)
+    private var showPermissionRationale by mutableStateOf(false)
+
+    private val notificationPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { /* result handled gracefully — denial does not break the app */ }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        pendingDeepLinkVaultId = extractDeepLinkVaultId(intent)
+
         setContent {
             TTLLegacyTheme {
-                AppNavigation()
+                NotificationPermissionEffect(
+                    showRationale = showPermissionRationale,
+                    onRationaleShown = { showPermissionRationale = false },
+                    onRequestPermission = {
+                        showPermissionRationale = false
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                        }
+                    }
+                )
+                AppNavigation(
+                    deepLinkVaultId = pendingDeepLinkVaultId,
+                    onDeepLinkConsumed = { pendingDeepLinkVaultId = null }
+                )
             }
         }
+
+        requestNotificationPermissionIfNeeded()
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        pendingDeepLinkVaultId = extractDeepLinkVaultId(intent)
+    }
+
+    private fun requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        when {
+            checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED -> Unit
+            shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) ->
+                showPermissionRationale = true
+            else ->
+                notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
+
+    private fun extractDeepLinkVaultId(intent: Intent): String? =
+        intent.data
+            ?.takeIf { it.scheme == "https" && it.host == "ttl-legacy.app" && it.path == "/accept" }
+            ?.getQueryParameter("vault_id")
+}
+
+@Composable
+private fun NotificationPermissionEffect(
+    showRationale: Boolean,
+    onRationaleShown: () -> Unit,
+    onRequestPermission: () -> Unit
+) {
+    if (showRationale) {
+        AlertDialog(
+            onDismissRequest = onRationaleShown,
+            title = { Text("Stay Notified") },
+            text = {
+                Text(
+                    "TTL-Legacy needs notification permission to alert you before your vault " +
+                    "expires and remind you to check in. Without it, reminders will not be delivered."
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = onRequestPermission) { Text("Allow") }
+            },
+            dismissButton = {
+                TextButton(onClick = onRationaleShown) { Text("Not now") }
+            }
+        )
     }
 }
 
 @Composable
-private fun AppNavigation() {
+private fun AppNavigation(
+    deepLinkVaultId: String?,
+    onDeepLinkConsumed: () -> Unit
+) {
     val navController = rememberNavController()
     val authVm: AuthViewModel = hiltViewModel()
     val authState by authVm.state.collectAsStateWithLifecycle()
@@ -39,10 +128,25 @@ private fun AppNavigation() {
         else navController.navigate("auth") { popUpTo("vaults") { inclusive = true } }
     }
 
+    LaunchedEffect(deepLinkVaultId) {
+        if (deepLinkVaultId != null && authState.isAuthenticated) {
+            navController.navigate("accept/$deepLinkVaultId")
+            onDeepLinkConsumed()
+        }
+    }
+
     NavHost(navController, startDestination = if (authState.isAuthenticated) "vaults" else "auth") {
         composable("auth") { AuthScreen(vm = authVm) }
         composable("vaults") {
             VaultListScreen(onVaultClick = { /* navigate to detail */ })
+        }
+        composable("accept/{vaultId}") { backStack ->
+            val vaultId = backStack.arguments?.getString("vaultId") ?: return@composable
+            BeneficiaryAcceptanceScreen(
+                vaultId = vaultId,
+                onAccepted = { navController.popBackStack() },
+                onDecline = { navController.popBackStack() }
+            )
         }
     }
 }

--- a/mobile/android/app/src/main/java/com/ttllegacy/ui/ViewModels.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/ui/ViewModels.kt
@@ -1,6 +1,7 @@
 package com.ttllegacy.ui
 
 import android.app.Activity
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ttllegacy.api.ApiClient
@@ -8,9 +9,13 @@ import com.ttllegacy.api.ApiResult
 import com.ttllegacy.api.TokenProvider
 import com.ttllegacy.models.CreateVaultRequest
 import com.ttllegacy.models.Vault
+import com.ttllegacy.services.CheckInSyncWorker
 import com.ttllegacy.services.NotificationHelper
 import com.ttllegacy.services.PasskeyService
+import com.ttllegacy.services.PendingCheckIn
+import com.ttllegacy.services.PendingCheckInDao
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -66,7 +71,9 @@ data class VaultUiState(
 @HiltViewModel
 class VaultViewModel @Inject constructor(
     private val apiClient: ApiClient,
-    private val notificationHelper: NotificationHelper
+    private val notificationHelper: NotificationHelper,
+    private val pendingCheckInDao: PendingCheckInDao,
+    @ApplicationContext private val context: Context
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(VaultUiState())
@@ -91,7 +98,13 @@ class VaultViewModel @Inject constructor(
         when (val result = apiClient.checkIn(vaultId)) {
             is ApiResult.Success -> load()
             is ApiResult.Error -> _state.update { it.copy(error = result.message) }
-            ApiResult.NetworkUnavailable -> _state.update { it.copy(error = "No network — check-in queued") }
+            ApiResult.NetworkUnavailable -> {
+                pendingCheckInDao.insert(PendingCheckIn(vaultId = vaultId, queuedAt = System.currentTimeMillis()))
+                val queued = pendingCheckInDao.getAll()
+                notificationHelper.showQueuedCheckIn(queued.size)
+                CheckInSyncWorker.schedule(context)
+                _state.update { it.copy(error = "Offline — check-in queued and will retry automatically") }
+            }
         }
     }
 
@@ -101,6 +114,32 @@ class VaultViewModel @Inject constructor(
             is ApiResult.Success -> load()
             is ApiResult.Error -> _state.update { it.copy(error = result.message) }
             ApiResult.NetworkUnavailable -> _state.update { it.copy(error = "No network") }
+        }
+    }
+}
+
+// --- Acceptance ViewModel ---
+
+data class AcceptanceUiState(
+    val isLoading: Boolean = false,
+    val isAccepted: Boolean = false,
+    val error: String? = null
+)
+
+@HiltViewModel
+class AcceptanceViewModel @Inject constructor(
+    private val apiClient: ApiClient
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(AcceptanceUiState())
+    val state = _state.asStateFlow()
+
+    fun accept(vaultId: String) = viewModelScope.launch {
+        _state.update { it.copy(isLoading = true, error = null) }
+        when (val result = apiClient.acceptBeneficiary(vaultId)) {
+            is ApiResult.Success -> _state.update { it.copy(isLoading = false, isAccepted = true) }
+            is ApiResult.Error -> _state.update { it.copy(isLoading = false, error = result.message) }
+            ApiResult.NetworkUnavailable -> _state.update { it.copy(isLoading = false, error = "No network. Please try again.") }
         }
     }
 }

--- a/mobile/android/app/src/main/java/com/ttllegacy/ui/screens/Screens.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/ui/screens/Screens.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ttllegacy.models.Vault
+import com.ttllegacy.ui.AcceptanceViewModel
 import com.ttllegacy.ui.AuthViewModel
 import com.ttllegacy.ui.VaultViewModel
 
@@ -188,6 +189,73 @@ private fun StatusChip(status: com.ttllegacy.models.VaultStatus) {
     }
     SuggestionChip(onClick = {}, label = { Text(label, style = MaterialTheme.typography.labelSmall) },
         colors = SuggestionChipDefaults.suggestionChipColors(labelColor = color))
+}
+
+// MARK: - Beneficiary Acceptance Screen
+
+@Composable
+fun BeneficiaryAcceptanceScreen(
+    vaultId: String,
+    onAccepted: () -> Unit,
+    onDecline: () -> Unit,
+    vm: AcceptanceViewModel = hiltViewModel()
+) {
+    val state by vm.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(state.isAccepted) {
+        if (state.isAccepted) onAccepted()
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            Icons.Default.Lock,
+            contentDescription = null,
+            modifier = Modifier.size(56.dp),
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Spacer(Modifier.height(16.dp))
+        Text("Beneficiary Acceptance", style = MaterialTheme.typography.headlineSmall)
+        Spacer(Modifier.height(8.dp))
+        Text(
+            "You have been named as the beneficiary for the following vault:",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(12.dp))
+        OutlinedTextField(
+            value = vaultId,
+            onValueChange = {},
+            label = { Text("Vault ID") },
+            readOnly = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+        state.error?.let {
+            Spacer(Modifier.height(8.dp))
+            Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+        }
+        Spacer(Modifier.height(24.dp))
+        Button(
+            onClick = { vm.accept(vaultId) },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !state.isLoading
+        ) {
+            if (state.isLoading) CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp)
+            else Text("Accept")
+        }
+        Spacer(Modifier.height(8.dp))
+        OutlinedButton(
+            onClick = onDecline,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !state.isLoading
+        ) {
+            Text("Decline")
+        }
+    }
 }
 
 @Composable

--- a/mobile/android/app/src/main/java/com/ttllegacy/widget/VaultStatusWidget.kt
+++ b/mobile/android/app/src/main/java/com/ttllegacy/widget/VaultStatusWidget.kt
@@ -1,0 +1,119 @@
+package com.ttllegacy.widget
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.widget.RemoteViews
+import androidx.hilt.work.HiltWorker
+import androidx.work.*
+import com.ttllegacy.R
+import com.ttllegacy.api.ApiClient
+import com.ttllegacy.api.ApiResult
+import com.ttllegacy.ui.MainActivity
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import java.util.concurrent.TimeUnit
+
+class VaultStatusWidget : AppWidgetProvider() {
+
+    override fun onUpdate(context: Context, manager: AppWidgetManager, widgetIds: IntArray) {
+        widgetIds.forEach { updateWidget(context, manager, it) }
+    }
+
+    companion object {
+        private const val PREFS = "vault_widget_prefs"
+        private const val KEY_VAULT_NAME = "vault_name"
+        private const val KEY_TTL = "ttl_remaining"
+        private const val KEY_LAST_CHECK_IN = "last_check_in"
+
+        fun saveVaultData(context: Context, vaultName: String, ttlRemaining: String, lastCheckIn: String) {
+            context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit()
+                .putString(KEY_VAULT_NAME, vaultName)
+                .putString(KEY_TTL, ttlRemaining)
+                .putString(KEY_LAST_CHECK_IN, lastCheckIn)
+                .apply()
+        }
+
+        fun updateWidget(context: Context, manager: AppWidgetManager, widgetId: Int) {
+            val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            val vaultName = prefs.getString(KEY_VAULT_NAME, "—") ?: "—"
+            val ttl = prefs.getString(KEY_TTL, "Unknown") ?: "Unknown"
+            val lastCheckIn = prefs.getString(KEY_LAST_CHECK_IN, "Never") ?: "Never"
+
+            val openIntent = Intent(context, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
+            val pendingIntent = PendingIntent.getActivity(
+                context, 0, openIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+
+            val views = RemoteViews(context.packageName, R.layout.vault_widget).apply {
+                setTextViewText(R.id.widget_vault_name, vaultName)
+                setTextViewText(R.id.widget_ttl, "TTL: $ttl")
+                setTextViewText(R.id.widget_last_check_in, "Last check-in: $lastCheckIn")
+                setOnClickPendingIntent(R.id.widget_root, pendingIntent)
+            }
+            manager.updateAppWidget(widgetId, views)
+        }
+
+        fun refreshAll(context: Context) {
+            val manager = AppWidgetManager.getInstance(context)
+            val ids = manager.getAppWidgetIds(ComponentName(context, VaultStatusWidget::class.java))
+            ids.forEach { updateWidget(context, manager, it) }
+        }
+    }
+}
+
+@HiltWorker
+class VaultWidgetUpdateWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters,
+    private val apiClient: ApiClient
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        val result = apiClient.listVaults()
+        if (result is ApiResult.Success) {
+            val vault = result.data.firstOrNull() ?: return Result.success()
+            val ttl = formatTtl(vault.ttlRemaining)
+            VaultStatusWidget.saveVaultData(
+                applicationContext,
+                vaultName = vault.id.take(12) + "…",
+                ttlRemaining = ttl,
+                lastCheckIn = vault.lastCheckIn
+            )
+            VaultStatusWidget.refreshAll(applicationContext)
+        }
+        return Result.success()
+    }
+
+    private fun formatTtl(seconds: Long?): String {
+        if (seconds == null) return "Unknown"
+        val days = seconds / 86400
+        val hours = (seconds % 86400) / 3600
+        return if (days > 0) "${days}d ${hours}h" else "${hours}h"
+    }
+
+    companion object {
+        const val WORK_NAME = "vault_widget_update"
+
+        fun schedule(context: Context) {
+            val request = PeriodicWorkRequestBuilder<VaultWidgetUpdateWorker>(15, TimeUnit.MINUTES)
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build()
+                )
+                .build()
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                request
+            )
+        }
+    }
+}

--- a/mobile/android/app/src/main/res/layout/vault_widget.xml
+++ b/mobile/android/app/src/main/res/layout/vault_widget.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="12dp"
+    android:background="#FF1C1C1E">
+
+    <TextView
+        android:id="@+id/widget_vault_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:textSize="14sp"
+        android:textColor="#FFFFFFFF"
+        android:text="—"
+        android:maxLines="1"
+        android:ellipsize="end" />
+
+    <TextView
+        android:id="@+id/widget_ttl"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="12sp"
+        android:textColor="#FFEBEBF5"
+        android:layout_marginTop="4dp"
+        android:text="TTL: —" />
+
+    <TextView
+        android:id="@+id/widget_last_check_in"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="12sp"
+        android:textColor="#FFEBEBF5"
+        android:layout_marginTop="4dp"
+        android:text="Last check-in: —" />
+
+</LinearLayout>

--- a/mobile/android/app/src/main/res/xml/vault_widget_info.xml
+++ b/mobile/android/app/src/main/res/xml/vault_widget_info.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="180dp"
+    android:minHeight="110dp"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/vault_widget"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" />

--- a/mobile/android/gradle/libs.versions.toml
+++ b/mobile/android/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ agp = "8.7.3"
 kotlin = "2.1.0"
 compose-bom = "2024.12.01"
 hilt = "2.53"
+hilt-androidx = "1.2.0"
 ktor = "3.0.3"
 lifecycle = "2.8.7"
 navigation = "2.8.5"
@@ -13,6 +14,8 @@ firebase-bom = "33.7.0"
 datastore = "1.1.1"
 coroutines = "1.9.0"
 mockk = "1.13.13"
+room = "2.6.1"
+work = "2.10.0"
 
 [libraries]
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
@@ -27,7 +30,13 @@ lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-
 lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version = "1.2.0" }
+hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hilt-androidx" }
+hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hilt-androidx" }
+hilt-work-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hilt-androidx" }
+room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 ktor-client-android = { group = "io.ktor", name = "ktor-client-android", version.ref = "ktor" }
 ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }


### PR DESCRIPTION
## Summary

This PR implements four Android enhancements:

### #838 — Deep Link Handling for Beneficiary Acceptance
- Added `intent-filter` in `AndroidManifest.xml` with `android:autoVerify="true"` for `https://ttl-legacy.app/accept?vault_id=...`, routing acceptance email links directly into the app via Android App Links instead of the browser.
- `MainActivity` extracts the `vault_id` from the incoming URI in both `onCreate()` and `onNewIntent()` (`singleTask` launch mode ensures correct re-entry when the app is already running).
- Added an `accept/{vaultId}` nav destination wired to a new `BeneficiaryAcceptanceScreen` composable with the vault ID pre-populated, plus Accept / Decline actions.
- Added `ApiClient.acceptBeneficiary()` calling `POST /vaults/{id}/accept` and a backing `AcceptanceViewModel`.
- Created `backend/.well-known/assetlinks.json` with the Digital Asset Links entry required for App Link verification — **the SHA-256 cert fingerprint must be replaced before production deployment** and the file must be served at `https://ttl-legacy.app/.well-known/assetlinks.json`.

### #839 — Push Notification Permission Request Flow (Android 13+)
- `MainActivity.requestNotificationPermissionIfNeeded()` follows the three-branch pattern on API 33+:
  1. Already granted → no-op.
  2. `shouldShowRequestPermissionRationale` → shows an educational `AlertDialog` explaining why the permission is needed before the system prompt appears.
  3. First request / silently denied → launches the system permission dialog directly.
- Denial is handled gracefully — the app continues to function without notifications; users can re-enable from system settings at any time.

### #837 — Offline Check-In Queuing
- New **Room database** (`CheckInDatabase` v1) with a `pending_checkins` table backed by `PendingCheckIn` entity and `PendingCheckInDao`.
- `VaultViewModel.checkIn()` now handles `NetworkUnavailable` by inserting into the Room queue, showing a persistent "check-in queued" notification, and scheduling `CheckInSyncWorker`.
- `CheckInSyncWorker` (`@HiltWorker` / `CoroutineWorker`) runs under a `CONNECTED` network constraint, flushes all queued check-ins, and cancels the notification once the queue is empty. Permanent API errors drop the item; transient network failures return `Result.retry()` with exponential back-off.
- `TTLLegacyApplication` now implements `Configuration.Provider` and injects `HiltWorkerFactory` so `@HiltWorker` dependencies resolve correctly.
- `NotificationHelper` gains `showQueuedCheckIn(count)` (ongoing, non-dismissible) and `cancelQueuedCheckIn()` on a dedicated `ttl_queued` channel.
- Room, WorkManager, and Hilt-Work dependencies added to `build.gradle.kts` and `libs.versions.toml`.

### #840 — Vault Status Home Screen Widget
- `VaultStatusWidget` (`AppWidgetProvider`) renders vault name, TTL remaining, and last check-in time via `RemoteViews` (`res/layout/vault_widget.xml`). Tapping the widget opens the app.
- Widget metadata (`res/xml/vault_widget_info.xml`): 180 × 110 dp minimum, `updatePeriodMillis=0` (updates driven by WorkManager).
- `VaultWidgetUpdateWorker` runs every 15 minutes under a `CONNECTED` constraint — fetches vaults, writes to `SharedPreferences`, and pushes updated `RemoteViews` to all widget instances.
- Widget receiver registered in `AndroidManifest.xml`; worker scheduled from `TTLLegacyApplication.onCreate()`.

## Files changed

| File | Change |
|---|---|
| `AndroidManifest.xml` | Deep link intent-filter, widget receiver, `singleTask` launch mode |
| `MainActivity.kt` | Deep link extraction + `onNewIntent`, notification permission flow |
| `ViewModels.kt` | `VaultViewModel` offline queuing, new `AcceptanceViewModel` |
| `screens/Screens.kt` | New `BeneficiaryAcceptanceScreen` |
| `api/ApiClient.kt` | `acceptBeneficiary()` endpoint |
| `services/CheckInQueue.kt` | Room entity + DAO *(new)* |
| `services/CheckInDatabase.kt` | Room database *(new)* |
| `services/CheckInSyncWorker.kt` | WorkManager sync worker *(new)* |
| `services/NotificationHelper.kt` | Queued notification methods + channel |
| `widget/VaultStatusWidget.kt` | AppWidgetProvider + update worker *(new)* |
| `res/layout/vault_widget.xml` | Widget RemoteViews layout *(new)* |
| `res/xml/vault_widget_info.xml` | AppWidget metadata *(new)* |
| `TTLLegacyApplication.kt` | `Configuration.Provider` for Hilt-Work |
| `di/AppModule.kt` | Room, DAO, WorkManager singletons |
| `build.gradle.kts` | Room, WorkManager, Hilt-Work dependencies |
| `gradle/libs.versions.toml` | New version entries |
| `backend/.well-known/assetlinks.json` | App Link verification file *(new)* |

Closes #837
Closes #838
Closes #839
Closes #840