### PR TITLE
Add custom metadata history for vaults 

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -6767,6 +6767,41 @@ impl TtlVaultContract {
         if vault.status != ReleaseStatus::Locked {
             return Err(ContractError::AlreadyReleased);
         }
+        // Append to custom metadata history (limit to last 100 entries)
+        let key = DataKey::CustomMetadataHistory(vault_id);
+        let mut history: Vec<CustomMetadataEntry> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let now = env.ledger().timestamp();
+        history.push_back(CustomMetadataEntry {
+            metadata: metadata.clone(),
+            timestamp: now,
+        });
+
+        // Trim to last 100 entries if necessary
+        if history.len() > 100 {
+            let total = history.len();
+            let start = total - 100;
+            let mut trimmed: Vec<CustomMetadataEntry> = Vec::new(&env);
+            for i in start..total {
+                trimmed.push_back(history.get(i).unwrap());
+            }
+            let ttl = vault_ttl_ledgers(vault.check_in_interval);
+            env.storage().persistent().set(&key, &trimmed);
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, VAULT_TTL_THRESHOLD, ttl);
+        } else {
+            let ttl = vault_ttl_ledgers(vault.check_in_interval);
+            env.storage().persistent().set(&key, &history);
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, VAULT_TTL_THRESHOLD, ttl);
+        }
+
         vault.custom_metadata = metadata.clone();
         Self::save_vault(&env, vault_id, &vault);
         env.storage()
@@ -6775,6 +6810,14 @@ impl TtlVaultContract {
         env.events()
             .publish((SET_METADATA_TOPIC, vault_id), metadata);
         Ok(())
+    }
+
+    /// Returns the custom metadata history (bytes + timestamp) for a vault.
+    pub fn get_custom_metadata_history(env: Env, vault_id: u64) -> Vec<CustomMetadataEntry> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CustomMetadataHistory(vault_id))
+            .unwrap_or_else(|| Vec::new(&env))
     }
 
     /// Gets custom metadata for a vault.

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -1096,6 +1096,33 @@ fn test_update_metadata_emits_event() {
 }
 
 #[test]
+fn test_set_vault_custom_metadata_appends_history_and_limits() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+
+    let m1 = Bytes::from_array(&env, &[1u8, 2u8]);
+    let m2 = Bytes::from_array(&env, &[3u8, 4u8]);
+
+    client.set_vault_metadata(&vault_id, &owner, &m1);
+    client.set_vault_metadata(&vault_id, &owner, &m2);
+
+    let history = client.get_custom_metadata_history(&vault_id);
+    assert_eq!(history.len(), 2);
+    assert_eq!(history.get(0).unwrap().metadata, m1);
+    assert_eq!(history.get(1).unwrap().metadata, m2);
+
+    // Exceed 100 entries and ensure trimming to last 100
+    for i in 0..101u8 {
+        let raw = [i, i.wrapping_add(1)];
+        let b = Bytes::from_array(&env, &raw);
+        client.set_vault_metadata(&vault_id, &owner, &b);
+    }
+
+    let history = client.get_custom_metadata_history(&vault_id);
+    assert_eq!(history.len(), 100);
+}
+
+#[test]
 fn test_get_contract_token_returns_correct_address() {
     let (_, _, _, _, token_address, client) = setup();
     assert_eq!(client.get_contract_token(), token_address);

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -368,6 +368,7 @@ pub enum DataKey {
     MultiSigProposal(u64, u64),
     MultiSigProposalCount(u64),
     MetadataHistory(u64),
+    CustomMetadataHistory(u64),
     OwnerVaultCount(Address),
     // Issue #472: state transition audit trail
     StateTransitionLog(u64),
@@ -936,6 +937,14 @@ pub struct MetadataVersionEntry {
     pub metadata: String,
     pub updated_at: u64,
     pub updated_by: Address,
+}
+
+/// A single custom metadata history entry (raw bytes + timestamp) - Issue #931
+#[contracttype]
+#[derive(Clone)]
+pub struct CustomMetadataEntry {
+    pub metadata: Bytes,
+    pub timestamp: u64,
 }
 
 /// Ownership transfer request


### PR DESCRIPTION
##closes #931 

Summary
- Add append-only history for vault custom metadata (bytes) so prior values can be recovered.

What I changed
- **DataKey**: added `CustomMetadataHistory(u64)` in types.rs.
- **Types**: added `CustomMetadataEntry { metadata: Bytes, timestamp: u64 }` in types.rs.
- **Logic**: updated `set_vault_metadata` in lib.rs to append a `CustomMetadataEntry` (with ledger timestamp) to persistent history, trim to the last 100 entries, and persist TTL. Existing behavior (update vault, emit `SET_METADATA_TOPIC`, extend instance TTL) preserved.
- **API**: added `get_custom_metadata_history(env, vault_id) -> Vec<CustomMetadataEntry>` in lib.rs.
- **Tests**: added `test_set_vault_custom_metadata_appends_history_and_limits` in test.rs.

Files modified
- types.rs
- lib.rs
- test.rs

Behavioral notes
- History entries are raw bytes + timestamp.
- History is limited to the last 100 entries (oldest entries dropped when exceeded).
- TTL for history storage uses the same vault-based TTL calculation (`vault_ttl_ledgers`).
- Did not change the existing string metadata versioning APIs (`MetadataVersionEntry` / `update_metadata_versioned`), kept the new API name `get_custom_metadata_history` to avoid conflict.

Testing / how to run
- Run the contract tests locally to verify:
```bash
cd contracts/ttl_vault
cargo test
```

Associated branch
- Changes pushed to branch `Add-Vault`.

References
- Closes / addresses: Issue #931 (Vault metadata versioning for custom metadata bytes).