### PR TITLE
perf: extend vault TTL in get_vault only when below threshold

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -5191,7 +5191,15 @@ impl TtlVaultContract {
     /// # Panics
     /// Panics if the vault does not exist (use `vault_exists` to check first)
     pub fn get_vault(env: Env, vault_id: u64) -> Vault {
-        Self::load_vault(&env, vault_id)
+        let vault = Self::load_vault(&env, vault_id);
+        // Extend the vault's persistent TTL only when it has dropped below
+        // VAULT_TTL_THRESHOLD ledgers. This avoids a write (and the associated
+        // fee) on every read when the TTL is already healthy.
+        let key = DataKey::Vault(vault_id);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, VAULT_TTL_THRESHOLD, VAULT_TTL_LEDGERS);
+        vault
     }
 
     /// Captures the state of a vault at a specific point in time.

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -3018,33 +3018,94 @@ fn test_is_expired_at_exact_deadline() {
     assert!(client.is_expired(&vault_id));
 }
 
-// --- #306: get_vault does not extend TTL ---
+// --- #306: get_vault conditionally extends TTL ---
 
-/// Verifies that get_vault is read-only and does not extend the vault's
-/// persistent storage TTL. Repeated reads must not alter ledger state.
+/// Verifies that get_vault extends the vault's persistent storage TTL when
+/// the remaining TTL has dropped below VAULT_TTL_THRESHOLD.
+///
+/// The Soroban `extend_ttl(key, min_ttl, max_ttl)` call is a no-op when the
+/// current TTL >= `min_ttl`, so after calling `get_vault` with the TTL below
+/// the threshold the storage TTL must be raised back up to VAULT_TTL_LEDGERS.
 #[test]
-fn test_get_vault_does_not_extend_ttl() {
+fn test_get_vault_extends_ttl_when_below_threshold() {
+    use soroban_sdk::testutils::storage::Persistent as _;
     let (env, owner, beneficiary, _, _, client) = setup();
+    let contract_id = client.address.clone();
     let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
 
-    // Capture TTL immediately after creation
+    // Advance the ledger sequence far enough that the vault entry's storage TTL
+    // falls below VAULT_TTL_THRESHOLD.
+    // Vault is created with VAULT_TTL_LEDGERS (200_000).
+    // Advancing by (VAULT_TTL_LEDGERS - VAULT_TTL_THRESHOLD + 1) leaves
+    // exactly (VAULT_TTL_THRESHOLD - 1) ledgers remaining — just below trigger.
+    let advance = (VAULT_TTL_LEDGERS - VAULT_TTL_THRESHOLD + 1) as u32;
+    env.ledger().set_sequence_number(env.ledger().sequence() + advance);
+
+    let ttl_before = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .get_ttl(&DataKey::Vault(vault_id))
+        });
+    assert!(
+        ttl_before < VAULT_TTL_THRESHOLD,
+        "pre-condition: TTL ({ttl_before}) must be below VAULT_TTL_THRESHOLD ({VAULT_TTL_THRESHOLD})"
+    );
+
+    // get_vault must extend the TTL back up to at least VAULT_TTL_LEDGERS.
+    client.get_vault(&vault_id);
+
+    let ttl_after = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .get_ttl(&DataKey::Vault(vault_id))
+        });
+    assert!(
+        ttl_after >= VAULT_TTL_LEDGERS,
+        "get_vault must restore TTL to at least VAULT_TTL_LEDGERS when below threshold (got {ttl_after})"
+    );
+}
+
+/// Verifies that get_vault does NOT write to storage (i.e. does not alter the
+/// TTL) when the remaining TTL is already at or above VAULT_TTL_THRESHOLD.
+///
+/// This is the hot-read path: no state change should occur when storage is
+/// healthy, keeping the call fee-efficient.
+#[test]
+fn test_get_vault_does_not_extend_ttl_when_above_threshold() {
+    use soroban_sdk::testutils::storage::Persistent as _;
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let contract_id = client.address.clone();
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+
+    // Confirm that the TTL set at creation is well above the threshold.
     let ttl_after_create = env
-        .storage()
-        .persistent()
-        .get_ttl(&DataKey::Vault(vault_id));
+        .as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .get_ttl(&DataKey::Vault(vault_id))
+        });
+    assert!(
+        ttl_after_create >= VAULT_TTL_THRESHOLD,
+        "pre-condition: freshly created vault TTL must be above threshold"
+    );
 
-    // Read the vault multiple times
+    // Repeated reads must leave the TTL unchanged.
     client.get_vault(&vault_id);
     client.get_vault(&vault_id);
     client.get_vault(&vault_id);
 
-    // TTL must be unchanged — get_vault must not extend it
     let ttl_after_reads = env
-        .storage()
-        .persistent()
-        .get_ttl(&DataKey::Vault(vault_id));
-
-    assert_eq!(ttl_after_create, ttl_after_reads);
+        .as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .get_ttl(&DataKey::Vault(vault_id))
+        });
+    assert_eq!(
+        ttl_after_create, ttl_after_reads,
+        "get_vault must not alter TTL when it is already above VAULT_TTL_THRESHOLD"
+    );
 }
 
 


### PR DESCRIPTION
 Summary
  
  get_vault was a pure passthrough to load_vault with no TTL management. The
  intent of this change is to protect vault entries from Soroban state archival
  without paying a write fee on every read.
  
  The fix adds a conditional extend_ttl call using the existing
  VAULT_TTL_THRESHOLD and VAULT_TTL_LEDGERS constants. Soroban's extend_ttl(key,
  min_ttl, max_ttl) is a built-in no-op when the current TTL ≥ min_ttl, so:
  
  - Hot reads (TTL healthy): pure read, no write, no extra fee
  - TTL near expiry (TTL < 1000 ledgers ≈ 83 min): write triggered, entry rescued
  to 200,000 ledgers
  
  Changes
  
  contracts/ttl_vault/src/lib.rs
  
  - get_vault: load vault first, then call extend_ttl(&DataKey::Vault(vault_id),
  VAULT_TTL_THRESHOLD, VAULT_TTL_LEDGERS) before returning
  
  contracts/ttl_vault/src/test.rs
  
  - Replaced test_get_vault_does_not_extend_ttl (which asserted the old no-extend
  behavior) with two new tests:
    - test_get_vault_extends_ttl_when_below_threshold — advances ledger sequence
  by VAULT_TTL_LEDGERS - VAULT_TTL_THRESHOLD + 1 to put entry TTL at 999 (below
  trigger), asserts post-read TTL ≥ VAULT_TTL_LEDGERS
    - test_get_vault_does_not_extend_ttl_when_above_threshold — asserts three
  reads on a freshly-created vault leave TTL unchanged
  
  What was tested
  
  - Confirmed no new compilation errors introduced (error count unchanged vs
  baseline)
  - Logic verified against Soroban SDK extend_ttl semantics: conditional by
  design, no write occurs above threshold

closes #874

