### PR TITLE
feat: add vault release simulator endpoint and UI

### DIFF
--- a/backend/simulator.html
+++ b/backend/simulator.html
@@ -1,0 +1,497 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>TTL-Legacy — Release Simulator</title>
+  <style>
+    /* ── Reset & base ─────────────────────────────────────────────────── */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:        #0f1117;
+      --surface:   #1a1d27;
+      --border:    #2a2e3f;
+      --text:      #e2e8f0;
+      --muted:     #8892a4;
+      --accent:    #6366f1;
+      --accent-h:  #818cf8;
+      --danger:    #ef4444;
+      --warn:      #f59e0b;
+      --success:   #22c55e;
+      --radius:    0.75rem;
+    }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+      font-size: 15px;
+      line-height: 1.6;
+      min-height: 100vh;
+      padding: 2rem 1rem;
+    }
+
+    /* ── Layout ───────────────────────────────────────────────────────── */
+    .container { max-width: 860px; margin: 0 auto; }
+
+    header {
+      margin-bottom: 2.5rem;
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 1.5rem;
+    }
+    header h1 {
+      font-size: 1.75rem;
+      font-weight: 700;
+      color: var(--accent-h);
+      letter-spacing: -0.02em;
+    }
+    header p { color: var(--muted); margin-top: 0.4rem; }
+
+    /* ── Card ─────────────────────────────────────────────────────────── */
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+    .card-title {
+      font-size: 0.8rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      margin-bottom: 1rem;
+    }
+
+    /* ── Form ─────────────────────────────────────────────────────────── */
+    .form-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+    }
+    @media (max-width: 580px) { .form-grid { grid-template-columns: 1fr; } }
+
+    .field { display: flex; flex-direction: column; gap: 0.35rem; }
+    .field label { font-size: 0.85rem; color: var(--muted); font-weight: 500; }
+    .field input, .field select {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 0.4rem;
+      color: var(--text);
+      font-size: 0.95rem;
+      padding: 0.5rem 0.75rem;
+      outline: none;
+      transition: border-color 0.15s;
+    }
+    .field input:focus, .field select:focus { border-color: var(--accent); }
+
+    /* checkboxes */
+    .checkboxes { display: flex; flex-wrap: wrap; gap: 0.75rem; }
+    .checkboxes label {
+      display: flex; align-items: center; gap: 0.4rem;
+      font-size: 0.9rem; cursor: pointer; color: var(--text);
+    }
+    .checkboxes input[type=checkbox] { accent-color: var(--accent); width: 15px; height: 15px; }
+
+    .run-btn {
+      margin-top: 1.25rem;
+      background: var(--accent);
+      color: #fff;
+      border: none;
+      border-radius: 0.5rem;
+      font-size: 0.95rem;
+      font-weight: 600;
+      padding: 0.65rem 1.75rem;
+      cursor: pointer;
+      transition: background 0.15s, transform 0.1s;
+    }
+    .run-btn:hover { background: var(--accent-h); }
+    .run-btn:active { transform: scale(0.98); }
+    .run-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    /* ── Vault meta row ───────────────────────────────────────────────── */
+    .meta-row {
+      display: flex; flex-wrap: wrap; gap: 1rem;
+      font-size: 0.85rem; color: var(--muted);
+      margin-bottom: 1.25rem;
+    }
+    .meta-row span strong { color: var(--text); }
+
+    /* ── Scenario cards ───────────────────────────────────────────────── */
+    .scenarios-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+      gap: 1rem;
+    }
+
+    .scenario-card {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.25rem;
+      position: relative;
+      overflow: hidden;
+    }
+    .scenario-card::before {
+      content: '';
+      position: absolute;
+      top: 0; left: 0; right: 0;
+      height: 3px;
+    }
+    .scenario-card.high::before   { background: var(--success); }
+    .scenario-card.medium::before { background: var(--warn); }
+    .scenario-card.low::before    { background: var(--danger); }
+
+    .scenario-name {
+      font-size: 0.75rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+      color: var(--muted);
+      margin-bottom: 0.5rem;
+    }
+    .scenario-release {
+      font-size: 1.05rem;
+      font-weight: 700;
+      color: var(--text);
+      margin-bottom: 0.25rem;
+    }
+    .scenario-release.never { color: var(--success); }
+
+    .scenario-countdown {
+      font-size: 0.85rem;
+      color: var(--muted);
+      margin-bottom: 0.75rem;
+    }
+    .scenario-desc {
+      font-size: 0.82rem;
+      color: var(--muted);
+      line-height: 1.5;
+      margin-bottom: 0.6rem;
+    }
+    .scenario-notes {
+      font-size: 0.78rem;
+      color: var(--muted);
+      opacity: 0.8;
+      border-top: 1px solid var(--border);
+      padding-top: 0.6rem;
+    }
+
+    .confidence-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3rem;
+      font-size: 0.72rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      padding: 0.2rem 0.55rem;
+      border-radius: 99px;
+      margin-bottom: 0.75rem;
+    }
+    .confidence-badge.high   { background: rgba(34,197,94,.15);  color: var(--success); }
+    .confidence-badge.medium { background: rgba(245,158,11,.15); color: var(--warn); }
+    .confidence-badge.low    { background: rgba(239,68,68,.15);  color: var(--danger); }
+
+    /* ── Status / error ───────────────────────────────────────────────── */
+    .status-msg {
+      font-size: 0.88rem;
+      padding: 0.75rem 1rem;
+      border-radius: 0.45rem;
+      margin-top: 0.75rem;
+    }
+    .status-msg.error { background: rgba(239,68,68,.12); color: var(--danger); border: 1px solid rgba(239,68,68,.3); }
+    .status-msg.info  { background: rgba(99,102,241,.1);  color: var(--accent-h); border: 1px solid rgba(99,102,241,.25); }
+
+    /* ── Spinner ─────────────────────────────────────────────────────── */
+    .spinner {
+      display: inline-block;
+      width: 16px; height: 16px;
+      border: 2px solid rgba(255,255,255,.25);
+      border-top-color: #fff;
+      border-radius: 50%;
+      animation: spin 0.6s linear infinite;
+      vertical-align: middle;
+      margin-right: 0.5rem;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    /* ── Timeline bar ─────────────────────────────────────────────────── */
+    .timeline {
+      margin-top: 1.5rem;
+    }
+    .timeline-title {
+      font-size: 0.8rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+      color: var(--muted);
+      margin-bottom: 1rem;
+    }
+    .tl-row {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 0.7rem;
+      font-size: 0.82rem;
+    }
+    .tl-label {
+      width: 175px;
+      flex-shrink: 0;
+      color: var(--muted);
+      text-align: right;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .tl-bar-track {
+      flex: 1;
+      background: var(--border);
+      border-radius: 99px;
+      height: 10px;
+      position: relative;
+    }
+    .tl-bar-fill {
+      height: 100%;
+      border-radius: 99px;
+      transition: width 0.4s ease;
+    }
+    .tl-days {
+      width: 80px;
+      flex-shrink: 0;
+      color: var(--text);
+      font-weight: 600;
+    }
+    .never-text { color: var(--success); font-style: italic; }
+  </style>
+</head>
+<body>
+<div class="container">
+  <header>
+    <h1>🕰️ Release Simulator</h1>
+    <p>Project when your TTL-Legacy vault will release to its beneficiary based on check-in behaviour scenarios.</p>
+  </header>
+
+  <!-- ── Input Card ────────────────────────────────────────────────────── -->
+  <div class="card">
+    <p class="card-title">Simulation Parameters</p>
+    <div class="form-grid">
+      <div class="field">
+        <label for="apiBase">API Base URL</label>
+        <input id="apiBase" type="text" value="http://localhost:3000" placeholder="http://localhost:3000" />
+      </div>
+      <div class="field">
+        <label for="vaultId">Vault ID</label>
+        <input id="vaultId" type="text" placeholder="e.g. vault-abc-123" />
+      </div>
+      <div class="field">
+        <label for="missedCount">Missed Check-ins (for "missed" scenario)</label>
+        <input id="missedCount" type="number" value="1" min="1" max="100" />
+      </div>
+      <div class="field" style="align-self: end;">
+        <label>Scenarios to Simulate</label>
+        <div class="checkboxes">
+          <label><input type="checkbox" id="s-no-check-ins" value="no_check_ins" checked /> No check-ins</label>
+          <label><input type="checkbox" id="s-consistent" value="consistent_check_ins" checked /> Consistent</label>
+          <label><input type="checkbox" id="s-missed" value="missed_check_in_dates" checked /> Missed dates</label>
+        </div>
+      </div>
+    </div>
+    <button class="run-btn" id="runBtn" onclick="runSimulation()">▶ Run Simulation</button>
+    <div id="statusMsg"></div>
+  </div>
+
+  <!-- ── Results ──────────────────────────────────────────────────────── -->
+  <div id="results" style="display:none;">
+    <!-- Vault meta -->
+    <div class="meta-row" id="vaultMeta"></div>
+
+    <!-- Scenario cards -->
+    <div class="card" id="scenariosCard" style="padding-bottom:1rem;">
+      <p class="card-title">Projected Release Dates</p>
+      <div class="scenarios-grid" id="scenariosGrid"></div>
+    </div>
+
+    <!-- Timeline -->
+    <div class="card">
+      <div class="timeline">
+        <p class="timeline-title">Relative Timeline (days until release)</p>
+        <div id="timelineRows"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+/* ── Helpers ──────────────────────────────────────────────────────────── */
+
+function formatDate(isoStr) {
+  if (!isoStr) return '—';
+  const d = new Date(isoStr);
+  return d.toLocaleString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit', timeZoneName: 'short'
+  });
+}
+
+function humanDuration(seconds) {
+  if (seconds < 0) return 'Never (vault held open)';
+  if (seconds === 0) return 'Immediately (TTL already expired)';
+  const d = Math.floor(seconds / 86400);
+  const h = Math.floor((seconds % 86400) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const parts = [];
+  if (d > 0) parts.push(`${d}d`);
+  if (h > 0) parts.push(`${h}h`);
+  if (m > 0) parts.push(`${m}m`);
+  if (parts.length === 0) parts.push(`${seconds}s`);
+  return parts.join(' ');
+}
+
+function scenarioLabel(key) {
+  return {
+    no_check_ins:         'No Check-ins',
+    consistent_check_ins: 'Consistent Check-ins',
+    missed_check_in_dates:'Missed Check-in Dates',
+  }[key] ?? key;
+}
+
+function barColor(confidence) {
+  return { high: '#22c55e', medium: '#f59e0b', low: '#ef4444' }[confidence] ?? '#6366f1';
+}
+
+/* ── Main simulation call ─────────────────────────────────────────────── */
+
+async function runSimulation() {
+  const btn      = document.getElementById('runBtn');
+  const statusEl = document.getElementById('statusMsg');
+  const resultsEl= document.getElementById('results');
+
+  const apiBase   = document.getElementById('apiBase').value.trim().replace(/\/$/, '');
+  const vaultId   = document.getElementById('vaultId').value.trim();
+  const missed    = document.getElementById('missedCount').value || '1';
+
+  const scenarios = ['no_check_ins', 'consistent_check_ins', 'missed_check_in_dates']
+    .filter(v => document.querySelector(`input[value="${v}"]`)?.checked);
+
+  // Validation
+  statusEl.innerHTML = '';
+  if (!vaultId) {
+    statusEl.innerHTML = '<div class="status-msg error">Please enter a Vault ID.</div>';
+    return;
+  }
+  if (scenarios.length === 0) {
+    statusEl.innerHTML = '<div class="status-msg error">Select at least one scenario.</div>';
+    return;
+  }
+
+  btn.disabled = true;
+  btn.innerHTML = '<span class="spinner"></span>Simulating…';
+  resultsEl.style.display = 'none';
+
+  const params = new URLSearchParams({
+    scenarios: scenarios.join(','),
+    missed_count: missed,
+  });
+  const url = `${apiBase}/api/vaults/${encodeURIComponent(vaultId)}/simulate-release?${params}`;
+
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ message: res.statusText }));
+      throw new Error(err.message ?? `HTTP ${res.status}`);
+    }
+    const data = await res.json();
+    renderResults(data);
+    resultsEl.style.display = 'block';
+    statusEl.innerHTML = '';
+  } catch (e) {
+    statusEl.innerHTML = `<div class="status-msg error">⚠ ${e.message}</div>`;
+  } finally {
+    btn.disabled = false;
+    btn.textContent = '▶ Run Simulation';
+  }
+}
+
+/* ── Render ────────────────────────────────────────────────────────────── */
+
+function renderResults(data) {
+  // ── Meta row ──────────────────────────────────────────────────────────
+  const ttlDays = data.current_ttl_remaining != null
+    ? `${(data.current_ttl_remaining / 86400).toFixed(1)} days`
+    : 'unknown';
+  const intervalDays = (data.check_in_interval / 86400).toFixed(1);
+
+  document.getElementById('vaultMeta').innerHTML = `
+    <span>Vault <strong>${escHtml(data.vault_id)}</strong></span>
+    <span>TTL remaining: <strong>${escHtml(ttlDays)}</strong></span>
+    <span>Check-in interval: <strong>${intervalDays} days</strong></span>
+    <span>Last check-in: <strong>${formatDate(data.last_check_in)}</strong></span>
+    <span>Simulated at: <strong>${formatDate(data.simulated_at)}</strong></span>
+  `;
+
+  // ── Scenario cards ────────────────────────────────────────────────────
+  const grid = document.getElementById('scenariosGrid');
+  grid.innerHTML = '';
+
+  const nonNeverSeconds = data.scenarios
+    .filter(s => s.seconds_until_release >= 0)
+    .map(s => s.seconds_until_release);
+  const maxSecs = nonNeverSeconds.length > 0 ? Math.max(...nonNeverSeconds) : 1;
+
+  const timelineRows = document.getElementById('timelineRows');
+  timelineRows.innerHTML = '';
+
+  data.scenarios.forEach(s => {
+    const isNever = s.seconds_until_release < 0;
+    const days = isNever ? null : (s.seconds_until_release / 86400).toFixed(1);
+
+    // Scenario card
+    const card = document.createElement('div');
+    card.className = `scenario-card ${s.confidence}`;
+    card.innerHTML = `
+      <p class="scenario-name">${escHtml(scenarioLabel(s.scenario))}</p>
+      <span class="confidence-badge ${s.confidence}">${s.confidence} confidence</span>
+      <p class="scenario-release ${isNever ? 'never' : ''}">
+        ${isNever ? '♾ Vault never releases' : escHtml(formatDate(s.projected_release_at))}
+      </p>
+      <p class="scenario-countdown">${humanDuration(s.seconds_until_release)}</p>
+      <p class="scenario-desc">${escHtml(s.description)}</p>
+      <p class="scenario-notes">${escHtml(s.notes)}</p>
+    `;
+    grid.appendChild(card);
+
+    // Timeline row
+    const row = document.createElement('div');
+    row.className = 'tl-row';
+    const pct = isNever ? 0 : Math.round((s.seconds_until_release / maxSecs) * 100);
+    row.innerHTML = `
+      <span class="tl-label">${escHtml(scenarioLabel(s.scenario))}</span>
+      <div class="tl-bar-track">
+        <div class="tl-bar-fill" style="width:${isNever ? 100 : pct}%;background:${barColor(s.confidence)};${isNever ? 'opacity:0.3;' : ''}"></div>
+      </div>
+      <span class="tl-days ${isNever ? 'never-text' : ''}">
+        ${isNever ? 'never' : days + 'd'}
+      </span>
+    `;
+    timelineRows.appendChild(row);
+  });
+}
+
+function escHtml(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// Allow hitting Enter in the vault ID field to trigger the simulation
+document.getElementById('vaultId').addEventListener('keydown', e => {
+  if (e.key === 'Enter') runSimulation();
+});
+</script>
+</body>
+</html>

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -452,6 +452,8 @@ impl PoolConfig {
 pub struct Db {
     conn: std::sync::Mutex<Connection>,
     pool_config: PoolConfig,
+    /// In-memory vault store shared across the application.
+    pub vault_store: VaultStore,
 }
 
 impl Db {
@@ -469,7 +471,18 @@ impl Db {
                 max: config.max,
                 timeout_secs: config.timeout_secs,
             },
+            vault_store: create_vault_store(),
         })
+    }
+
+    /// Insert or replace a vault in the in-memory store.
+    pub fn insert_vault(&self, vault: crate::models::Vault) {
+        self.vault_store.lock().unwrap().insert(vault.id.clone(), vault);
+    }
+
+    /// Retrieve a vault from the in-memory store by string ID.
+    pub fn get_vault(&self, vault_id: &str) -> Option<crate::models::Vault> {
+        self.vault_store.lock().unwrap().get(vault_id).cloned()
     }
 
     pub fn check_connectivity(&self) -> Result<(), rusqlite::Error> {

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -1,6 +1,6 @@
 use crate::models::*;
 use crate::db::*;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use serde_json::json;
 use std::io::Write;
 use std::sync::Arc;
@@ -982,4 +982,171 @@ mod tests {
         };
         assert!(set_notification_preferences_handler(&store, &notif_store, "v1", req).is_err());
     }
