### PR TITLE
chore: add Justfile and document just targets in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,15 +4,45 @@ We welcome contributions! Please follow these guidelines to help us maintain pro
 
 ## Development Workflow
 1. **Fork the repo** and create your branch: git checkout -b feature/your-feature-name.
-2. **Formatting:** We use ustfmt. Please run the following command before committing:
-   \\\ash
+2. **Formatting:** We use rustfmt. Please run the following command before committing:
+   ```bash
+   just fmt
+   # or without just:
    cargo fmt
-   \\\
+   ```
 3. **Testing:** Run the test suite before submitting:
-   \\\ash
+   ```bash
+   just test
+   # or without just:
    ./scripts/test.sh
-   \\\
-4. **Pull Requests:** Open a PR against main. Ensure your PR description clearly outlines the changes and links to the relevant issue.
+   ```
+4. **Pre-PR check:** Run the full CI suite locally before opening a PR:
+   ```bash
+   just ci
+   ```
+5. **Pull Requests:** Open a PR against main. Ensure your PR description clearly outlines the changes and links to the relevant issue.
+
+## Available `just` Targets
+
+Install [just](https://just.systems/man/en/packages.html), then run `just --list` from the repo root:
+
+```
+Available recipes:
+    audit               # Run cargo-audit (install with: cargo install cargo-audit)
+    build               # Build both Soroban contracts for wasm32 release
+    ci                  # Run build + test + clippy in one shot (useful before opening a PR)
+    clippy              # Run clippy (warnings treated as errors, matching CI)
+    deploy-mainnet      # Deploy to Stellar mainnet (requires STELLAR_MAINNET_RPC_URL; prompts for confirmation)
+    deploy-mainnet-force# Force-redeploy to mainnet without the existing-contract prompt
+    deploy-testnet      # Deploy to Stellar testnet (prompts if a contract already exists)
+    deploy-testnet-force# Force-redeploy to testnet without confirmation prompt
+    docker-down         # Stop and remove local dev stack containers
+    docker-up           # Start local dev stack (PostgreSQL, backend, Stellar Quickstart)
+    env-setup           # Copy .env.example to .env (skips if .env already exists)
+    fmt                 # Auto-format all code
+    fmt-check           # Check code formatting
+    test                # Run the full ttl_vault test suite
+```
 
 ## Style Guide
 - Follow standard Rust idiomatic practices.

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,86 @@
+# TTL-Legacy Justfile
+# Run `just` or `just --list` to see all available targets.
+# Install just: https://just.systems/man/en/packages.html
+
+# Default: list all targets
+default:
+    @just --list
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+
+# Build both Soroban contracts for wasm32 release
+build:
+    @echo "Building TTL-Legacy contracts..."
+    cargo build --target wasm32-unknown-unknown --release --manifest-path contracts/ttl_vault/Cargo.toml
+    cargo build --target wasm32-unknown-unknown --release --manifest-path contracts/zk_verifier/Cargo.toml
+    @echo "Build complete."
+
+# ── Test ──────────────────────────────────────────────────────────────────────
+
+# Run the full ttl_vault test suite
+test:
+    @echo "Running TTL-Legacy tests..."
+    cargo test --manifest-path contracts/ttl_vault/Cargo.toml
+    @echo "All tests passed."
+
+# ── Lint / Quality ────────────────────────────────────────────────────────────
+
+# Run clippy (warnings treated as errors, matching CI)
+clippy:
+    cargo clippy --package ttl-vault -- -D warnings
+
+# Check code formatting
+fmt-check:
+    cargo fmt --all -- --check
+
+# Auto-format all code
+fmt:
+    cargo fmt --all
+
+# ── Security ──────────────────────────────────────────────────────────────────
+
+# Run cargo-audit (install with: cargo install cargo-audit)
+audit:
+    cargo audit --deny warnings
+
+# ── Deploy ────────────────────────────────────────────────────────────────────
+
+# Deploy to Stellar testnet (prompts if a contract already exists)
+deploy-testnet:
+    ./scripts/deploy_testnet.sh
+
+# Force-redeploy to testnet without confirmation prompt
+deploy-testnet-force:
+    ./scripts/deploy_testnet.sh --force
+
+# Deploy to Stellar mainnet (requires STELLAR_MAINNET_RPC_URL; prompts for confirmation)
+deploy-mainnet:
+    ./scripts/deploy_mainnet.sh
+
+# Force-redeploy to mainnet without the existing-contract prompt
+deploy-mainnet-force:
+    ./scripts/deploy_mainnet.sh --force
+
+# ── Docker ────────────────────────────────────────────────────────────────────
+
+# Start local dev stack (PostgreSQL, backend, Stellar Quickstart)
+docker-up:
+    docker-compose up -d
+
+# Stop and remove local dev stack containers
+docker-down:
+    docker-compose down
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# Run build + test + clippy in one shot (useful before opening a PR)
+ci: build test clippy
+
+# Copy .env.example to .env (skips if .env already exists)
+env-setup:
+    @if [ -f .env ]; then \
+        echo ".env already exists — skipping."; \
+    else \
+        cp .env.example .env; \
+        echo "Created .env from .env.example. Fill in your values."; \
+    fi

--- a/README.md
+++ b/README.md
@@ -48,16 +48,43 @@ This Soroban implementation makes TTL-Legacy:
 - Rust (1.70+)
 - Soroban CLI
 - Stellar CLI
+- [just](https://just.systems/man/en/packages.html) (optional but recommended — centralizes all dev commands)
+
+### Using just
+
+Install `just` once, then run `just --list` to see every available target:
+
+```
+Available recipes:
+    audit               # Run cargo-audit (install with: cargo install cargo-audit)
+    build               # Build both Soroban contracts for wasm32 release
+    ci                  # Run build + test + clippy in one shot (useful before opening a PR)
+    clippy              # Run clippy (warnings treated as errors, matching CI)
+    deploy-mainnet      # Deploy to Stellar mainnet (requires STELLAR_MAINNET_RPC_URL; prompts for confirmation)
+    deploy-mainnet-force# Force-redeploy to mainnet without the existing-contract prompt
+    deploy-testnet      # Deploy to Stellar testnet (prompts if a contract already exists)
+    deploy-testnet-force# Force-redeploy to testnet without confirmation prompt
+    docker-down         # Stop and remove local dev stack containers
+    docker-up           # Start local dev stack (PostgreSQL, backend, Stellar Quickstart)
+    env-setup           # Copy .env.example to .env (skips if .env already exists)
+    fmt                 # Auto-format all code
+    fmt-check           # Check code formatting
+    test                # Run the full ttl_vault test suite
+```
 
 ### Build
 
 ```bash
+just build
+# or without just:
 ./scripts/build.sh
 ```
 
 ### Test
 
 ```bash
+just test
+# or without just:
 ./scripts/test.sh
 ```
 


### PR DESCRIPTION
 Summary
  
  Developers currently need to memorize cargo, stellar CLI, and ./scripts/
  commands spread across multiple files with no single entry point. This PR adds
  a Justfile to centralize all common dev tasks and updates the docs to match.
  
  Changes
  
  Justfile (new)
  
  14 targets covering the full development lifecycle:
  
  ┌────────┬─────────────┐
  │ Target │ Description │
  ├────────┼─────────────────────────────────────────────────┤
  │ build  │ Build both Soroban contracts for wasm32 release │
  ├────────┼─────────────────────────────────────────────────┤
  │ test   │ Run the full ttl_vault test suite               │
  ├────────┼─────────────────────────────────────────────────┤
  │ clippy │ Run clippy with -D warnings (matches CI)        │
  ├───────────┼─────────────────────────────────────────────────┤
  │ fmt       │ Auto-format all code                            │
  ├───────────┼─────────────────────────────────────────────────┤
  │ fmt-check │ Check formatting without writing                │
  ├───────────┼─────────────────────────────────────────────────┤
  │ audit          │ Run cargo-audit, deny warnings                  │
  ├──────────────────────┼─────────────────────────────────────────────────┤
  │ deploy-testnet       │ Deploy to testnet (prompts if contract exists)  │
  ├──────────────────────┼─────────────────────────────────────────────────┤
  │ deploy-testnet-force │ Force redeploy to testnet                       │
  ├──────────────────────┼─────────────────────────────────────────────────┤
  │ deploy-mainnet       │ Deploy to mainnet (requires confirmation)       │
  ├──────────────────────┼─────────────────────────────────────────────────┤
  │ deploy-mainnet-force │ Force redeploy to mainnet                       │
  ├──────────────────────┼─────────────────────────────────────────────────┤
  │ docker-up            │ Start local dev stack                           │
  ├──────────────────────┼─────────────────────────────────────────────────┤
  │ docker-down          │ Stop and remove containers                      │
  ├──────────────────────┼─────────────────────────────────────────────────┤
  │ ci                   │ Run build + test + clippy in one shot           │
  ├──────────────────────┼─────────────────────────────────────────────────┤
  │ env-setup            │ Copy .env.example → .env safely                 │
  └──────────────────────┴─────────────────────────────────────────────────┘
  
  README.md
  
  - Added just to prerequisites
  - Added just --list output to Quick Start
  - Updated build and test examples to show just alongside ./scripts/ equivalents
  
  CONTRIBUTING.md`
  
  - Fixed broken code fences (were rendering as \\\ash in the original)
  - Replaced ./scripts/test.sh references with just test
  - Added just ci as the recommended pre-PR check
  - Added full just --list reference section
  
  How to use
  
  # Install just (once)
  cargo install just
  # or: brew install just / apt install just
  
  # See all targets
  just --list
  
  # Common workflow
  just env-setup   # first-time setup
  just build       # compile contracts
  just test        # run tests
  just ci          # full pre-PR check


closes #875 
