### PR TITLE
feat: implement check-in delegation with expiry (#946) and score syst…

### DIFF
--- a/contracts/ttl_vault/src/check_in_delegation_score_tests.rs
+++ b/contracts/ttl_vault/src/check_in_delegation_score_tests.rs
@@ -1,0 +1,472 @@
+/// Tests for Check-In Delegation (#946) and Check-In Verification Score (#947).
+extern crate alloc;
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, BytesN, Env,
+};
+
+fn setup() -> (
+    Env,
+    Address,
+    Address,
+    Address,
+    Address,
+    TtlVaultContractClient<'static>,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let owner = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token_address = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    soroban_sdk::token::StellarAssetClient::new(&env, &token_address).mint(&owner, &1_000_000);
+
+    let contract_address = env.register_contract(None, TtlVaultContract);
+    let client = TtlVaultContractClient::new(&env, &contract_address);
+    client.initialize(&token_address, &admin);
+
+    let client: TtlVaultContractClient<'static> = unsafe { core::mem::transmute(client) };
+
+    (env, owner, beneficiary, admin, token_address, client)
+}
+
+// ── Issue #946: delegate_check_in ─────────────────────────────────────────────
+
+/// Owner can register a delegate with no expiry.
+#[test]
+fn test_delegate_check_in_no_expiry() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let delegate = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client
+        .delegate_check_in(&id, &owner, &delegate, &None)
+        .unwrap();
+
+    assert!(client.is_check_in_delegate_pub(&id, &delegate));
+    assert!(!client.is_delegate_expired(&id, &delegate));
+}
+
+/// Owner can register a delegate with a future expiry.
+#[test]
+fn test_delegate_check_in_with_expiry() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let delegate = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    let now = env.ledger().timestamp();
+    let expiry = now + 7200; // 2 hours
+    client
+        .delegate_check_in(&id, &owner, &delegate, &Some(expiry))
+        .unwrap();
+
+    assert!(client.is_check_in_delegate_pub(&id, &delegate));
+    // Expiry is in the future — not yet expired
+    assert!(!client.is_delegate_expired(&id, &delegate));
+}
+
+/// Non-owner cannot register a delegate.
+#[test]
+fn test_delegate_check_in_non_owner_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let delegate = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    let err = client
+        .try_delegate_check_in(&id, &stranger, &delegate, &None)
+        .unwrap_err()
+        .unwrap();
+    // NotOwner = 6
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(6));
+}
+
+/// Registering the same delegate twice fails with InvalidBeneficiary (17).
+#[test]
+fn test_delegate_check_in_duplicate_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let delegate = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client
+        .delegate_check_in(&id, &owner, &delegate, &None)
+        .unwrap();
+
+    let err = client
+        .try_delegate_check_in(&id, &owner, &delegate, &None)
+        .unwrap_err()
+        .unwrap();
+    // InvalidBeneficiary = 17 (reused for duplicate delegate)
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(17));
+}
+
+// ── Issue #946: check_in_as_delegate ─────────────────────────────────────────
+
+/// Registered delegate (no expiry) can perform a check-in.
+#[test]
+fn test_check_in_as_delegate_success() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let delegate = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client
+        .delegate_check_in(&id, &owner, &delegate, &None)
+        .unwrap();
+
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    client.check_in_as_delegate(&id, &delegate, &0u64).unwrap();
+
+    let vault = client.get_vault(&id);
+    assert!(vault.last_check_in > 0);
+}
+
+/// check_in_as_delegate increments nonce — replaying nonce=0 fails.
+#[test]
+fn test_check_in_as_delegate_nonce_increments() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let delegate = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client
+        .delegate_check_in(&id, &owner, &delegate, &None)
+        .unwrap();
+
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    client.check_in_as_delegate(&id, &delegate, &0u64).unwrap();
+
+    // Replay nonce=0 must fail with InvalidNonce (83)
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    let err = client
+        .try_check_in_as_delegate(&id, &delegate, &0u64)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(83));
+}
+
+/// check_in_as_delegate with wrong nonce is rejected.
+#[test]
+fn test_check_in_as_delegate_wrong_nonce_rejected() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let delegate = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client
+        .delegate_check_in(&id, &owner, &delegate, &None)
+        .unwrap();
+
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    // First nonce should be 0; sending 1 must fail
+    let err = client
+        .try_check_in_as_delegate(&id, &delegate, &1u64)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(83)); // InvalidNonce
+}
+
+/// Non-registered address cannot call check_in_as_delegate.
+#[test]
+fn test_check_in_as_delegate_non_delegate_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let stranger = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    let err = client
+        .try_check_in_as_delegate(&id, &stranger, &0u64)
+        .unwrap_err()
+        .unwrap();
+    // NotDelegate = 90
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(90));
+}
+
+// ── Issue #946: expiry enforcement ───────────────────────────────────────────
+
+/// is_delegate_expired returns false before expiry time.
+#[test]
+fn test_is_delegate_not_expired_before_expiry() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let delegate = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    let now = env.ledger().timestamp();
+    client
+        .delegate_check_in(&id, &owner, &delegate, &Some(now + 3600))
+        .unwrap();
+
+    assert!(!client.is_delegate_expired(&id, &delegate));
+}
+
+/// is_delegate_expired returns true once the ledger passes the expiry.
+#[test]
+fn test_is_delegate_expired_after_expiry() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let delegate = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    let now = env.ledger().timestamp();
+    let expiry = now + 500;
+    client
+        .delegate_check_in(&id, &owner, &delegate, &Some(expiry))
+        .unwrap();
+
+    // Advance ledger past expiry
+    env.ledger().with_mut(|l| l.timestamp = expiry + 1);
+    assert!(client.is_delegate_expired(&id, &delegate));
+}
+
+/// check_in_as_delegate fails with DelegateExpired (89) once expiry has passed.
+#[test]
+fn test_check_in_as_delegate_expired_fails() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let delegate = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    let now = env.ledger().timestamp();
+    let expiry = now + 500;
+    client
+        .delegate_check_in(&id, &owner, &delegate, &Some(expiry))
+        .unwrap();
+
+    // Advance ledger past expiry
+    env.ledger().with_mut(|l| l.timestamp = expiry + 1);
+
+    let err = client
+        .try_check_in_as_delegate(&id, &delegate, &0u64)
+        .unwrap_err()
+        .unwrap();
+    // DelegateExpired = 89
+    assert_eq!(err, soroban_sdk::Error::from_contract_error(89));
+}
+
+/// Delegate with no expiry set never returns is_delegate_expired = true.
+#[test]
+fn test_delegate_no_expiry_never_expires() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let delegate = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client
+        .delegate_check_in(&id, &owner, &delegate, &None)
+        .unwrap();
+
+    // Advance ledger by a long time
+    env.ledger().with_mut(|l| l.timestamp += 999_999);
+    assert!(!client.is_delegate_expired(&id, &delegate));
+}
+
+/// Delegate can check-in right up to expiry boundary (not yet expired).
+#[test]
+fn test_check_in_as_delegate_at_expiry_boundary_succeeds() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let delegate = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &7200u64, &None);
+
+    let now = env.ledger().timestamp();
+    let expiry = now + 500;
+    client
+        .delegate_check_in(&id, &owner, &delegate, &Some(expiry))
+        .unwrap();
+
+    // Advance to expiry - 1 (still valid)
+    env.ledger().with_mut(|l| l.timestamp = expiry - 1);
+    client.check_in_as_delegate(&id, &delegate, &0u64).unwrap();
+}
+
+// ── Issue #947: check_in_score initial state ─────────────────────────────────
+
+/// Newly created vault starts with check_in_score = 10000.
+#[test]
+fn test_initial_check_in_score() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    assert_eq!(client.get_check_in_score(&id), 10000u32);
+    let vault = client.get_vault(&id);
+    assert_eq!(vault.check_in_score, 10000u32);
+    assert_eq!(vault.total_check_ins, 0u32);
+    assert_eq!(vault.on_time_check_ins, 0u32);
+}
+
+// ── Issue #947: score updates via check_in ───────────────────────────────────
+
+/// On-time check-in keeps score at 10000.
+#[test]
+fn test_score_stays_perfect_after_on_time_check_in() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let passkey = BytesN::from_array(&env, &[1u8; 32]);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    // Check in well within the interval
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    client.check_in(&id, &owner, &passkey, &0u64).unwrap();
+
+    assert_eq!(client.get_check_in_score(&id), 10000u32);
+    let vault = client.get_vault(&id);
+    assert_eq!(vault.total_check_ins, 1u32);
+    assert_eq!(vault.on_time_check_ins, 1u32);
+}
+
+/// Late check-in (after interval) lowers the score below 10000.
+#[test]
+fn test_score_decreases_after_late_check_in() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let passkey = BytesN::from_array(&env, &[1u8; 32]);
+    // Use a short interval so we can advance past it easily
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    // Advance past the check-in interval → late
+    env.ledger().with_mut(|l| l.timestamp += 7200);
+    client.check_in(&id, &owner, &passkey, &0u64).unwrap();
+
+    let score = client.get_check_in_score(&id);
+    // 1 on-time out of 1 total would be 10000; but this was late → 0 on-time out of 1 = 0
+    assert_eq!(score, 0u32);
+    let vault = client.get_vault(&id);
+    assert_eq!(vault.total_check_ins, 1u32);
+    assert_eq!(vault.on_time_check_ins, 0u32);
+}
+
+/// Multiple on-time check-ins keep score at 10000.
+#[test]
+fn test_score_stays_perfect_multiple_on_time() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let passkey = BytesN::from_array(&env, &[1u8; 32]);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    for i in 1u64..=5 {
+        env.ledger().with_mut(|l| l.timestamp = i * 100);
+        client.check_in(&id, &owner, &passkey, &0u64).unwrap();
+    }
+
+    assert_eq!(client.get_check_in_score(&id), 10000u32);
+    let vault = client.get_vault(&id);
+    assert_eq!(vault.total_check_ins, 5u32);
+    assert_eq!(vault.on_time_check_ins, 5u32);
+}
+
+/// Mixed on-time and late check-ins produce the correct proportional score.
+#[test]
+fn test_score_proportional_mixed_check_ins() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let passkey = BytesN::from_array(&env, &[1u8; 32]);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    // 1st: on time (within interval)
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    client.check_in(&id, &owner, &passkey, &0u64).unwrap();
+
+    // 2nd: on time
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    client.check_in(&id, &owner, &passkey, &0u64).unwrap();
+
+    // 3rd: late (past interval from 2nd check-in)
+    env.ledger().with_mut(|l| l.timestamp += 7200);
+    client.check_in(&id, &owner, &passkey, &0u64).unwrap();
+
+    // 4th: late again
+    env.ledger().with_mut(|l| l.timestamp += 7200);
+    client.check_in(&id, &owner, &passkey, &0u64).unwrap();
+
+    // 2 on-time out of 4 total → score = 2*10000/4 = 5000
+    assert_eq!(client.get_check_in_score(&id), 5000u32);
+}
+
+// ── Issue #947: score updates via check_in_as_delegate ───────────────────────
+
+/// Delegate on-time check-in keeps score at 10000.
+#[test]
+fn test_score_on_time_via_delegate() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let delegate = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client
+        .delegate_check_in(&id, &owner, &delegate, &None)
+        .unwrap();
+
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    client.check_in_as_delegate(&id, &delegate, &0u64).unwrap();
+
+    assert_eq!(client.get_check_in_score(&id), 10000u32);
+    let vault = client.get_vault(&id);
+    assert_eq!(vault.total_check_ins, 1u32);
+    assert_eq!(vault.on_time_check_ins, 1u32);
+}
+
+/// Delegate late check-in lowers the score.
+#[test]
+fn test_score_late_via_delegate() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let delegate = Address::generate(&env);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    client
+        .delegate_check_in(&id, &owner, &delegate, &None)
+        .unwrap();
+
+    // Advance past the check-in interval → late
+    env.ledger().with_mut(|l| l.timestamp += 7200);
+    client.check_in_as_delegate(&id, &delegate, &0u64).unwrap();
+
+    assert_eq!(client.get_check_in_score(&id), 0u32);
+    let vault = client.get_vault(&id);
+    assert_eq!(vault.total_check_ins, 1u32);
+    assert_eq!(vault.on_time_check_ins, 0u32);
+}
+
+/// Score accumulates correctly across owner and delegate check-ins.
+#[test]
+fn test_score_mixed_owner_and_delegate_check_ins() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let delegate = Address::generate(&env);
+    let passkey = BytesN::from_array(&env, &[1u8; 32]);
+    let id = client.create_vault(&owner, &beneficiary, &7200u64, &None);
+
+    client
+        .delegate_check_in(&id, &owner, &delegate, &None)
+        .unwrap();
+
+    // Owner on-time check-in
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    client.check_in(&id, &owner, &passkey, &0u64).unwrap();
+
+    // Delegate on-time check-in
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    client.check_in_as_delegate(&id, &delegate, &0u64).unwrap();
+
+    // Owner late check-in
+    env.ledger().with_mut(|l| l.timestamp += 100_000);
+    client.check_in(&id, &owner, &passkey, &0u64).unwrap();
+
+    // 2 on-time, 3 total → 2*10000/3 = 6666
+    let score = client.get_check_in_score(&id);
+    assert_eq!(score, 6666u32);
+}
+
+// ── Issue #947: get_check_in_score ───────────────────────────────────────────
+
+/// get_check_in_score returns the same value as vault.check_in_score.
+#[test]
+fn test_get_check_in_score_matches_vault_field() {
+    let (env, owner, beneficiary, _, _, client) = setup();
+    let passkey = BytesN::from_array(&env, &[1u8; 32]);
+    let id = client.create_vault(&owner, &beneficiary, &3600u64, &None);
+
+    env.ledger().with_mut(|l| l.timestamp += 100);
+    client.check_in(&id, &owner, &passkey, &0u64).unwrap();
+
+    env.ledger().with_mut(|l| l.timestamp += 7200);
+    client.check_in(&id, &owner, &passkey, &0u64).unwrap();
+
+    let vault_score = client.get_vault(&id).check_in_score;
+    let fn_score = client.get_check_in_score(&id);
+    assert_eq!(vault_score, fn_score);
+}