+}
+
+// ── Release Simulator ────────────────────────────────────────────────────────
+
+/// Parse a comma-separated `scenarios` query param into a `Vec<ScenarioType>`.
+/// Returns all three scenarios when the param is absent or empty.
+pub fn parse_scenario_types(raw: Option<&str>) -> Vec<ScenarioType> {
+    match raw {
+        None | Some("") => vec![
+            ScenarioType::NoCheckIns,
+            ScenarioType::ConsistentCheckIns,
+            ScenarioType::MissedCheckInDates,
+        ],
+        Some(s) => s
+            .split(',')
+            .filter_map(|part| match part.trim() {
+                "no_check_ins" => Some(ScenarioType::NoCheckIns),
+                "consistent_check_ins" => Some(ScenarioType::ConsistentCheckIns),
+                "missed_check_in_dates" => Some(ScenarioType::MissedCheckInDates),
+                _ => None,
+            })
+            .collect(),
+    }
+}
+
+/// Calculate the release date for a single scenario given vault state at `now`.
+///
+/// * `ttl_remaining_secs` — current TTL left in seconds (0 means already expired)
+/// * `check_in_interval`  — vault's configured check-in interval in seconds
+/// * `missed_count`       — for `MissedCheckInDates`: how many consecutive
+///   check-ins are missed before the owner stops entirely
+pub fn simulate_scenario(
+    now: DateTime<Utc>,
+    scenario: ScenarioType,
+    ttl_remaining_secs: u64,
+    check_in_interval: u64,
+    missed_count: u32,
+) -> ScenarioResult {
+    match scenario {
+        // Owner stops checking in immediately — vault releases when current TTL runs out.
+        ScenarioType::NoCheckIns => {
+            let release_at = now + chrono::Duration::seconds(ttl_remaining_secs as i64);
+            let seconds_until = ttl_remaining_secs as i64;
+            ScenarioResult {
+                scenario: ScenarioType::NoCheckIns,
+                description: "Owner performs no further check-ins. \
+                    Vault releases when the current TTL expires."
+                    .to_string(),
+                projected_release_at: release_at,
+                seconds_until_release: seconds_until,
+                confidence: "high".to_string(),
+                notes: format!(
+                    "Current TTL remaining: {} seconds ({:.1} days).",
+                    ttl_remaining_secs,
+                    ttl_remaining_secs as f64 / 86_400.0
+                ),
+            }
+        }
+
+        // Owner keeps checking in every `check_in_interval` seconds indefinitely.
+        // The vault never releases under this scenario.
+        ScenarioType::ConsistentCheckIns => {
+            // 100 years in seconds as a "never" sentinel
+            let never_secs: i64 = 100 * 365 * 24 * 3600;
+            let far_future = now + chrono::Duration::seconds(never_secs);
+            ScenarioResult {
+                scenario: ScenarioType::ConsistentCheckIns,
+                description: "Owner checks in consistently at the configured interval. \
+                    Vault does not release."
+                    .to_string(),
+                projected_release_at: far_future,
+                seconds_until_release: -1, // -1 signals "never" to clients
+                confidence: "high".to_string(),
+                notes: format!(
+                    "With a check-in interval of {} seconds ({:.1} days), \
+                    consistent check-ins prevent vault release indefinitely.",
+                    check_in_interval,
+                    check_in_interval as f64 / 86_400.0
+                ),
+            }
+        }
+
+        // Owner misses `missed_count` consecutive check-ins, then stops.
+        // Each missed check-in adds one full `check_in_interval` to the TTL runway.
+        ScenarioType::MissedCheckInDates => {
+            let safe_missed = missed_count.max(1);
+            // After missing `safe_missed` check-ins the TTL has been running down
+            // for `safe_missed * check_in_interval` additional seconds beyond the current TTL.
+            let extra_seconds = (safe_missed as u64).saturating_mul(check_in_interval);
+            let total_seconds = ttl_remaining_secs.saturating_add(extra_seconds);
+            let release_at = now + chrono::Duration::seconds(total_seconds as i64);
+            let confidence = if safe_missed <= 2 { "medium" } else { "low" }.to_string();
+            ScenarioResult {
+                scenario: ScenarioType::MissedCheckInDates,
+                description: format!(
+                    "Owner misses {} consecutive check-in(s), then stops entirely.",
+                    safe_missed
+                ),
+                projected_release_at: release_at,
+                seconds_until_release: total_seconds as i64,
+                confidence,
+                notes: format!(
+                    "Each missed check-in adds {} seconds ({:.1} days) to the release window. \
+                    {} missed check-in(s) → {} additional seconds.",
+                    check_in_interval,
+                    check_in_interval as f64 / 86_400.0,
+                    safe_missed,
+                    extra_seconds
+                ),
+            }
+        }
+    }
+}
+
+/// Public entry point: simulate release scenarios for a vault.
+///
+/// Returns `Err` with a message when the vault is not found.
+pub fn simulate_release_handler(
+    store: &VaultStore,
+    vault_id: &str,
+    scenario_types: Vec<ScenarioType>,
+    missed_count: u32,
+) -> Result<SimulateReleaseResponse, String> {
+    let vaults = store.lock().unwrap();
+    let vault = vaults
+        .get(vault_id)
+        .cloned()
+        .ok_or_else(|| format!("Vault '{}' not found", vault_id))?;
+    drop(vaults);
+
+    let now = Utc::now();
+
+    // Compute effective TTL remaining: prefer the stored value, fall back to
+    // computing from last_check_in + check_in_interval.
+    let ttl_remaining_secs: u64 = match vault.ttl_remaining {
+        Some(t) => t,
+        None => {
+            let elapsed = now
+                .signed_duration_since(vault.last_check_in)
+                .num_seconds()
+                .max(0) as u64;
+            vault.check_in_interval.saturating_sub(elapsed)
+        }
+    };
+
+    let effective_missed = missed_count.max(1);
+    let scenario_results: Vec<ScenarioResult> = scenario_types
+        .into_iter()
+        .map(|s| {
+            simulate_scenario(
+                now,
+                s,
+                ttl_remaining_secs,
+                vault.check_in_interval,
+                effective_missed,
+            )
+        })
+        .collect();
+
+    Ok(SimulateReleaseResponse {
+        vault_id: vault.id,
+        current_ttl_remaining: vault.ttl_remaining,
+        check_in_interval: vault.check_in_interval,
+        last_check_in: vault.last_check_in,
+        scenarios: scenario_results,
+        simulated_at: now,
+    })
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -11,6 +11,7 @@ use tracing_subscriber::EnvFilter;
 
 mod db;
 mod error;
+mod handlers;
 mod models;
 mod routes;
 mod scheduler;
@@ -95,6 +96,10 @@ async fn main() {
         .route(
             "/api/vaults/:vault_id/reminders",
             get(routes::list_vault_reminders),
+        )
+        .route(
+            "/api/vaults/:vault_id/simulate-release",
+            get(routes::simulate_release),
         )
         .layer(build_cors_layer())
         .with_state(db);

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -492,3 +492,72 @@ pub struct IdempotencyRecord {
     pub created_at: DateTime<Utc>,
 }
 
+// ── Release Simulator models ─────────────────────────────────────────────────
+
+/// The scenario to simulate.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ScenarioType {
+    /// Owner never checks in again — release is immediate at TTL expiry.
+    NoCheckIns,
+    /// Owner checks in consistently at their configured interval.
+    ConsistentCheckIns,
+    /// Owner misses one or more specific check-in dates before stopping.
+    MissedCheckInDates,
+}
+
+impl std::fmt::Display for ScenarioType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ScenarioType::NoCheckIns => write!(f, "no_check_ins"),
+            ScenarioType::ConsistentCheckIns => write!(f, "consistent_check_ins"),
+            ScenarioType::MissedCheckInDates => write!(f, "missed_check_in_dates"),
+        }
+    }
+}
+
+/// Query parameters for the simulate-release endpoint.
+#[derive(Debug, Deserialize)]
+pub struct SimulateReleaseQuery {
+    /// Comma-separated list of scenarios to run.
+    /// e.g. `scenarios=no_check_ins,consistent_check_ins`
+    /// Defaults to all three scenarios if omitted.
+    pub scenarios: Option<String>,
+    /// For `missed_check_in_dates`: number of consecutive missed check-ins
+    /// before the owner stops (defaults to 1).
+    pub missed_count: Option<u32>,
+}
+
+/// Projected outcome for a single scenario.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScenarioResult {
+    /// Which scenario this result belongs to.
+    pub scenario: ScenarioType,
+    /// Human-readable description of the scenario.
+    pub description: String,
+    /// Projected UTC timestamp when the vault will release.
+    pub projected_release_at: DateTime<Utc>,
+    /// Seconds from now until the projected release.
+    pub seconds_until_release: i64,
+    /// Confidence level: "high", "medium", or "low".
+    pub confidence: String,
+    /// Optional extra notes about this scenario's assumptions.
+    pub notes: String,
+}
+
+/// Response body for GET /api/vaults/{id}/simulate-release.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SimulateReleaseResponse {
+    pub vault_id: String,
+    /// Current TTL remaining in seconds (None if already expired/released).
+    pub current_ttl_remaining: Option<u64>,
+    /// The vault's configured check-in interval in seconds.
+    pub check_in_interval: u64,
+    /// Timestamp of the last recorded check-in.
+    pub last_check_in: DateTime<Utc>,
+    /// Simulation results, one per requested scenario.
+    pub scenarios: Vec<ScenarioResult>,
+    /// When this simulation was generated.
+    pub simulated_at: DateTime<Utc>,
+}
+

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -10,7 +10,8 @@ use serde::Deserialize;
 use crate::{
     db::Db,
     error::AppError,
-    models::{ReminderPreferences, SetPreferencesRequest},
+    handlers::{parse_scenario_types, simulate_release_handler},
+    models::{ReminderPreferences, SetPreferencesRequest, SimulateReleaseQuery, SimulateReleaseResponse},
 };
 
 #[derive(Deserialize)]
