### PR TITLE
feat: add per-vault admin freeze (#per-vault-freeze)

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -65,7 +65,7 @@ use types::{
     WITHDRAWAL_LIMIT_EXCEEDED_TOPIC, WITHDRAWAL_LIMIT_SET_TOPIC, WITHDRAWAL_NOTIF_TOPIC,
     WITHDRAWAL_REVERSED_TOPIC, WITHDRAWAL_SCHEDULED_TOPIC, WITHDRAWAL_VALIDATION_TOPIC,
     WITHDRAW_TOPIC, WRAPPED_TOKEN_REGISTERED_TOPIC, WRAPPED_TOKEN_UNREGISTERED_TOPIC,
-    YIELD_DISTRIBUTED_TOPIC, YIELD_REINVESTED_TOPIC,
+    YIELD_DISTRIBUTED_TOPIC, YIELD_REINVESTED_TOPIC, FREEZE_VAULT_TOPIC, UNFREEZE_VAULT_TOPIC,
 };
 #[cfg(test)]
 mod beneficiary_auction_tests;
@@ -1425,6 +1425,9 @@ impl TtlVaultContract {
         if vault.is_paused {
             return Err(ContractError::Paused);
         }
+        if Self::check_vault_frozen(&env, vault_id) {
+            return Err(ContractError::VaultFrozen);
+        }
         let is_delegate = caller != vault.owner && Self::is_check_in_delegate(&env, vault_id, &caller);
         if caller != vault.owner && !is_delegate {
             return Err(ContractError::NotOwner);
@@ -1598,6 +1601,9 @@ impl TtlVaultContract {
         }
         if vault.is_paused {
             panic_with_error!(&env, ContractError::Paused);
+        }
+        if Self::check_vault_frozen(&env, vault_id) {
+            panic_with_error!(&env, ContractError::VaultFrozen);
         }
         if vault.status != ReleaseStatus::Locked {
             panic_with_error!(&env, ContractError::AlreadyReleased);
@@ -1777,6 +1783,10 @@ impl TtlVaultContract {
         }
         if vault.status == ReleaseStatus::EmergencyFrozen {
             Self::record_withdrawal_audit(&env, vault_id, &caller, amount, false, "Vault frozen");
+            return Err(ContractError::VaultFrozen);
+        }
+        if Self::check_vault_frozen(&env, vault_id) {
+            Self::record_withdrawal_audit(&env, vault_id, &caller, amount, false, "Vault admin-frozen");
             return Err(ContractError::VaultFrozen);
         }
         if vault.status != ReleaseStatus::Locked {
@@ -2397,6 +2407,9 @@ impl TtlVaultContract {
         // Attempt to restore archived vault state before proceeding - Issue #443
         Self::try_restore_archived_vault(&env, vault_id);
         let mut vault = Self::load_vault(&env, vault_id);
+        if Self::check_vault_frozen(&env, vault_id) {
+            panic_with_error!(&env, ContractError::VaultFrozen);
+        }
         if env
             .storage()
             .persistent()
@@ -6913,6 +6926,75 @@ impl TtlVaultContract {
         }
     }
 
+    // --- Per-vault admin freeze (Issue: per-vault freeze) ---
+
+    /// Freezes a specific vault, blocking deposit, withdraw, check_in, and trigger_release.
+    ///
+    /// Unlike the global contract pause or the per-vault owner pause, this is an **admin-only**
+    /// action intended for incident response when a single vault is believed to be compromised.
+    /// The freeze flag is stored as a separate persistent key (`DataKey::VaultFrozen`) so it
+    /// survives vault-struct updates and can be inspected independently.
+    ///
+    /// # Arguments
+    /// * `env`      - The Soroban environment
+    /// * `vault_id` - The unique identifier of the vault to freeze
+    ///
+    /// # Errors
+    /// * `ContractError::NotAdmin`      - If the caller is not the contract admin
+    /// * `ContractError::VaultNotFound` - If the vault does not exist
+    pub fn freeze_vault(env: Env, vault_id: u64) -> Result<(), ContractError> {
+        Self::require_admin(&env);
+        // Verify the vault exists before acting on it
+        Self::load_vault(&env, vault_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::VaultFrozen(vault_id), &true);
+        env.storage().persistent().extend_ttl(
+            &DataKey::VaultFrozen(vault_id),
+            VAULT_TTL_THRESHOLD,
+            VAULT_TTL_LEDGERS,
+        );
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events()
+            .publish((FREEZE_VAULT_TOPIC, vault_id), true);
+        Ok(())
+    }
+
+    /// Unfreezes a previously frozen vault, restoring normal operation.
+    ///
+    /// # Arguments
+    /// * `env`      - The Soroban environment
+    /// * `vault_id` - The unique identifier of the vault to unfreeze
+    ///
+    /// # Errors
+    /// * `ContractError::NotAdmin`      - If the caller is not the contract admin
+    /// * `ContractError::VaultNotFound` - If the vault does not exist
+    pub fn unfreeze_vault(env: Env, vault_id: u64) -> Result<(), ContractError> {
+        Self::require_admin(&env);
+        // Verify the vault exists before acting on it
+        Self::load_vault(&env, vault_id);
+        env.storage()
+            .persistent()
+            .remove(&DataKey::VaultFrozen(vault_id));
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events()
+            .publish((UNFREEZE_VAULT_TOPIC, vault_id), false);
+        Ok(())
+    }
+
+    /// Returns `true` if the vault is currently frozen by an admin.
+    ///
+    /// # Arguments
+    /// * `env`      - The Soroban environment
+    /// * `vault_id` - The unique identifier of the vault
+    pub fn is_vault_frozen(env: Env, vault_id: u64) -> bool {
+        Self::check_vault_frozen(&env, vault_id)
+    }
+
     // --- Issue #379: Conditional Release Logic ---
 
     /// Sets the release condition for a vault.
@@ -8065,6 +8147,15 @@ impl TtlVaultContract {
         env.storage()
             .instance()
             .get(&DataKey::Paused)
+            .unwrap_or(false)
+    }
+
+    /// Returns `true` when the vault's admin freeze flag is set.
+    /// Used internally by deposit, withdraw, check_in, and trigger_release.
+    fn check_vault_frozen(env: &Env, vault_id: u64) -> bool {
+        env.storage()
+            .persistent()
+            .get::<DataKey, bool>(&DataKey::VaultFrozen(vault_id))
             .unwrap_or(false)
     }
 

--- a/contracts/ttl_vault/src/test.rs
+++ b/contracts/ttl_vault/src/test.rs
@@ -6856,3 +6856,231 @@ fn test_check_in_history_page_consistent_with_full_history() {
         );
     }
 }
+
+// ============================================================
+// Per-vault admin freeze tests (Issue: per-vault freeze)
+// ============================================================
+
+/// Helper: create a vault and fund it so operations are meaningful.
+fn setup_funded_vault(
+    env: &Env,
+    owner: &Address,
+    beneficiary: &Address,
+    client: &TtlVaultContractClient<'_>,
+    token_address: &Address,
+) -> u64 {
+    let vault_id = client.create_vault(owner, beneficiary, &100u64, &None);
+    StellarAssetClient::new(env, token_address).mint(owner, &500_000);
+    client.deposit(&vault_id, owner, &100_000);
+    vault_id
+}
+
+#[test]
+fn test_freeze_vault_is_vault_frozen_reflects_state() {
+    let (env, owner, beneficiary, admin, token_address, client) = setup();
+    let vault_id = setup_funded_vault(&env, &owner, &beneficiary, &client, &token_address);
+
+    // Initially not frozen
+    assert!(!client.is_vault_frozen(&vault_id));
+
+    // Admin freezes the vault
+    client.freeze_vault(&vault_id);
+    assert!(client.is_vault_frozen(&vault_id));
+
+    // Admin unfreezes the vault
+    client.unfreeze_vault(&vault_id);
+    assert!(!client.is_vault_frozen(&vault_id));
+
+    let _ = admin; // referenced via mock_all_auths
+}
+
+#[test]
+fn test_freeze_blocks_deposit() {
+    let (env, owner, beneficiary, _admin, token_address, client) = setup();
+    let vault_id = setup_funded_vault(&env, &owner, &beneficiary, &client, &token_address);
+
+    client.freeze_vault(&vault_id);
+
+    StellarAssetClient::new(&env, &token_address).mint(&owner, &100_000);
+    let err = client.try_deposit(&vault_id, &owner, &10_000).unwrap_err().unwrap();
+    // ContractError::VaultFrozen = 59
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(59));
+}
+
+#[test]
+fn test_freeze_blocks_withdraw() {
+    let (env, owner, beneficiary, _admin, token_address, client) = setup();
+    let vault_id = setup_funded_vault(&env, &owner, &beneficiary, &client, &token_address);
+
+    client.freeze_vault(&vault_id);
+
+    let err = client.try_withdraw(&vault_id, &owner, &1_000).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(59));
+
+    let _ = env;
+}
+
+#[test]
+fn test_freeze_blocks_check_in() {
+    let (env, owner, beneficiary, _admin, token_address, client) = setup();
+    let vault_id = setup_funded_vault(&env, &owner, &beneficiary, &client, &token_address);
+
+    client.freeze_vault(&vault_id);
+
+    let passkey_hash: BytesN<32> = BytesN::from_array(&env, &[0u8; 32]);
+    let err = client
+        .try_check_in(&vault_id, &owner, &passkey_hash, &0u64)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(59));
+}
+
+#[test]
+fn test_freeze_blocks_trigger_release() {
+    let (env, owner, beneficiary, _admin, token_address, client) = setup();
+    let vault_id = setup_funded_vault(&env, &owner, &beneficiary, &client, &token_address);
+
+    // Advance time past check_in_interval so the vault is expired
+    env.ledger().with_mut(|li| li.timestamp += 200);
+
+    client.freeze_vault(&vault_id);
+
+    let err = client.try_trigger_release(&vault_id).unwrap_err().unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(59));
+}
+
+#[test]
+fn test_unfreeze_restores_deposit() {
+    let (env, owner, beneficiary, _admin, token_address, client) = setup();
+    let vault_id = setup_funded_vault(&env, &owner, &beneficiary, &client, &token_address);
+
+    client.freeze_vault(&vault_id);
+    client.unfreeze_vault(&vault_id);
+
+    StellarAssetClient::new(&env, &token_address).mint(&owner, &100_000);
+    // Should succeed without error
+    client.deposit(&vault_id, &owner, &5_000);
+    let vault = client.get_vault(&vault_id);
+    assert_eq!(vault.balance, 105_000);
+}
+
+#[test]
+fn test_unfreeze_restores_withdraw() {
+    let (env, owner, beneficiary, _admin, token_address, client) = setup();
+    let vault_id = setup_funded_vault(&env, &owner, &beneficiary, &client, &token_address);
+
+    client.freeze_vault(&vault_id);
+    client.unfreeze_vault(&vault_id);
+
+    // Should succeed without error
+    client.withdraw(&vault_id, &owner, &10_000);
+    let vault = client.get_vault(&vault_id);
+    assert_eq!(vault.balance, 90_000);
+
+    let _ = env;
+}
+
+#[test]
+fn test_non_admin_cannot_freeze() {
+    let (env, owner, beneficiary, _admin, token_address, client) = setup();
+    let vault_id = setup_funded_vault(&env, &owner, &beneficiary, &client, &token_address);
+
+    // mock_all_auths is active, so we can't test auth rejection directly here.
+    // We verify the admin-identity guard: freeze_vault internally calls
+    // require_admin which fetches the stored admin address and calls
+    // admin.require_auth(). The admin is set during initialize() and is NOT
+    // the owner. With mock_all_auths any require_auth succeeds, so the guard
+    // passes — but the vault is correctly frozen by admin action.
+    // The auth enforcement is unit-tested via the #[should_panic] companion below.
+    client.freeze_vault(&vault_id);
+    assert!(client.is_vault_frozen(&vault_id));
+    client.unfreeze_vault(&vault_id);
+    assert!(!client.is_vault_frozen(&vault_id));
+
+    let _ = owner;
+    let _ = beneficiary;
+    let _ = token_address;
+}
+
+/// Verifies that freeze_vault panics when the admin's auth is NOT provided.
+/// Uses a fresh env without mock_all_auths so Soroban enforces real auth.
+#[test]
+#[should_panic]
+fn test_non_admin_freeze_panics_without_admin_auth() {
+    let env = Env::default();
+    // No mock_all_auths — auth is fully enforced
+    let token_admin = Address::generate(&env);
+    let token_address = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let owner = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    let contract = env.register_contract(None, TtlVaultContract);
+    let client = TtlVaultContractClient::new(&env, &contract);
+
+    // Initialize with admin auth
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &admin,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract,
+            fn_name: "initialize",
+            args: (token_address.clone(), admin.clone()).into_val(&env),
+        },
+    }]);
+    client.initialize(&token_address, &admin);
+
+    // Mint tokens and create vault (need owner + token_admin auth)
+    env.mock_all_auths();
+    StellarAssetClient::new(&env, &token_address).mint(&owner, &1_000_000);
+    let vault_id = client.create_vault(&owner, &beneficiary, &100u64, &None);
+
+    // Now attempt freeze_vault with ONLY owner auth (not admin) — must panic
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &owner,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract,
+            fn_name: "freeze_vault",
+            args: (vault_id,).into_val(&env),
+        },
+    }]);
+    // This call should panic because admin.require_auth() is not satisfied
+    client.freeze_vault(&vault_id);
+}
+
+#[test]
+fn test_freeze_vault_emits_event() {
+    let (env, owner, beneficiary, _admin, token_address, client) = setup();
+    let vault_id = setup_funded_vault(&env, &owner, &beneficiary, &client, &token_address);
+
+    client.freeze_vault(&vault_id);
+
+    let found = env.events().all().iter().find(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
+        topics
+            .get(0)
+            .and_then(|v| v.try_into_val(&env).ok())
+            .map(|s: soroban_sdk::Symbol| s == types::FREEZE_VAULT_TOPIC)
+            .unwrap_or(false)
+    });
+    assert!(found.is_some(), "freeze_vault should emit frz_vlt event");
+}
+
+#[test]
+fn test_unfreeze_vault_emits_event() {
+    let (env, owner, beneficiary, _admin, token_address, client) = setup();
+    let vault_id = setup_funded_vault(&env, &owner, &beneficiary, &client, &token_address);
+
+    client.freeze_vault(&vault_id);
+    client.unfreeze_vault(&vault_id);
+
+    let found = env.events().all().iter().find(|e| {
+        let topics: soroban_sdk::Vec<soroban_sdk::Val> = e.1.clone().into_val(&env);
+        topics
+            .get(0)
+            .and_then(|v| v.try_into_val(&env).ok())
+            .map(|s: soroban_sdk::Symbol| s == types::UNFREEZE_VAULT_TOPIC)
+            .unwrap_or(false)
+    });
+    assert!(found.is_some(), "unfreeze_vault should emit ufrz_vlt event");
+}

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -240,6 +240,9 @@ pub const TTL_ACCELERATE_TOPIC: Symbol = symbol_short!("ttl_acc");
 // Emergency freeze events
 pub const EMERGENCY_FREEZE_TOPIC: Symbol = symbol_short!("emg_frz");
 pub const FREEZE_RESOLVED_TOPIC: Symbol = symbol_short!("frz_res");
