### PR TITLE
fix: Enforce Minimum Check-in Interval Lower Bound

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -98,7 +98,9 @@ mod vault_pause_tests;
 #[cfg(test)]
 mod passkey_device_type_tests;
 
-/// Minimum TTL (in ledgers) before a persistent entry is eligible for extension.
+
+#[cfg(test)]
+mod min_checkin_interval_tests;/// Minimum TTL (in ledgers) before a persistent entry is eligible for extension.
 /// At ~5 s/ledger this is ~83 minutes.
 pub const VAULT_TTL_THRESHOLD: u32 = 1000;
 
@@ -152,6 +154,10 @@ fn vault_ttl_ledgers(check_in_interval: u64) -> u32 {
         .saturating_div(LEDGER_SECOND);
     ledgers.clamp(VAULT_TTL_LEDGERS, MAX_PERSISTENT_TTL)
 }
+
+/// Minimum check-in interval: 1 hour (3600 seconds)
+/// Prevents abuse of TTL extension mechanisms with unreasonably short intervals
+pub const MIN_CHECK_IN_INTERVAL: u64 = 3600;
 
 #[contracterror(export = false)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -254,6 +260,7 @@ pub enum ContractError {
     ChallengeNotFound = 86,
     ChallengeExpired = 87,
     DuplicateSignature = 88,
+    CheckInIntervalTooShort = 89,  // Issue #1121: Enforce minimum check-in interval
 }
 
 #[contract]
@@ -1291,6 +1298,11 @@ impl TtlVaultContract {
         }
         if check_in_interval == 0 {
             panic_with_error!(&env, ContractError::InvalidInterval);
+        }
+        
+        // Issue #1121: Enforce minimum check-in interval (1 hour)
+        if check_in_interval < MIN_CHECK_IN_INTERVAL {
+            panic_with_error!(&env, ContractError::CheckInIntervalTooShort);
         }
 
         Self::assert_interval_in_bounds(&env, check_in_interval);