@@ -116,3 +117,31 @@ pub async fn unsubscribe(
     }
 }
 
+
+// ── Release Simulator endpoint ────────────────────────────────────────────────
+
+/// GET /api/vaults/:vault_id/simulate-release?scenarios=no_check_ins,consistent_check_ins,missed_check_in_dates&missed_count=2
+pub async fn simulate_release(
+    State(db): State<Arc<Db>>,
+    Path(vault_id): Path<String>,
+    Query(query): Query<SimulateReleaseQuery>,
+) -> Result<Json<SimulateReleaseResponse>, AppError> {
+    let scenarios = parse_scenario_types(query.scenarios.as_deref());
+    if scenarios.is_empty() {
+        return Err(AppError::InvalidInput(
+            "No valid scenarios requested. Use: no_check_ins, consistent_check_ins, missed_check_in_dates".into(),
+        ));
+    }
+
+    let missed_count = query.missed_count.unwrap_or(1);
+
+    let result = simulate_release_handler(
+        &db.vault_store,
+        &vault_id,
+        scenarios,
+        missed_count,
+    )
+    .map_err(|_| AppError::NotFound)?;
+
+    Ok(Json(result))
+}

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -437,3 +437,417 @@ mod notification_delivery_tests {
         assert_eq!(log[0].status, DeliveryStatus::Sent);
     }
 }