+// Per-vault admin freeze/unfreeze events
+pub const FREEZE_VAULT_TOPIC: Symbol = symbol_short!("frz_vlt");
+pub const UNFREEZE_VAULT_TOPIC: Symbol = symbol_short!("ufrz_vlt");
 
 // Beneficiary rotation
 pub const BEN_ROTATION_TOPIC: Symbol = symbol_short!("ben_rot");
@@ -458,6 +461,9 @@ pub enum DataKey {
     // Issue #965: two-factor authentication
     TwoFactorConfig(u64),
     TwoFactorVerified(u64),
+    /// Per-vault admin freeze flag. When `true`, deposit/withdraw/check_in/trigger_release
+    /// are all rejected with `ContractError::VaultFrozen`.
+    VaultFrozen(u64),
 }
 
 /// Check-in history entry for TTL prediction - Issue #482


### PR DESCRIPTION
feat: add per-vault admin freeze
  
  Problem
  
  The contract previously only supported a global pause, meaning if a single
  vault was suspected compromised, the only mitigation was halting the entire
  contract — blocking all users.
  
  Solution
  
  Introduces a per-vault admin freeze backed by a dedicated
  DataKey::VaultFrozen(u64) persistent flag, completely independent of the vault
  struct and the global pause state.
  
  Changes
  
  types.rs
  
  - Added DataKey::VaultFrozen(u64) — persistent boolean flag per vault
  - Added FREEZE_VAULT_TOPIC (frz_vlt) and UNFREEZE_VAULT_TOPIC (ufrz_vlt) event
  symbols
  
  lib.rs
  
  - freeze_vault(env, vault_id) — admin-only; sets the flag and emits frz_vlt
  - unfreeze_vault(env, vault_id) — admin-only; removes the flag and emits
  ufrz_vlt
  - is_vault_frozen(env, vault_id) — public query
  - check_vault_frozen — private helper used internally
  - Freeze guard wired into deposit, withdraw, check_in, and trigger_release —
  all return ContractError::VaultFrozen (error 59) when frozen
  
  test.rs
  
  - 11 new tests covering: state toggle, all four blocked operations, restore
  after unfreeze, non-admin auth guard (#[should_panic]), and event emission
  
  Behaviour
  
  ┌───────┬─────────┬──────────┬──────────┬─────────────────┐
  │ State  │ deposit │ withdraw │ check_in │ trigger_release │
  ├────────┼─────────┼──────────┼──────────┼─────────────────┤
  │ Normal │ ✅      │ ✅       │ ✅       │ ✅              │
  │ Normal │ ✅            │ ✅            │ ✅            │ ✅             │
  ├────────┼───────────────┼───────────────┼───────────────┼────────────────┤
  │ Frozen │ ❌            │ ❌            │ ❌            │ ❌ VaultFrozen │
  │          │ VaultFrozen   │ VaultFrozen   │ VaultFrozen   │ VaultFrozen   │
  ├──────────┼───────────────┼───────────────┼───────────────┼───────────────┤
  │ Unfrozen │ ✅            │ ✅            │ ✅            │ ✅            │
  └──────────┴───────────────┴───────────────┴───────────────┴───────────────┘
  
  The freeze flag is independent of vault.is_paused (owner-controlled) and the
  global Paused instance key (admin-controlled). A frozen vault can still be
  inspected via read-only calls.
  
  Security
  
  - Only the contract admin can freeze or unfreeze a vault
  - The flag is stored in persistent storage with full TTL extension, so it
  survives ledger archival
  - Freezing a vault that doesn't exist panics with VaultNotFound before writing
  any state

closes #870
