### PR TITLE
feat: add ttl-legacy:// App Links scheme test coverage (#1146)

### DIFF
--- a/mobile/android/app/src/test/java/com/ttllegacy/VaultDeepLinkParserTest.kt
+++ b/mobile/android/app/src/test/java/com/ttllegacy/VaultDeepLinkParserTest.kt
@@ -6,39 +6,99 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 
+/**
+ * Unit tests for [VaultDeepLinkParser].
+ *
+ * Covers both URI schemes:
+ *  - `ttllegacy://` — legacy custom scheme (backwards compatibility)
+ *  - `ttl-legacy://` — new App Links scheme with android:autoVerify="true" (Issue #1146)
+ */
 class VaultDeepLinkParserTest {
 
+    // -----------------------------------------------------------------------
+    // Legacy scheme: ttllegacy://
+    // -----------------------------------------------------------------------
+
     @Test
-    fun parseUrl_checkIn_returnsVaultDeepLink() {
+    fun parseUrl_legacy_checkIn_returnsVaultDeepLink() {
         val result = VaultDeepLinkParser.parseUrl("ttllegacy://vault/vault-abc-123/check-in")
         assertEquals("vault-abc-123", result?.vaultId)
         assertEquals(VaultDeepLinkAction.CHECK_IN, result?.action)
     }
 
     @Test
-    fun parseUrl_withdraw_returnsVaultDeepLink() {
+    fun parseUrl_legacy_withdraw_returnsVaultDeepLink() {
         val result = VaultDeepLinkParser.parseUrl("ttllegacy://vault/vault-xyz/withdraw")
         assertEquals("vault-xyz", result?.vaultId)
         assertEquals(VaultDeepLinkAction.WITHDRAW, result?.action)
     }
 
     @Test
-    fun parseUrl_viewDetails_returnsVaultDeepLink() {
+    fun parseUrl_legacy_viewDetails_returnsVaultDeepLink() {
         val result = VaultDeepLinkParser.parseUrl("ttllegacy://vault/v1/view-details")
         assertEquals("v1", result?.vaultId)
         assertEquals(VaultDeepLinkAction.VIEW_DETAILS, result?.action)
     }
 
     @Test
-    fun parseUrl_manageBeneficiary_returnsVaultDeepLink() {
+    fun parseUrl_legacy_manageBeneficiary_returnsVaultDeepLink() {
         val result = VaultDeepLinkParser.parseUrl("ttllegacy://vault/vault-42/manage-beneficiary")
         assertEquals("vault-42", result?.vaultId)
         assertEquals(VaultDeepLinkAction.MANAGE_BENEFICIARY, result?.action)
     }
 
+    // -----------------------------------------------------------------------
+    // New App Links scheme: ttl-legacy:// (Issue #1146)
+    // Registered with android:autoVerify="true" in AndroidManifest.xml.
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun parseUrl_appLinks_checkIn_returnsVaultDeepLink() {
+        val result = VaultDeepLinkParser.parseUrl("ttl-legacy://vault/vault-abc-123/check-in")
+        assertEquals("vault-abc-123", result?.vaultId)
+        assertEquals(VaultDeepLinkAction.CHECK_IN, result?.action)
+    }
+
+    @Test
+    fun parseUrl_appLinks_withdraw_returnsVaultDeepLink() {
+        val result = VaultDeepLinkParser.parseUrl("ttl-legacy://vault/vault-xyz/withdraw")
+        assertEquals("vault-xyz", result?.vaultId)
+        assertEquals(VaultDeepLinkAction.WITHDRAW, result?.action)
+    }
+
+    @Test
+    fun parseUrl_appLinks_viewDetails_returnsVaultDeepLink() {
+        val result = VaultDeepLinkParser.parseUrl("ttl-legacy://vault/v1/view-details")
+        assertEquals("v1", result?.vaultId)
+        assertEquals(VaultDeepLinkAction.VIEW_DETAILS, result?.action)
+    }
+
+    @Test
+    fun parseUrl_appLinks_manageBeneficiary_returnsVaultDeepLink() {
+        val result = VaultDeepLinkParser.parseUrl("ttl-legacy://vault/vault-42/manage-beneficiary")
+        assertEquals("vault-42", result?.vaultId)
+        assertEquals(VaultDeepLinkAction.MANAGE_BENEFICIARY, result?.action)
+    }
+
+    @Test
+    fun parseUrl_appLinks_hyphenatedVaultId_returnsVaultDeepLink() {
+        val result = VaultDeepLinkParser.parseUrl("ttl-legacy://vault/vault-with-dashes-99/check-in")
+        assertEquals("vault-with-dashes-99", result?.vaultId)
+        assertEquals(VaultDeepLinkAction.CHECK_IN, result?.action)
+    }
+
+    // -----------------------------------------------------------------------
+    // Negative cases (apply to both schemes)
+    // -----------------------------------------------------------------------
+
     @Test
     fun parseUrl_unknownAction_returnsNull() {
         assertNull(VaultDeepLinkParser.parseUrl("ttllegacy://vault/vault-1/unknown-action"))
+    }
+
+    @Test
+    fun parseUrl_appLinks_unknownAction_returnsNull() {
+        assertNull(VaultDeepLinkParser.parseUrl("ttl-legacy://vault/vault-1/unknown-action"))
     }
 
     @Test
@@ -52,7 +112,22 @@ class VaultDeepLinkParserTest {
     }
 
     @Test
+    fun parseUrl_appLinks_wrongHost_returnsNull() {
+        assertNull(VaultDeepLinkParser.parseUrl("ttl-legacy://other/v1/check-in"))
+    }
+
+    @Test
     fun parseUrl_missingActionSegment_returnsNull() {
         assertNull(VaultDeepLinkParser.parseUrl("ttllegacy://vault/v1"))
+    }
+
+    @Test
+    fun parseUrl_appLinks_missingActionSegment_returnsNull() {
+        assertNull(VaultDeepLinkParser.parseUrl("ttl-legacy://vault/v1"))
+    }
+
+    @Test
+    fun parseUrl_emptyString_returnsNull() {
+        assertNull(VaultDeepLinkParser.parseUrl(""))
     }
 }


### PR DESCRIPTION
Extend VaultDeepLinkParserTest to cover the new ttl-legacy:// scheme registered with android:autoVerify="true" in AndroidManifest.xml.

Previously the unit tests only exercised the legacy ttllegacy:// scheme. This adds a parallel suite for the new App Links scheme — all four actions (check-in, withdraw, view-details, manage-beneficiary), hyphenated vault IDs, and negative cases (wrong scheme, wrong host, missing segment, empty string).

Part of issue #1146 — Android App Links for Vault Deep Linking.
closes #1146 
closes #1147 