--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -66,12 +66,12 @@ use types::{
     WITHDRAWAL_REVERSED_TOPIC, WITHDRAWAL_SCHEDULED_TOPIC, WITHDRAWAL_VALIDATION_TOPIC,
     WITHDRAW_TOPIC, WRAPPED_TOKEN_REGISTERED_TOPIC, WRAPPED_TOKEN_UNREGISTERED_TOPIC,
     YIELD_DISTRIBUTED_TOPIC, YIELD_REINVESTED_TOPIC, FREEZE_VAULT_TOPIC, UNFREEZE_VAULT_TOPIC,
+    CHECKIN_SCORE_UPDATED_TOPIC,
 };
 #[cfg(test)]
 mod beneficiary_auction_tests;
 #[cfg(test)]
-mod beneficiary_pooling_tests;
-#[cfg(test)]
+mod beneficiary_pooling_tests;#[cfg(test)]
 mod beneficiary_vesting_auction_tests;
 #[cfg(test)]
 mod beneficiary_vesting_tests;
@@ -97,6 +97,8 @@ mod vault_expiry_tests;
 mod vault_pause_tests;
 #[cfg(test)]
 mod passkey_device_type_tests;
+#[cfg(test)]
+mod check_in_delegation_score_tests;
 
 /// Minimum TTL (in ledgers) before a persistent entry is eligible for extension.
 /// At ~5 s/ledger this is ~83 minutes.
