### PR TITLE
feat(vault): add get_check_in_history_page for paginated history 

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -9433,6 +9433,51 @@ impl TtlVaultContract {
             .unwrap_or_else(|| Vec::new(&env))
     }
 
+    /// Returns a page of check-in history for a vault.
+    ///
+    /// Entries are ordered oldest-first (index 0 is the oldest stored entry).
+    /// `cursor` is the zero-based index of the first entry to return; passing
+    /// `cursor = 0` starts from the oldest entry.  `limit` is capped at 50.
+    ///
+    /// Returns an empty `Vec` when `cursor` is out of bounds or the history is
+    /// empty.
+    ///
+    /// # Arguments
+    /// * `vault_id` - The vault whose check-in history to page through.
+    /// * `cursor`   - Zero-based index of the first entry to return.
+    /// * `limit`    - Maximum number of entries to return (capped at 50).
+    pub fn get_check_in_history_page(
+        env: Env,
+        vault_id: u64,
+        cursor: u64,
+        limit: u32,
+    ) -> Vec<CheckInHistoryEntry> {
+        const MAX_PAGE_SIZE: u32 = 50;
+        let page_size = limit.min(MAX_PAGE_SIZE);
+
+        let history: Vec<CheckInHistoryEntry> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CheckInHistory(vault_id))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let total = history.len() as u64;
+
+        // cursor beyond the end of the list → return empty page
+        if cursor >= total || page_size == 0 {
+            return Vec::new(&env);
+        }
+
+        let start = cursor as u32;
+        let end = ((cursor + page_size as u64).min(total)) as u32;
+
+        let mut page = Vec::new(&env);
+        for i in start..end {
+            page.push_back(history.get(i).unwrap());
+        }
+        page
+    }
+
     /// Returns the current check-in streak for a vault.
     pub fn get_check_in_streak(env: Env, vault_id: u64) -> CheckInStreak {
         env.storage()

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -6293,3 +6293,187 @@ fn test_trigger_release_with_50_beneficiaries() {
     // Last beneficiary absorbs any dust
     assert!(token_client.balance(&addresses[49]) >= per_beneficiary);
 }
+
+// ── Issue #482: get_check_in_history_page ────────────────────────────────────
+
+#[test]
+fn test_check_in_history_page_empty_history() {
+    // A brand-new vault has no check-in history; any page should be empty.
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let _ = env; // env not mutated in this test
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    let page = client.get_check_in_history_page(&id, &0u64, &10u32);
+    assert_eq!(page.len(), 0, "expected empty page for vault with no history");
+}
+
+#[test]
+fn test_check_in_history_page_first_page() {
+    // Record 5 check-ins then request the first 3 → should return entries [0..3].
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let passkey = BytesN::from_array(&env, &[1u8; 32]);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    for _ in 0..5 {
+        env.ledger().with_mut(|l| l.timestamp += 600);
+        client.check_in(&id, &owner, &passkey).unwrap();
+    }
+
+    let page = client.get_check_in_history_page(&id, &0u64, &3u32);
+    assert_eq!(page.len(), 3);
+
+    // Entries should be ordered oldest-first, so timestamps must be ascending.
+    assert!(page.get(0).unwrap().timestamp < page.get(1).unwrap().timestamp);
+    assert!(page.get(1).unwrap().timestamp < page.get(2).unwrap().timestamp);
+}
+
+#[test]
+fn test_check_in_history_page_second_page() {
+    // Record 5 check-ins; cursor=3, limit=3 should return the last 2 entries.
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let passkey = BytesN::from_array(&env, &[1u8; 32]);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    for _ in 0..5 {
+        env.ledger().with_mut(|l| l.timestamp += 600);
+        client.check_in(&id, &owner, &passkey).unwrap();
+    }
+
+    // Full history for cross-checking
+    let all = client.get_check_in_history(&id);
+    assert_eq!(all.len(), 5);
+
+    let page = client.get_check_in_history_page(&id, &3u64, &3u32);
+    assert_eq!(page.len(), 2, "cursor=3 into 5-entry list with limit=3 should yield 2 entries");
+    assert_eq!(page.get(0).unwrap().timestamp, all.get(3).unwrap().timestamp);
+    assert_eq!(page.get(1).unwrap().timestamp, all.get(4).unwrap().timestamp);
+}
+
+#[test]
+fn test_check_in_history_page_exact_full_page() {
+    // Request exactly as many entries as exist → should return all of them.
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let passkey = BytesN::from_array(&env, &[1u8; 32]);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    for _ in 0..4 {
+        env.ledger().with_mut(|l| l.timestamp += 600);
+        client.check_in(&id, &owner, &passkey).unwrap();
+    }
+
+    let page = client.get_check_in_history_page(&id, &0u64, &4u32);
+    assert_eq!(page.len(), 4);
+}
+
+#[test]
+fn test_check_in_history_page_cursor_at_last_entry() {
+    // cursor pointing at the last element should return exactly one entry.
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let passkey = BytesN::from_array(&env, &[1u8; 32]);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    for _ in 0..3 {
+        env.ledger().with_mut(|l| l.timestamp += 600);
+        client.check_in(&id, &owner, &passkey).unwrap();
+    }
+
+    let all = client.get_check_in_history(&id);
+    let page = client.get_check_in_history_page(&id, &2u64, &10u32);
+    assert_eq!(page.len(), 1);
+    assert_eq!(page.get(0).unwrap().timestamp, all.get(2).unwrap().timestamp);
+}
+
+#[test]
+fn test_check_in_history_page_cursor_out_of_bounds() {
+    // cursor >= total entries → empty result, no panic.
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let passkey = BytesN::from_array(&env, &[1u8; 32]);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    for _ in 0..3 {
+        env.ledger().with_mut(|l| l.timestamp += 600);
+        client.check_in(&id, &owner, &passkey).unwrap();
+    }
+
+    // cursor == len
+    let page = client.get_check_in_history_page(&id, &3u64, &10u32);
+    assert_eq!(page.len(), 0, "cursor equal to len should return empty page");
+
+    // cursor >> len
+    let page2 = client.get_check_in_history_page(&id, &9999u64, &10u32);
+    assert_eq!(page2.len(), 0, "cursor far beyond len should return empty page");
+}
+
+#[test]
+fn test_check_in_history_page_limit_zero() {
+    // limit=0 should always return an empty page, regardless of cursor.
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let passkey = BytesN::from_array(&env, &[1u8; 32]);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    for _ in 0..3 {
+        env.ledger().with_mut(|l| l.timestamp += 600);
+        client.check_in(&id, &owner, &passkey).unwrap();
+    }
+
+    let page = client.get_check_in_history_page(&id, &0u64, &0u32);
+    assert_eq!(page.len(), 0, "limit=0 should return empty page");
+}
+
+#[test]
+fn test_check_in_history_page_limit_capped_at_50() {
+    // Requesting more than 50 entries should be silently capped to 50.
+    // We only seed 10 entries so we can verify cap without 50+ check-ins.
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let passkey = BytesN::from_array(&env, &[1u8; 32]);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    for _ in 0..10 {
+        env.ledger().with_mut(|l| l.timestamp += 600);
+        client.check_in(&id, &owner, &passkey).unwrap();
+    }
+
+    // u32::MAX >> 50; result is capped, not a panic, and returns at most 10 entries.
+    let page = client.get_check_in_history_page(&id, &0u64, &u32::MAX);
+    assert_eq!(page.len(), 10, "capped limit with only 10 entries should return 10");
+}
+
+#[test]
+fn test_check_in_history_page_consistent_with_full_history() {
+    // Walking through all pages reassembled equals the full history.
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let passkey = BytesN::from_array(&env, &[1u8; 32]);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    for _ in 0..7 {
+        env.ledger().with_mut(|l| l.timestamp += 600);
+        client.check_in(&id, &owner, &passkey).unwrap();
+    }
+
+    let all = client.get_check_in_history(&id);
+    assert_eq!(all.len(), 7);
+
+    // Reassemble using page size of 3
+    let page_size: u32 = 3;
+    let mut cursor: u64 = 0;
+    let mut reassembled: soroban_sdk::Vec<u64> = soroban_sdk::Vec::new(&env);
+    loop {
+        let page = client.get_check_in_history_page(&id, &cursor, &page_size);
+        if page.len() == 0 {
+            break;
+        }
+        for entry in page.iter() {
+            reassembled.push_back(entry.timestamp);
+        }
+        cursor += page_size as u64;
+    }
+
+    assert_eq!(reassembled.len(), 7, "reassembled pages should cover all 7 entries");
+    for i in 0..7u32 {
+        assert_eq!(
+            reassembled.get(i).unwrap(),
+            all.get(i).unwrap().timestamp,
+            "entry {i} timestamp mismatch between full history and paged walk"
+        );
+    }
+}


### PR DESCRIPTION
CheckInHistory entries accumulate over a vault's lifetime and returning the full list in a single call can exceed Soroban's instruction budget for long-lived vaults.

- Add get_check_in_history_page(env, vault_id, cursor, limit) contract method that returns at most 50 entries per call.
- cursor is a zero-based, oldest-first index; callers walk forward by incrementing cursor by the page size between calls.
- limit is silently capped at 50; limit=0 or an out-of-bounds cursor returns an empty Vec without panicking.
- Add 8 unit tests covering: empty history, first page, second/partial page, exact-full page, cursor at last entry, cursor out of bounds, limit zero, limit overflow, and full-history reassembly by walking all pages.
"closes #771 