--- a/contracts/ttl_vault/src/min_checkin_interval_tests.rs
+++ b/contracts/ttl_vault/src/min_checkin_interval_tests.rs
@@ -1,0 +1,151 @@
+/// Tests for minimum check-in interval enforcement (Issue #1121)
+/// Ensures vaults cannot be created with intervals shorter than MIN_CHECK_IN_INTERVAL (1 hour / 3600 seconds)
+
+#[cfg(test)]
+mod tests {
+    use super::super::*;
+
+    fn setup() -> (Env, Address, Address, TtlVaultContractClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let owner = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+
+        let contract_id = env.register_contract(None, TtlVaultContract);
+        let client: TtlVaultContractClient<'static> = unsafe { core::mem::transmute(client) };
+
+        // Setup: initialize contract
+        let xlm_token = Address::generate(&env);
+        client.initialize(&admin, &xlm_token);
+
+        (env, owner, beneficiary, client)
+    }
+
+    /// Test creating vault with exactly the minimum interval (3600 seconds / 1 hour)
+    /// Should succeed
+    #[test]
+    fn test_create_vault_with_exactly_minimum_interval() {
+        let (env, owner, beneficiary, client) = setup();
+        let result = client.try_create_vault(
+            &owner,
+            &beneficiary,
+            &MIN_CHECK_IN_INTERVAL,
+            &None,
+        );
+        assert!(result.is_ok(), "Creating vault with exactly minimum interval should succeed");
+    }
+
+    /// Test creating vault with interval just below minimum (3599 seconds)
+    /// Should fail with CheckInIntervalTooShort error
+    #[test]
+    fn test_create_vault_with_interval_below_minimum() {
+        let (env, owner, beneficiary, client) = setup();
+        let below_min = MIN_CHECK_IN_INTERVAL - 1;
+        let result = client.try_create_vault(
+            &owner,
+            &beneficiary,
+            &below_min,
+            &None,
+        );
+        assert!(
+            result.is_err(),
+            "Creating vault with interval below minimum should fail"
+        );
+        match result.unwrap_err().unwrap() {
+            ContractError::CheckInIntervalTooShort => {},
+            e => panic!("Expected CheckInIntervalTooShort, got {:?}", e),
+        }
+    }
+
+    /// Test creating vault with very small interval (1 second)
+    /// Should fail with CheckInIntervalTooShort error
+    #[test]
+    fn test_create_vault_with_one_second_interval() {
+        let (env, owner, beneficiary, client) = setup();
+        let result = client.try_create_vault(&owner, &beneficiary, &1, &None);
+        assert!(
+            result.is_err(),
+            "Creating vault with 1 second interval should fail"
+        );
+        match result.unwrap_err().unwrap() {
+            ContractError::CheckInIntervalTooShort => {},
+            e => panic!("Expected CheckInIntervalTooShort, got {:?}", e),
+        }
+    }
+
+    /// Test creating vault with zero interval
+    /// Should fail with InvalidInterval error (this is the first check)
+    #[test]
+    fn test_create_vault_with_zero_interval() {
+        let (env, owner, beneficiary, client) = setup();
+        let result = client.try_create_vault(&owner, &beneficiary, &0, &None);
+        assert!(result.is_err(), "Creating vault with 0 interval should fail");
+        match result.unwrap_err().unwrap() {
+            ContractError::InvalidInterval => {},
+            e => panic!("Expected InvalidInterval, got {:?}", e),
+        }
+    }
+
+    /// Test creating vault with well-above minimum interval (30 days / 2592000 seconds)
+    /// Should succeed
+    #[test]
+    fn test_create_vault_with_well_above_minimum_interval() {
+        let (env, owner, beneficiary, client) = setup();
+        let thirty_days = 30u64 * 24u64 * 3600u64; // 2,592,000 seconds
+        let result = client.try_create_vault(
+            &owner,
+            &beneficiary,
+            &thirty_days,
+            &None,
+        );
+        assert!(
+            result.is_ok(),
+            "Creating vault with 30-day interval should succeed"
+        );
+    }
+
+    /// Test creating vault with 2-hour interval (7200 seconds)
+    /// Should succeed
+    #[test]
+    fn test_create_vault_with_two_hour_interval() {
+        let (env, owner, beneficiary, client) = setup();
+        let two_hours = 2u64 * 3600u64;
+        let result = client.try_create_vault(&owner, &beneficiary, &two_hours, &None);
+        assert!(
+            result.is_ok(),
+            "Creating vault with 2-hour interval should succeed"
+        );
+    }
+
+    /// Test MIN_CHECK_IN_INTERVAL constant value
+    /// Ensures it's set to 1 hour as expected
+    #[test]
+    fn test_min_checkin_interval_is_one_hour() {
+        assert_eq!(
+            MIN_CHECK_IN_INTERVAL, 3600,
+            "MIN_CHECK_IN_INTERVAL should be 3600 seconds (1 hour)"
+        );
+    }
+
+    /// Test that multiple vaults cannot be created with short intervals
+    /// Each attempt should fail consistently
+    #[test]
+    fn test_multiple_short_interval_attempts_all_fail() {
+        let (env, owner, beneficiary, client) = setup();
+        
+        // Try creating vaults with various short intervals
+        let short_intervals = vec![1u64, 100, 500, 1000, 3599];
+        
+        for interval in short_intervals {
+            let gen_beneficiary = Address::generate(&env);
+            let result = client.try_create_vault(&owner, &gen_beneficiary, &interval, &None);
+            assert!(
+                result.is_err(),
+                "Creating vault with interval {} should fail",
+                interval
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds validation to prevent vault creation with unreasonably short check-in intervals. Vaults now require a minimum interval of 1 hour (3600 seconds) to prevent abuse of TTL extension mechanisms.

## Changes
- **Constant**: `MIN_CHECK_IN_INTERVAL = 3600` seconds (1 hour)
- **Error**: New `CheckInIntervalTooShort` error (code 89) for violations
- **Validation**: Check-in interval must be `≥ 3600` seconds in `create_vault()`
- **Tests**: Comprehensive test coverage including:
  - Exactly minimum (succeeds)
  - Below minimum (fails)
  - Zero interval (fails with different error)
  - Multiple short intervals all rejected
  - Well-above minimum (succeeds)

## Impact
- Prevents creation of vaults with intervals < 1 hour
- Blocks gaming of TTL extension costs
- Maintains usability for all practical vault scenarios (existing templates: 30/60/90 days)

Closes #1121