@@ -254,6 +256,12 @@ pub enum ContractError {
     ChallengeNotFound = 86,
     ChallengeExpired = 87,
     DuplicateSignature = 88,
+    // Issue #946: delegate expiry
+    DelegateExpired = 89,
+    NotDelegate = 90,
+    // Missing error codes used in the contract
+    AdminCannotOwnVault = 91,
+    UnauthorizedDepositor = 92,
 }
 
 #[contract]
@@ -1366,6 +1374,9 @@ impl TtlVaultContract {
             passkey_rotation_period_seconds: 0,
             challenge_timeout_seconds: 300,
             multi_sig_threshold: 1,
+            check_in_score: 10000,
+            total_check_ins: 0,
+            on_time_check_ins: 0,
         };
         Self::save_vault(&env, vault_id, &vault);
         Self::add_owner_vault_id(&env, &owner, vault_id, check_in_interval);
@@ -1566,6 +1577,15 @@ impl TtlVaultContract {
         }
 
         // Attempt to save vault - if this fails, TTL is not extended
+        // Issue #947: update check-in score
+        {
+            let is_on_time = now <= original_last_check_in + vault.check_in_interval;
+            vault.total_check_ins = vault.total_check_ins.saturating_add(1);
+            if is_on_time {
+                vault.on_time_check_ins = vault.on_time_check_ins.saturating_add(1);
+            }
+            vault.check_in_score = Self::compute_check_in_score(vault.on_time_check_ins, vault.total_check_ins);
+        }
         Self::save_vault(&env, vault_id, &vault);
         let owner_ids = Self::load_owner_vault_ids(&env, &vault.owner);
         Self::save_owner_vault_ids(&env, &vault.owner, &owner_ids, vault.check_in_interval);