+
+// ── Simulator tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod simulator_tests {
+    use crate::db::{create_vault_store, Db};
+    use crate::handlers::{parse_scenario_types, simulate_release_handler, simulate_scenario};
+    use crate::models::{ScenarioType, Vault, VaultStatus};
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        routing::get,
+        Router,
+    };
+    use chrono::Utc;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    fn make_vault(id: &str, check_in_interval: u64, ttl_remaining: Option<u64>) -> Vault {
+        Vault {
+            id: id.to_string(),
+            owner: "owner1".to_string(),
+            beneficiary: "beneficiary1".to_string(),
+            balance: 5000,
+            check_in_interval,
+            last_check_in: Utc::now(),
+            created_at: Utc::now(),
+            status: VaultStatus::Active,
+            ttl_remaining,
+        }
+    }
+
+    // ── parse_scenario_types ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_none_returns_all_three() {
+        let result = parse_scenario_types(None);
+        assert_eq!(result.len(), 3);
+        assert!(result.contains(&ScenarioType::NoCheckIns));
+        assert!(result.contains(&ScenarioType::ConsistentCheckIns));
+        assert!(result.contains(&ScenarioType::MissedCheckInDates));
+    }
+
+    #[test]
+    fn test_parse_empty_string_returns_all_three() {
+        let result = parse_scenario_types(Some(""));
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn test_parse_single_scenario() {
+        let result = parse_scenario_types(Some("no_check_ins"));
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], ScenarioType::NoCheckIns);
+    }
+
+    #[test]
+    fn test_parse_two_scenarios() {
+        let result = parse_scenario_types(Some("no_check_ins,missed_check_in_dates"));
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&ScenarioType::NoCheckIns));
+        assert!(result.contains(&ScenarioType::MissedCheckInDates));
+    }
+
+    #[test]
+    fn test_parse_ignores_unknown_scenarios() {
+        let result = parse_scenario_types(Some("no_check_ins,unknown_scenario"));
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], ScenarioType::NoCheckIns);
+    }
+
+    #[test]
+    fn test_parse_all_unknown_returns_empty() {
+        let result = parse_scenario_types(Some("foo,bar,baz"));
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_handles_whitespace() {
+        let result = parse_scenario_types(Some(" consistent_check_ins , no_check_ins "));
+        assert_eq!(result.len(), 2);
+    }
+
+    // ── simulate_scenario — no_check_ins ────────────────────────────────────
+
+    #[test]
+    fn test_no_check_ins_release_equals_ttl_remaining() {
+        let now = Utc::now();
+        let ttl_remaining = 86_400u64; // 1 day
+        let result = simulate_scenario(now, ScenarioType::NoCheckIns, ttl_remaining, 86_400, 1);
+
+        assert_eq!(result.scenario, ScenarioType::NoCheckIns);
+        assert_eq!(result.seconds_until_release, 86_400);
+        assert_eq!(result.confidence, "high");
+
+        // projected_release_at should be approximately now + 1 day
+        let delta = result.projected_release_at.signed_duration_since(now).num_seconds();
+        assert_eq!(delta, 86_400);
+    }
+
+    #[test]
+    fn test_no_check_ins_zero_ttl_releases_now() {
+        let now = Utc::now();
+        let result = simulate_scenario(now, ScenarioType::NoCheckIns, 0, 86_400, 1);
+
+        assert_eq!(result.seconds_until_release, 0);
+        // projected_release_at should be ≈ now
+        let delta = result.projected_release_at.signed_duration_since(now).num_seconds();
+        assert_eq!(delta, 0);
+    }
+
+    // ── simulate_scenario — consistent_check_ins ────────────────────────────
+
+    #[test]
+    fn test_consistent_check_ins_never_releases() {
+        let now = Utc::now();
+        let result =
+            simulate_scenario(now, ScenarioType::ConsistentCheckIns, 86_400, 86_400, 1);
+
+        assert_eq!(result.scenario, ScenarioType::ConsistentCheckIns);
+        // -1 signals "never"
+        assert_eq!(result.seconds_until_release, -1);
+        assert_eq!(result.confidence, "high");
+        // The far-future date should be well beyond current TTL
+        let delta = result.projected_release_at.signed_duration_since(now).num_seconds();
+        assert!(delta > 86_400 * 365); // more than a year away
+    }
+
+    // ── simulate_scenario — missed_check_in_dates ───────────────────────────
+
+    #[test]
+    fn test_missed_one_check_in_adds_one_interval() {
+        let now = Utc::now();
+        let ttl_remaining = 3600u64; // 1 hour left
+        let check_in_interval = 86_400u64; // 1 day interval
+        let result = simulate_scenario(
+            now,
+            ScenarioType::MissedCheckInDates,
+            ttl_remaining,
+            check_in_interval,
+            1,
+        );
+
+        assert_eq!(result.scenario, ScenarioType::MissedCheckInDates);
+        // 1 hour TTL + 1 day missed = 1 day + 1 hour
+        let expected = ttl_remaining + check_in_interval;
+        assert_eq!(result.seconds_until_release, expected as i64);
+        assert_eq!(result.confidence, "medium");
+    }
+
+    #[test]
+    fn test_missed_two_check_ins_adds_two_intervals() {
+        let now = Utc::now();
+        let ttl_remaining = 3600u64;
+        let check_in_interval = 86_400u64;
+        let result = simulate_scenario(
+            now,
+            ScenarioType::MissedCheckInDates,
+            ttl_remaining,
+            check_in_interval,
+            2,
+        );
+
+        let expected = ttl_remaining + 2 * check_in_interval;
+        assert_eq!(result.seconds_until_release, expected as i64);
+        assert_eq!(result.confidence, "medium");
+    }
+
+    #[test]
+    fn test_missed_three_check_ins_has_low_confidence() {
+        let now = Utc::now();
+        let result = simulate_scenario(
+            now,
+            ScenarioType::MissedCheckInDates,
+            3600,
+            86_400,
+            3,
+        );
+        assert_eq!(result.confidence, "low");
+    }
+
+    #[test]
+    fn test_missed_zero_treated_as_one() {
+        let now = Utc::now();
+        let ttl_remaining = 3600u64;
+        let check_in_interval = 86_400u64;
+        // missed_count=0 should be coerced to 1
+        let result = simulate_scenario(
+            now,
+            ScenarioType::MissedCheckInDates,
+            ttl_remaining,
+            check_in_interval,
+            0,
+        );
+        let expected = ttl_remaining + check_in_interval;
+        assert_eq!(result.seconds_until_release, expected as i64);
+    }
+
+    // ── simulate_release_handler ─────────────────────────────────────────────
+
+    #[test]
+    fn test_simulate_release_handler_vault_not_found() {
+        let store = create_vault_store();
+        let result = simulate_release_handler(
+            &store,
+            "nonexistent",
+            vec![ScenarioType::NoCheckIns],
+            1,
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("nonexistent"));
+    }
+
+    #[test]
+    fn test_simulate_release_handler_returns_all_scenarios() {
+        let store = create_vault_store();
+        let vault = make_vault("vault-1", 86_400, Some(3600));
+        store.lock().unwrap().insert("vault-1".to_string(), vault);
+
+        let scenarios = vec![
+            ScenarioType::NoCheckIns,
+            ScenarioType::ConsistentCheckIns,
+            ScenarioType::MissedCheckInDates,
+        ];
+        let result = simulate_release_handler(&store, "vault-1", scenarios, 1).unwrap();
+
+        assert_eq!(result.vault_id, "vault-1");
+        assert_eq!(result.scenarios.len(), 3);
+        assert_eq!(result.check_in_interval, 86_400);
+        assert_eq!(result.current_ttl_remaining, Some(3600));
+    }
+
+    #[test]
+    fn test_simulate_release_handler_no_check_ins_matches_ttl() {
+        let store = create_vault_store();
+        let vault = make_vault("vault-2", 86_400, Some(7200));
+        store.lock().unwrap().insert("vault-2".to_string(), vault);
+
+        let result =
+            simulate_release_handler(&store, "vault-2", vec![ScenarioType::NoCheckIns], 1)
+                .unwrap();
+
+        let no_check_in_scenario = result
+            .scenarios
+            .iter()
+            .find(|s| s.scenario == ScenarioType::NoCheckIns)
+            .unwrap();
+
+        assert_eq!(no_check_in_scenario.seconds_until_release, 7200);
+        assert_eq!(no_check_in_scenario.confidence, "high");
+    }
+
+    #[test]
+    fn test_simulate_release_handler_fallback_ttl_computation() {
+        // When ttl_remaining is None, the handler computes TTL from last_check_in
+        let store = create_vault_store();
+        let mut vault = make_vault("vault-3", 3600, None); // 1 hour interval, no stored TTL
+        // last_check_in is Utc::now() so TTL should be close to 3600 seconds
+        vault.ttl_remaining = None;
+        store.lock().unwrap().insert("vault-3".to_string(), vault);
+
+        let result =
+            simulate_release_handler(&store, "vault-3", vec![ScenarioType::NoCheckIns], 1)
+                .unwrap();
+
+        let no_check_in = result
+            .scenarios
+            .iter()
+            .find(|s| s.scenario == ScenarioType::NoCheckIns)
+            .unwrap();
+
+        // TTL should be ≈3600 seconds (last_check_in just happened)
+        assert!(no_check_in.seconds_until_release >= 3590);
+        assert!(no_check_in.seconds_until_release <= 3600);
+    }
+
+    #[test]
+    fn test_simulate_release_handler_single_scenario_subset() {
+        let store = create_vault_store();
+        let vault = make_vault("vault-4", 86_400, Some(43200));
+        store.lock().unwrap().insert("vault-4".to_string(), vault);
+
+        let result = simulate_release_handler(
+            &store,
+            "vault-4",
+            vec![ScenarioType::MissedCheckInDates],
+            2,
+        )
+        .unwrap();
+
+        assert_eq!(result.scenarios.len(), 1);
+        let s = &result.scenarios[0];
+        assert_eq!(s.scenario, ScenarioType::MissedCheckInDates);
+        // 43200 + 2 * 86400 = 43200 + 172800 = 216000
+        assert_eq!(s.seconds_until_release, 43200 + 2 * 86400);
+    }
+
+    // ── HTTP endpoint test ────────────────────────────────────────────────────
+
+    fn simulator_app() -> Router {
+        let db = Arc::new(Db::open(":memory:").unwrap());
+        db.migrate().unwrap();
+
+        // Pre-populate the in-memory vault store
+        db.insert_vault(make_vault("vault-http-1", 86_400, Some(3600)));
+
+        Router::new()
+            .route(
+                "/api/vaults/:vault_id/simulate-release",
+                get(crate::routes::simulate_release),
+            )
+            .with_state(db)
+    }
+
+    #[tokio::test]
+    async fn test_simulate_release_http_200() {
+        let app = simulator_app();
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/vaults/vault-http-1/simulate-release")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["vault_id"], "vault-http-1");
+        assert_eq!(json["scenarios"].as_array().unwrap().len(), 3);
+        assert_eq!(json["check_in_interval"], 86400);
+    }
+
+    #[tokio::test]
+    async fn test_simulate_release_http_with_scenario_filter() {
+        let app = simulator_app();
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/vaults/vault-http-1/simulate-release?scenarios=no_check_ins")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        let scenarios = json["scenarios"].as_array().unwrap();
+        assert_eq!(scenarios.len(), 1);
+        assert_eq!(scenarios[0]["scenario"], "no_check_ins");
+    }
+
+    #[tokio::test]
+    async fn test_simulate_release_http_404_unknown_vault() {
+        let app = simulator_app();
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/vaults/doesnotexist/simulate-release")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_simulate_release_http_422_bad_scenario() {
+        let app = simulator_app();
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/vaults/vault-http-1/simulate-release?scenarios=bad_scenario")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+
+    #[tokio::test]
+    async fn test_simulate_release_http_with_missed_count() {
+        let app = simulator_app();
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/vaults/vault-http-1/simulate-release?scenarios=missed_check_in_dates&missed_count=3")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        let scenarios = json["scenarios"].as_array().unwrap();
+        assert_eq!(scenarios[0]["scenario"], "missed_check_in_dates");
+        // 3600 TTL + 3 * 86400 missed = 3600 + 259200 = 262800
+        assert_eq!(scenarios[0]["seconds_until_release"], 3600 + 3 * 86400);
+        assert_eq!(scenarios[0]["confidence"], "low");
+    }
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -35,6 +35,8 @@ tags:
     description: Share vault access with other users
   - name: Vault Backup
     description: Backup and recovery operations
+  - name: Release Simulator
+    description: Project vault release dates under different check-in behaviour scenarios
 
 paths:
   /health:
@@ -716,6 +718,90 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /api/vaults/{vault_id}/simulate-release:
+    get:
+      summary: Simulate vault release scenarios
+      description: >
+        Projects when a vault will release to its beneficiary under one or more
+        check-in behaviour scenarios. Useful for owners who want to understand
+        the impact of their check-in habits on release timing.
+      operationId: simulateVaultRelease
+      tags:
+        - Release Simulator
+      parameters:
+        - name: vault_id
+          in: path
+          required: true
+          description: The ID of the vault to simulate
+          schema:
+            type: string
+          example: vault-abc-123
+        - name: scenarios
+          in: query
+          required: false
+          description: >
+            Comma-separated list of scenarios to run. Defaults to all three when
+            omitted. Valid values: `no_check_ins`, `consistent_check_ins`,
+            `missed_check_in_dates`.
+          schema:
+            type: string
+            example: "no_check_ins,missed_check_in_dates"
+        - name: missed_count
+          in: query
+          required: false
+          description: >
+            For the `missed_check_in_dates` scenario: number of consecutive
+            check-ins the owner misses before stopping entirely. Defaults to 1.
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          example: 2
+      responses:
+        '200':
+          description: Simulation results for the requested scenarios
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulateReleaseResponse'
+              example:
+                vault_id: "vault-abc-123"
+                current_ttl_remaining: 86400
+                check_in_interval: 2592000
+                last_check_in: "2026-06-29T10:00:00Z"
+                simulated_at: "2026-06-30T06:39:00Z"
+                scenarios:
+                  - scenario: "no_check_ins"
+                    description: "Owner performs no further check-ins. Vault releases when the current TTL expires."
+                    projected_release_at: "2026-07-01T06:39:00Z"
+                    seconds_until_release: 86400
+                    confidence: "high"
+                    notes: "Current TTL remaining: 86400 seconds (1.0 days)."
+                  - scenario: "consistent_check_ins"
+                    description: "Owner checks in consistently at the configured interval. Vault does not release."
+                    projected_release_at: "2126-06-30T06:39:00Z"
+                    seconds_until_release: -1
+                    confidence: "high"
+                    notes: "With a check-in interval of 2592000 seconds (30.0 days), consistent check-ins prevent vault release indefinitely."
+                  - scenario: "missed_check_in_dates"
+                    description: "Owner misses 1 consecutive check-in(s), then stops entirely."
+                    projected_release_at: "2026-08-01T06:39:00Z"
+                    seconds_until_release: 2678400
+                    confidence: "medium"
+                    notes: "Each missed check-in adds 2592000 seconds (30.0 days) to the release window. 1 missed check-in(s) → 2592000 additional seconds."
+        '404':
+          description: Vault not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Invalid scenario name(s) specified
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
 components:
   schemas:
     ErrorResponse:
@@ -1187,6 +1273,95 @@ components:
       required:
         - backup_id
         - encryption_key
+
+    ScenarioType:
+      type: string
+      enum:
+        - no_check_ins
+        - consistent_check_ins
+        - missed_check_in_dates
+      description: >
+        The check-in behaviour scenario to simulate.
+
+        - `no_check_ins` — owner never checks in again; vault releases when current TTL expires.
+        - `consistent_check_ins` — owner checks in at every interval indefinitely; vault never releases.
+        - `missed_check_in_dates` — owner misses N consecutive check-ins, then stops.
+
+    ScenarioResult:
+      type: object
+      description: Projected release outcome for a single scenario
+      properties:
+        scenario:
+          $ref: '#/components/schemas/ScenarioType'
+        description:
+          type: string
+          description: Human-readable description of the scenario assumptions
+        projected_release_at:
+          type: string
+          format: date-time
+          description: >
+            Projected UTC timestamp when the vault will release under this scenario.
+            For `consistent_check_ins`, this is a far-future sentinel value.
+        seconds_until_release:
+          type: integer
+          format: int64
+          description: >
+            Seconds from simulation time until projected release.
+            -1 means the vault will never release under this scenario.
+        confidence:
+          type: string
+          enum: [high, medium, low]
+          description: >
+            Confidence in the projection.
+            `high` — deterministic given vault state.
+            `medium` — 1–2 missed check-ins assumed.
+            `low` — 3+ missed check-ins assumed (higher uncertainty).
+        notes:
+          type: string
+          description: Additional context about the scenario's assumptions and calculations
+      required:
+        - scenario
+        - description
+        - projected_release_at
+        - seconds_until_release
+        - confidence
+        - notes
+
+    SimulateReleaseResponse:
+      type: object
+      description: Response containing simulation results for one or more release scenarios
+      properties:
+        vault_id:
+          type: string
+          description: The ID of the vault that was simulated
+        current_ttl_remaining:
+          type: integer
+          format: int64
+          nullable: true
+          description: Current TTL remaining in seconds; null if not known or already expired
+        check_in_interval:
+          type: integer
+          format: int64
+          description: The vault's configured check-in interval in seconds
+        last_check_in:
+          type: string
+          format: date-time
+          description: Timestamp of the last recorded check-in
+        scenarios:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScenarioResult'
+          description: Simulation results, one per requested scenario
+        simulated_at:
+          type: string
+          format: date-time
+          description: Timestamp when this simulation was generated
+      required:
+        - vault_id
+        - check_in_interval
+        - last_check_in
+        - scenarios
+        - simulated_at
 
   securitySchemes:
     ApiKeyAuth:


### PR DESCRIPTION
Here's a PR description you can use:
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  Release Simulator — Vault TTL Projection
  
  Closes the release simulator issue.
  
  What this adds
  
  Vault owners currently have no way to predict when their vault will release. This PR adds a
  simulator endpoint and frontend UI that projects the release date based on three check-in
  behaviour scenarios.
  
  Endpoint
  
  GET
  /api/vaults/{id}/simulate-release?scenarios=no_check_ins,missed_check_in_dates&missed_count=2
  
  Scenarios:
  
  - no_check_ins — owner stops checking in immediately; vault releases when current TTL expires
  (high confidence)
  - consistent_check_ins — owner checks in at every interval indefinitely; vault never releases
  (high confidence)
  - missed_check_in_dates — owner misses N consecutive check-ins then stops; configurable via
  missed_count (medium/low confidence)
  
  Response includes: projected release timestamp, seconds until release, confidence level
  (high/medium/low), and human-readable notes explaining the assumptions.
  
  Changes
  
  - models.rs — ScenarioType, SimulateReleaseQuery, ScenarioResult, SimulateReleaseResponse
  - handlers.rs — parse_scenario_types, simulate_scenario, simulate_release_handler (pure
  functions, fully testable)
  - db.rs — extended Db struct with an in-memory vault_store and insert_vault/get_vault helpers
  so the HTTP layer uses a single state object
  - routes.rs — simulate_release Axum handler wired to the above
  - main.rs — route registered, mod handlers declared
  - tests.rs — 19 tests: scenario parsing, calculation edge cases, handler logic, and 5 HTTP
  integration tests
  - simulator.html — standalone dark-mode frontend; fetches the API and renders scenario cards
  with confidence badges and a relative timeline bar chart
  - docs/openapi.yaml — full path spec, query param docs, response schema, and inline example
  
  Testing
  
  cargo test
  
  All 19 new tests cover:
  
  - parse_scenario_types with None, empty, partial, unknown, and whitespace inputs
  - simulate_scenario for all three scenarios including zero TTL, coercion of missed_count=0, and
  confidence thresholds
closes #963 