@@ -1597,6 +1617,8 @@ impl TtlVaultContract {
             .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
         env.events()
             .publish((CHECK_IN_TOPIC, vault_id), vault.last_check_in);
+        env.events()
+            .publish((CHECKIN_SCORE_UPDATED_TOPIC, vault_id), vault.check_in_score);
         Ok(())
     }
     ///
@@ -7259,6 +7281,9 @@ impl TtlVaultContract {
             passkey_rotation_period_seconds: 0,
             challenge_timeout_seconds: 300,
             multi_sig_threshold: 1,
+            check_in_score: 10000,
+            total_check_ins: 0,
+            on_time_check_ins: 0,
         };
 
         Self::save_vault(&env, vault_id, &new_vault);
@@ -8882,6 +8907,9 @@ impl TtlVaultContract {
             passkey_rotation_period_seconds: original.passkey_rotation_period_seconds,
             challenge_timeout_seconds: original.challenge_timeout_seconds,
             multi_sig_threshold: original.multi_sig_threshold,
+            check_in_score: 10000,
+            total_check_ins: 0,
+            on_time_check_ins: 0,
         };
         Self::save_vault(&env, new_vault_id, &cloned_vault);
         Self::add_owner_vault_id(&env, &new_owner, new_vault_id, original.check_in_interval);
@@ -9022,6 +9050,9 @@ impl TtlVaultContract {
             passkey_rotation_period_seconds: original.passkey_rotation_period_seconds,
             challenge_timeout_seconds: original.challenge_timeout_seconds,
             multi_sig_threshold: original.multi_sig_threshold,
+            check_in_score: 10000,
+            total_check_ins: 0,
+            on_time_check_ins: 0,
         };
         Self::save_vault(&env, new_vault_id, &cloned_vault);
         Self::add_owner_vault_id(&env, &new_owner, new_vault_id, check_in_interval);
@@ -12032,6 +12063,270 @@ impl TtlVaultContract {
     /// Returns whether `delegate` is a registered check-in delegate for `vault_id`.
     pub fn is_check_in_delegate_pub(env: Env, vault_id: u64, delegate: Address) -> bool {
         Self::is_check_in_delegate(&env, vault_id, &delegate)
+    }
+
+    // ── Issue #946: Check-In Delegation to Service Provider ──────────────────
+
+    /// Registers a delegate who may perform check-ins on behalf of the vault owner,
+    /// with an optional expiry timestamp after which the delegation is invalid.
+    ///
+    /// Only the vault owner may call this. The delegate address is added to the
+    /// existing `CheckInDelegates` list (compatible with `check_in`) and its
+    /// expiry (if any) is recorded separately under `CheckInDelegateExpiry`.
+    ///
+    /// # Arguments
+    /// * `env`              - The Soroban environment
+    /// * `vault_id`         - Vault to authorise the delegate for
+    /// * `delegate_address` - Address of the trusted service provider / delegate
+    /// * `expiry`           - Optional Unix timestamp after which delegation is revoked;
+    ///                        `None` means no expiry (delegate is permanent until removed)
+    ///
+    /// # Errors
+    /// * `NotOwner`            - Caller is not the vault owner
+    /// * `AlreadyReleased`     - Vault has already been released
+    /// * `InvalidBeneficiary`  - Delegate is already registered (error code reused)
+    /// * `Paused`              - Contract or vault is paused
+    pub fn delegate_check_in(
+        env: Env,
+        vault_id: u64,
+        caller: Address,
+        delegate_address: Address,
+        expiry: Option<u64>,
+    ) -> Result<(), ContractError> {
+        if Self::load_paused(&env) {
+            return Err(ContractError::Paused);
+        }
+        caller.require_auth();
+        let vault = Self::load_vault(&env, vault_id);
+        if caller != vault.owner {
+            return Err(ContractError::NotOwner);
+        }
+        if vault.status != ReleaseStatus::Locked {
+            return Err(ContractError::AlreadyReleased);
+        }
+        if vault.is_paused {
+            return Err(ContractError::Paused);
+        }
+
+        // Reuse existing CheckInDelegates storage for compatibility with check_in
+        let key = DataKey::CheckInDelegates(vault_id);
+        let mut delegates: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(&env));
+        for d in delegates.iter() {
+            if d == delegate_address {
+                return Err(ContractError::InvalidBeneficiary); // delegate already registered
+            }
+        }
+        delegates.push_back(delegate_address.clone());
+        let ttl = vault_ttl_ledgers(vault.check_in_interval);
+        env.storage().persistent().set(&key, &delegates);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, VAULT_TTL_THRESHOLD, ttl);
+
+        // Store the expiry timestamp (if provided)
+        if let Some(exp) = expiry {
+            let expiry_key = DataKey::CheckInDelegateExpiry(vault_id, delegate_address.clone());
+            env.storage().persistent().set(&expiry_key, &exp);
+            env.storage()
+                .persistent()
+                .extend_ttl(&expiry_key, VAULT_TTL_THRESHOLD, ttl);
+        }
+
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        env.events()
+            .publish((DELEGATE_CHECKIN_TOPIC, vault_id), (delegate_address, expiry));
+        Ok(())
+    }
+
+    /// Performs a check-in on behalf of the vault owner by a registered delegate.
+    ///
+    /// Unlike the owner-oriented `check_in`, this entry point:
+    /// - Does **not** require a passkey (service providers typically cannot supply one)
+    /// - Enforces the delegate expiry set via `delegate_check_in`
+    /// - Applies the same rate-limit, TTL extension, and score logic as `check_in`
+    ///
+    /// The delegate's nonce is still incremented to prevent replay attacks.
+    ///
+    /// # Arguments
+    /// * `env`      - The Soroban environment
+    /// * `vault_id` - Vault to check in on behalf of
+    /// * `caller`   - Address of the delegate (must be registered and not expired)
+    ///
+    /// # Errors
+    /// * `NotDelegate`     - Caller is not a registered delegate
+    /// * `DelegateExpired` - Delegate's authorisation has passed its expiry timestamp
+    /// * `AlreadyReleased` - Vault has already been released
+    /// * `Paused`          - Contract or vault is paused
+    /// * `VaultFrozen`     - Vault is frozen
+    /// * `InvalidInterval` - Check-in rate limit not yet elapsed
+    pub fn check_in_as_delegate(
+        env: Env,
+        vault_id: u64,
+        caller: Address,
+        nonce: u64,
+    ) -> Result<(), ContractError> {
+        if Self::load_paused(&env) {
+            return Err(ContractError::Paused);
+        }
+        caller.require_auth();
+        let mut vault = Self::load_vault(&env, vault_id);
+        if vault.is_paused {
+            return Err(ContractError::Paused);
+        }
+        if Self::check_vault_frozen(&env, vault_id) {
+            return Err(ContractError::VaultFrozen);
+        }
+        if vault.status != ReleaseStatus::Locked {
+            return Err(ContractError::AlreadyReleased);
+        }
+
+        // Verify caller is a registered delegate
+        if !Self::is_check_in_delegate(&env, vault_id, &caller) {
+            return Err(ContractError::NotDelegate);
+        }
+
+        let now = env.ledger().timestamp();
+
+        // Enforce expiry if one was set for this delegate
+        let expiry_key = DataKey::CheckInDelegateExpiry(vault_id, caller.clone());
+        if let Some(expiry) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, u64>(&expiry_key)
+        {
+            if now >= expiry {
+                return Err(ContractError::DelegateExpired);
+            }
+        }
+
+        // Enforce per-delegation nonce to prevent replay attacks
+        let nonce_key = DataKey::DelegateNonce(vault_id, caller.clone());
+        let expected: u64 = env.storage().persistent().get(&nonce_key).unwrap_or(0);
+        if nonce != expected {
+            return Err(ContractError::InvalidNonce);
+        }
+        let ttl = vault_ttl_ledgers(vault.check_in_interval);
+        env.storage().persistent().set(&nonce_key, &(expected + 1));
+        env.storage()
+            .persistent()
+            .extend_ttl(&nonce_key, VAULT_TTL_THRESHOLD, ttl);
+
+        // Rate limiting: enforce minimum cooldown between check-ins
+        let cooldown: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinCheckInCooldown)
+            .unwrap_or(DEFAULT_MIN_CHECKIN_COOLDOWN);
+        if cooldown > 0 {
+            if let Some(last) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, u64>(&DataKey::LastCheckInTime(vault_id))
+            {
+                if now < last + cooldown {
+                    return Err(ContractError::InvalidInterval);
+                }
+            }
+        }
+
+        // Cap TTL at max_ttl_seconds
+        let max_ttl = Self::get_max_ttl_seconds(env.clone());
+        let deadline = now + vault.check_in_interval;
+        let max_deadline = now + max_ttl;
+        if deadline > max_deadline {
+            return Err(ContractError::MaxTtlExceeded);
+        }
+
+        // Record the check-in timestamp and update score
+        let original_last_check_in = vault.last_check_in;
+        vault.last_check_in = now;
+
+        // Update score: on-time if within check_in_interval from last check-in
+        let is_on_time = now <= original_last_check_in + vault.check_in_interval;
+        vault.total_check_ins = vault.total_check_ins.saturating_add(1);
+        if is_on_time {
+            vault.on_time_check_ins = vault.on_time_check_ins.saturating_add(1);
+        }
+        vault.check_in_score = Self::compute_check_in_score(vault.on_time_check_ins, vault.total_check_ins);
+
+        Self::save_vault(&env, vault_id, &vault);
+        let owner_ids = Self::load_owner_vault_ids(&env, &vault.owner);
+        Self::save_owner_vault_ids(&env, &vault.owner, &owner_ids, vault.check_in_interval);
+
+        // Persist last check-in time for rate limiting
+        let lci_key = DataKey::LastCheckInTime(vault_id);
+        env.storage().persistent().set(&lci_key, &now);
+        env.storage()
+            .persistent()
+            .extend_ttl(&lci_key, VAULT_TTL_THRESHOLD, ttl);
+
+        // Record check-in history and streak
+        Self::record_check_in_history(&env, vault_id, now);
+        Self::update_check_in_streak(&env, vault_id, &vault, now);
+
+        Self::log_audit_entry(&env, vault_id, "check_in_as_delegate", &caller, "");
+        Self::append_activity_log(&env, vault_id, "check_in_as_delegate", &caller, "");
+
+        // Reset countdown fired flags so thresholds fire again on the new cycle
+        env.storage()
+            .persistent()
+            .remove(&DataKey::CountdownFired(vault_id));
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+
+        env.events()
+            .publish((CHECK_IN_TOPIC, vault_id), vault.last_check_in);
+        env.events()
+            .publish((CHECKIN_SCORE_UPDATED_TOPIC, vault_id), vault.check_in_score);
+        Ok(())
+    }
+
+    // ── Issue #947: Check-In Verification Score ───────────────────────────────
+
+    /// Returns the current check-in score for a vault (0-10000).
+    ///
+    /// The score is the ratio of on-time check-ins to total check-ins, scaled to
+    /// the range 0-10000 (i.e. 10000 = 100% on-time, 0 = 0% on-time).
+    /// A freshly created vault starts at 10000.
+    ///
+    /// # Arguments
+    /// * `env`      - The Soroban environment
+    /// * `vault_id` - The vault to query
+    pub fn get_check_in_score(env: Env, vault_id: u64) -> u32 {
+        let vault = Self::load_vault(&env, vault_id);
+        vault.check_in_score
+    }
+
+    /// Returns whether a given delegate's expiry has passed.
+    ///
+    /// Returns `true` if an expiry exists and the current ledger timestamp is
+    /// past it; returns `false` otherwise (no expiry set = never expired).
+    pub fn is_delegate_expired(env: Env, vault_id: u64, delegate: Address) -> bool {
+        let expiry_key = DataKey::CheckInDelegateExpiry(vault_id, delegate);
+        if let Some(expiry) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, u64>(&expiry_key)
+        {
+            env.ledger().timestamp() >= expiry
+        } else {
+            false
+        }
+    }
+
+    /// Computes the check-in score as a value in 0-10000 from on-time and total counts.
+    fn compute_check_in_score(on_time: u32, total: u32) -> u32 {
+        if total == 0 {
+            return 10000;
+        }
+        ((on_time as u64 * 10000) / total as u64) as u32
     }
 
     // ── Internal withdraw helper (shared by withdraw + multisig execute) ─────

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -92,6 +92,8 @@ pub const VAULT_CAP_TOPIC: Symbol = symbol_short!("v_cap");
 // Issue #480: check-in delegation events
 pub const DELEGATE_CHECKIN_TOPIC: Symbol = symbol_short!("del_ci");
 pub const REVOKE_DELEGATE_TOPIC: Symbol = symbol_short!("rev_del");
+/// Emitted when check-in score is updated - Issue #947
+pub const CHECKIN_SCORE_UPDATED_TOPIC: Symbol = symbol_short!("ci_score");
 // Issue #481: proof-of-work event
 pub const CHECKIN_POW_TOPIC: Symbol = symbol_short!("ci_pow");
 // Issue #482: TTL prediction event
@@ -395,6 +397,8 @@ pub enum DataKey {
     CheckInDelegates(u64),
     // Per-delegation nonce to prevent check-in replay attacks
     DelegateNonce(u64, Address),
+    // Issue #946: expiry timestamp for each check-in delegate
+    CheckInDelegateExpiry(u64, Address),
     // Issue #498: beneficiary proof of life
     ProofOfLife(u64),
     // Issue #499: beneficiary release votes
@@ -813,6 +817,12 @@ pub struct Vault {
     pub challenge_timeout_seconds: u64,
     /// Multi-sig passkey threshold for withdrawals - Issue #939
     pub multi_sig_threshold: u32,
+    /// Check-in score (0-10000) for tracking consistency - Issue #947
+    pub check_in_score: u32,
+    /// Total number of check-ins recorded - Issue #947
+    pub total_check_ins: u32,
+    /// Number of on-time check-ins - Issue #947
+    pub on_time_check_ins: u32,
 }
 
 /// Passkey usage entry for tracking check-ins - Issue #395


### PR DESCRIPTION
…em (#947)

#946 - Check-In Delegation to Service Provider:
- Add `delegate_check_in(vault_id, caller, delegate_address, expiry)` (owner-only) Registers a trusted service provider as a delegate with an optional expiry timestamp. Compatible with existing CheckInDelegates storage.
- Add `check_in_as_delegate(vault_id, caller, nonce)` (delegate-only) Passkey-free check-in path for service providers. Enforces expiry, nonce replay protection, rate limiting and TTL extension identically to check_in.
- Add `is_delegate_expired(vault_id, delegate)` public query helper
- Add CheckInDelegateExpiry(u64, Address) DataKey variant for per-delegate expiry
- Add DelegateExpired (89) and NotDelegate (90) ContractError variants

#947 - Check-In Verification Score System:
- Add `check_in_score: u32` (0-10000), `total_check_ins: u32`, and `on_time_check_ins: u32` fields to Vault struct
- Score starts at 10000 on vault creation; updated on every check-in
- A check-in is "on-time" when it occurs within check_in_interval of the previous one; late check-ins reduce the score proportionally
- Add `get_check_in_score(vault_id) -> u32` public function
- Emit CheckInScoreUpdated event after each check_in and check_in_as_delegate
- Add CHECKIN_SCORE_UPDATED_TOPIC ("ci_score") constant
- Integrate score tracking into both check_in and check_in_as_delegate

Also fix two missing ContractError variants that were referenced but undeclared:
- AdminCannotOwnVault (91)
- UnauthorizedDepositor (92)

Tests (check_in_delegation_score_tests.rs):
- 22 tests covering delegation registration, expiry enforcement, nonce replay protection, score calculation, and get_check_in_score accuracy

Closes #946 
Closes #947 