### PR TITLE
feat: Escalation, Webhook Retry, Dark Mode, Vault Timeline (#1101–#1104)

### DIFF
--- a/backend/simulator.html
+++ b/backend/simulator.html
@@ -8,6 +8,7 @@
     /* ── Reset & base ─────────────────────────────────────────────────── */
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
+    /* Dark theme (default) */
     :root {
       --bg:        #0f1117;
       --surface:   #1a1d27;
@@ -21,6 +22,53 @@
       --success:   #22c55e;
       --radius:    0.75rem;
     }
+
+    /* Light theme overrides */
+    :root[data-theme="light"] {
+      --bg:        #f8f9fc;
+      --surface:   #ffffff;
+      --border:    #d1d5e0;
+      --text:      #1a1d27;
+      --muted:     #5a6478;
+      --accent:    #4f46e5;
+      --accent-h:  #6366f1;
+      --danger:    #dc2626;
+      --warn:      #d97706;
+      --success:   #16a34a;
+    }
+
+    /* Respect system preference when no manual override is set */
+    @media (prefers-color-scheme: light) {
+      :root:not([data-theme]) {
+        --bg:        #f8f9fc;
+        --surface:   #ffffff;
+        --border:    #d1d5e0;
+        --text:      #1a1d27;
+        --muted:     #5a6478;
+        --accent:    #4f46e5;
+        --accent-h:  #6366f1;
+        --danger:    #dc2626;
+        --warn:      #d97706;
+        --success:   #16a34a;
+      }
+    }
+
+    /* ── Theme toggle button ──────────────────────────────────────────── */
+    .theme-toggle {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 99px;
+      color: var(--muted);
+      cursor: pointer;
+      font-size: 0.85rem;
+      font-weight: 500;
+      padding: 0.35rem 0.85rem;
+      transition: background 0.15s, color 0.15s, border-color 0.15s;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+    .theme-toggle:hover { border-color: var(--accent); color: var(--accent); }
 
     body {
       background: var(--bg);
@@ -265,13 +313,150 @@
       font-weight: 600;
     }
     .never-text { color: var(--success); font-style: italic; }
+
+    /* ── #1104: Vault Status Timeline ────────────────────────────────── */
+    .vault-timeline { margin-top: 0; }
+
+    .vtl-filter-row {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 1.25rem;
+      flex-wrap: wrap;
+    }
+    .vtl-filter-row label { font-size: 0.85rem; color: var(--muted); font-weight: 500; }
+    .vtl-filter-row select {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 0.4rem;
+      color: var(--text);
+      font-size: 0.9rem;
+      padding: 0.35rem 0.65rem;
+      outline: none;
+      transition: border-color 0.15s;
+    }
+    .vtl-filter-row select:focus { border-color: var(--accent); }
+    .vtl-reload-btn {
+      background: transparent;
+      border: 1px solid var(--border);
+      border-radius: 0.4rem;
+      color: var(--muted);
+      cursor: pointer;
+      font-size: 0.85rem;
+      padding: 0.35rem 0.75rem;
+      transition: border-color 0.15s, color 0.15s;
+    }
+    .vtl-reload-btn:hover { border-color: var(--accent); color: var(--accent); }
+
+    /* Event list */
+    .vtl-list { list-style: none; position: relative; }
+    .vtl-list::before {
+      content: '';
+      position: absolute;
+      left: 18px;
+      top: 0; bottom: 0;
+      width: 2px;
+      background: var(--border);
+    }
+    .vtl-item {
+      display: flex;
+      gap: 1rem;
+      align-items: flex-start;
+      padding: 0.85rem 0;
+      position: relative;
+    }
+    .vtl-icon {
+      width: 38px; height: 38px;
+      border-radius: 50%;
+      background: var(--surface);
+      border: 2px solid var(--border);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1rem;
+      flex-shrink: 0;
+      position: relative;
+      z-index: 1;
+    }
+    .vtl-icon.created       { border-color: var(--accent);  background: rgba(99,102,241,.1); }
+    .vtl-icon.deposited     { border-color: var(--success); background: rgba(34,197,94,.1);  }
+    .vtl-icon.checkedin     { border-color: var(--success); background: rgba(34,197,94,.1);  }
+    .vtl-icon.hibernated    { border-color: var(--warn);    background: rgba(245,158,11,.1); }
+    .vtl-icon.released      { border-color: var(--danger);  background: rgba(239,68,68,.1);  }
+    .vtl-icon.escalation    { border-color: var(--warn);    background: rgba(245,158,11,.1); }
+    .vtl-icon.webhook       { border-color: var(--muted);   background: rgba(136,146,164,.1);}
+
+    .vtl-body { flex: 1; }
+    .vtl-desc {
+      font-size: 0.9rem;
+      color: var(--text);
+      font-weight: 500;
+      margin-bottom: 0.15rem;
+    }
+    .vtl-meta {
+      font-size: 0.78rem;
+      color: var(--muted);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+    .vtl-amount {
+      font-size: 0.82rem;
+      color: var(--success);
+      font-weight: 600;
+    }
+
+    /* Skeleton loading state */
+    .vtl-skeleton {
+      display: flex;
+      gap: 1rem;
+      align-items: center;
+      padding: 0.85rem 0;
+    }
+    .skel-circle {
+      width: 38px; height: 38px;
+      border-radius: 50%;
+      background: var(--border);
+      flex-shrink: 0;
+      animation: shimmer 1.4s ease-in-out infinite;
+    }
+    .skel-lines { flex: 1; display: flex; flex-direction: column; gap: 0.4rem; }
+    .skel-line {
+      height: 10px;
+      border-radius: 6px;
+      background: var(--border);
+      animation: shimmer 1.4s ease-in-out infinite;
+    }
+    .skel-line.short { max-width: 40%; }
+    @keyframes shimmer {
+      0%,100% { opacity: 1; }
+      50%      { opacity: 0.4; }
+    }
+
+    /* Empty state */
+    .vtl-empty {
+      text-align: center;
+      padding: 2.5rem 1rem;
+      color: var(--muted);
+    }
+    .vtl-empty .vtl-empty-icon { font-size: 2.5rem; margin-bottom: 0.75rem; }
+    .vtl-empty p { font-size: 0.9rem; }
   </style>
 </head>
 <body>
 <div class="container">
   <header>
-    <h1>🕰️ Release Simulator</h1>
-    <p>Project when your TTL-Legacy vault will release to its beneficiary based on check-in behaviour scenarios.</p>
+    <div style="display:flex; justify-content:space-between; align-items:flex-start; flex-wrap:wrap; gap:0.75rem;">
+      <div>
+        <h1>🕰️ Release Simulator</h1>
+        <p>Project when your TTL-Legacy vault will release to its beneficiary based on check-in behaviour scenarios.</p>
+      </div>
+      <!-- #1103: Dark mode toggle -->
+      <button class="theme-toggle" id="themeToggle" onclick="toggleTheme()" aria-label="Toggle colour theme">
+        <span id="themeIcon">☀️</span>
+        <span id="themeLabel">Light</span>
+      </button>
+    </div>
   </header>
 
   <!-- ── Input Card ────────────────────────────────────────────────────── -->
@@ -314,12 +499,41 @@
       <div class="scenarios-grid" id="scenariosGrid"></div>
     </div>
 
-    <!-- Timeline -->
+    <!-- Timeline bar -->
     <div class="card">
       <div class="timeline">
         <p class="timeline-title">Relative Timeline (days until release)</p>
         <div id="timelineRows"></div>
       </div>
+    </div>
+  </div>
+
+  <!-- ── #1104: Vault Status Timeline ──────────────────────────────────── -->
+  <div class="card" style="margin-top:2rem;">
+    <p class="card-title">Vault Status Timeline</p>
+    <div class="vault-timeline">
+      <div class="vtl-filter-row">
+        <label for="vtlKind">Filter by event type:</label>
+        <select id="vtlKind" onchange="loadTimeline()">
+          <option value="">All events</option>
+          <option value="created">Created</option>
+          <option value="deposited">Deposited</option>
+          <option value="checkedin">Checked In</option>
+          <option value="hibernated">Hibernated</option>
+          <option value="released">Released</option>
+          <option value="escalation_sent">Escalation Sent</option>
+          <option value="webhook_delivered">Webhook Delivered</option>
+          <option value="webhook_failed">Webhook Failed</option>
+        </select>
+        <button class="vtl-reload-btn" onclick="loadTimeline()">↺ Refresh</button>
+      </div>
+      <ul class="vtl-list" id="vtlList">
+        <!-- populated by loadTimeline() -->
+        <li class="vtl-empty">
+          <div class="vtl-empty-icon">📋</div>
+          <p>Enter a Vault ID above and run a simulation to load the event timeline.</p>
+        </li>
+      </ul>
     </div>
   </div>
 </div>
@@ -492,6 +706,154 @@ function escHtml(str) {
 document.getElementById('vaultId').addEventListener('keydown', e => {
   if (e.key === 'Enter') runSimulation();
 });
+
+/* ── #1103: Dark Mode Toggle ──────────────────────────────────────────── */
+
+(function initTheme() {
+  // Restore preference from localStorage, if any.
+  const saved = localStorage.getItem('ttl-theme');
+  if (saved === 'light' || saved === 'dark') {
+    document.documentElement.setAttribute('data-theme', saved);
+  }
+  updateToggleButton();
+})();
+
+function toggleTheme() {
+  const current = document.documentElement.getAttribute('data-theme');
+  // Determine effective theme (accounting for system preference when unset).
+  const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const effectiveDark = current ? current === 'dark' : systemDark;
+  const next = effectiveDark ? 'light' : 'dark';
+  document.documentElement.setAttribute('data-theme', next);
+  localStorage.setItem('ttl-theme', next);
+  updateToggleButton();
+}
+
+function updateToggleButton() {
+  const current = document.documentElement.getAttribute('data-theme');
+  const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const isDark = current ? current === 'dark' : systemDark;
+  document.getElementById('themeIcon').textContent  = isDark ? '☀️' : '🌙';
+  document.getElementById('themeLabel').textContent = isDark ? 'Light' : 'Dark';
+}
+
+// Sync button label if OS theme changes while the tab is open.
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+  if (!document.documentElement.getAttribute('data-theme')) updateToggleButton();
+});
+
+/* ── #1104: Vault Status Timeline ─────────────────────────────────────── */
+
+const KIND_ICONS = {
+  created:           '🏦',
+  deposited:         '💰',
+  checkedin:         '✅',
+  checked_in:        '✅',
+  hibernated:        '❄️',
+  released:          '🔓',
+  escalation_sent:   '🚨',
+  escalationsent:    '🚨',
+  webhook_delivered: '🔗',
+  webhookdelivered:  '🔗',
+  webhook_failed:    '⚠️',
+  webhookfailed:     '⚠️',
+};
+
+const KIND_CLASS = {
+  created:           'created',
+  deposited:         'deposited',
+  checkedin:         'checkedin',
+  checked_in:        'checkedin',
+  hibernated:        'hibernated',
+  released:          'released',
+  escalation_sent:   'escalation',
+  escalationsent:    'escalation',
+  webhook_delivered: 'webhook',
+  webhookdelivered:  'webhook',
+  webhook_failed:    'webhook',
+  webhookfailed:     'webhook',
+};
+
+function renderSkeletons(n) {
+  return Array.from({ length: n }, () => `
+    <li class="vtl-skeleton">
+      <div class="skel-circle"></div>
+      <div class="skel-lines">
+        <div class="skel-line"></div>
+        <div class="skel-line short"></div>
+      </div>
+    </li>
+  `).join('');
+}
+
+async function loadTimeline() {
+  const vaultId = document.getElementById('vaultId').value.trim();
+  const list    = document.getElementById('vtlList');
+
+  if (!vaultId) {
+    list.innerHTML = `
+      <li class="vtl-empty">
+        <div class="vtl-empty-icon">📋</div>
+        <p>Enter a Vault ID above to load the event timeline.</p>
+      </li>`;
+    return;
+  }
+
+  // Show loading skeletons.
+  list.innerHTML = renderSkeletons(4);
+
+  const apiBase = document.getElementById('apiBase').value.trim().replace(/\/$/, '');
+  const kind    = document.getElementById('vtlKind').value;
+  const params  = kind ? `?kind=${encodeURIComponent(kind)}` : '';
+  const url     = `${apiBase}/api/vaults/${encodeURIComponent(vaultId)}/events${params}`;
+
+  try {
+    const res    = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const events = await res.json();
+
+    if (!Array.isArray(events) || events.length === 0) {
+      list.innerHTML = `
+        <li class="vtl-empty">
+          <div class="vtl-empty-icon">🌱</div>
+          <p>No events recorded yet for this vault.</p>
+        </li>`;
+      return;
+    }
+
+    list.innerHTML = events.map(ev => {
+      const kindKey  = (ev.kind || '').toLowerCase().replace(/-/g, '_');
+      const icon     = KIND_ICONS[kindKey]  ?? '📌';
+      const cssClass = KIND_CLASS[kindKey]  ?? 'created';
+      const amount   = ev.amount != null
+        ? `<span class="vtl-amount">+${Number(ev.amount).toLocaleString()} XLM</span>` : '';
+      return `
+        <li class="vtl-item">
+          <div class="vtl-icon ${cssClass}" aria-hidden="true">${icon}</div>
+          <div class="vtl-body">
+            <div class="vtl-desc">${escHtml(ev.description || kindKey)}</div>
+            <div class="vtl-meta">
+              <span>${formatDate(ev.timestamp)}</span>
+              ${amount}
+            </div>
+          </div>
+        </li>`;
+    }).join('');
+  } catch (e) {
+    list.innerHTML = `
+      <li class="vtl-empty">
+        <div class="vtl-empty-icon">⚠️</div>
+        <p>Could not load timeline: ${escHtml(e.message)}</p>
+      </li>`;
+  }
+}
+
+// Auto-load timeline after a successful simulation.
+const _origRunSimulation = runSimulation;
+async function runSimulation() {
+  await _origRunSimulation();
+  await loadTimeline();
+}
 </script>
 </body>
 </html>

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -620,6 +620,63 @@ impl Db {
                 "#,
             ),
             (
+                "5",
+                r#"
+                CREATE TABLE IF NOT EXISTS escalation_states (
+                    vault_id                INTEGER PRIMARY KEY,
+                    last_escalation_tier    TEXT,
+                    escalated_at            TEXT
+                );
+                CREATE TABLE IF NOT EXISTS escalation_events (
+                    id              TEXT PRIMARY KEY,
+                    vault_id        INTEGER NOT NULL,
+                    tier            TEXT NOT NULL,
+                    dispatched_at   TEXT NOT NULL,
+                    channels        TEXT NOT NULL DEFAULT '[]'
+                );
+                CREATE INDEX IF NOT EXISTS idx_escalation_events_vault_id ON escalation_events(vault_id);
+                CREATE TABLE IF NOT EXISTS webhook_deliveries (
+                    id              TEXT PRIMARY KEY,
+                    vault_id        TEXT NOT NULL,
+                    event_type      TEXT NOT NULL,
+                    payload         TEXT NOT NULL DEFAULT '{}',
+                    endpoint_url    TEXT NOT NULL,
+                    status          TEXT NOT NULL DEFAULT 'pending',
+                    attempt_count   INTEGER NOT NULL DEFAULT 0,
+                    next_retry_at   TEXT,
+                    created_at      TEXT NOT NULL,
+                    attempts        TEXT NOT NULL DEFAULT '[]'
+                );
+                CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_vault_id ON webhook_deliveries(vault_id);
+                CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_status   ON webhook_deliveries(status);
+                CREATE TABLE IF NOT EXISTS webhook_subscriptions (
+                    id              TEXT PRIMARY KEY,
+                    vault_id        TEXT NOT NULL,
+                    endpoint_url    TEXT NOT NULL,
+                    event_types     TEXT NOT NULL DEFAULT '[]',
+                    created_at      TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_webhook_subscriptions_vault_id ON webhook_subscriptions(vault_id);
+                CREATE TABLE IF NOT EXISTS vault_timeline_events (
+                    id          TEXT PRIMARY KEY,
+                    vault_id    TEXT NOT NULL,
+                    kind        TEXT NOT NULL,
+                    timestamp   TEXT NOT NULL,
+                    description TEXT NOT NULL DEFAULT '',
+                    amount      INTEGER,
+                    metadata    TEXT NOT NULL DEFAULT '{}'
+                );
+                CREATE INDEX IF NOT EXISTS idx_vault_timeline_events_vault_id  ON vault_timeline_events(vault_id);
+                CREATE INDEX IF NOT EXISTS idx_vault_timeline_events_kind      ON vault_timeline_events(kind);
+                CREATE TABLE IF NOT EXISTS vault_subscriptions (
+                    vault_id  INTEGER PRIMARY KEY,
+                    owner     TEXT NOT NULL,
+                    channels  TEXT NOT NULL,
+                    frequency TEXT NOT NULL
+                );
+                "#,
+            ),
+            (
                 "4",
                 r#"
                 CREATE TABLE IF NOT EXISTS sponsored_releases (
@@ -1244,6 +1301,374 @@ impl Db {
             ],
         )?;
         Ok(())
+    }
+
+    // ── #1101: Reminder Escalation ───────────────────────────────────────────
+
+    /// Upsert the escalation state for a vault.
+    pub fn upsert_escalation_state(
+        &self,
+        state: &crate::models::EscalationState,
+    ) -> Result<(), rusqlite::Error> {
+        use crate::models::EscalationTier;
+        let tier_str = state.last_escalation_tier.as_ref().map(|t| match t {
+            EscalationTier::T1 => "t1",
+            EscalationTier::T2 => "t2",
+            EscalationTier::T3 => "t3",
+        });
+        let escalated_at_str = state.escalated_at.map(|d| d.to_rfc3339());
+        self.conn.lock().unwrap().execute(
+            r#"
+            INSERT INTO escalation_states (vault_id, last_escalation_tier, escalated_at)
+            VALUES (?1, ?2, ?3)
+            ON CONFLICT(vault_id) DO UPDATE SET
+                last_escalation_tier = excluded.last_escalation_tier,
+                escalated_at = excluded.escalated_at
+            "#,
+            params![state.vault_id as i64, tier_str, escalated_at_str],
+        )?;
+        Ok(())
+    }
+
+    /// Retrieve the escalation state for a vault.
+    pub fn get_escalation_state(
+        &self,
+        vault_id: u64,
+    ) -> Result<Option<crate::models::EscalationState>, rusqlite::Error> {
+        use crate::models::EscalationTier;
+        let binding = self.conn.lock().unwrap();
+        let mut stmt = binding.prepare(
+            "SELECT vault_id, last_escalation_tier, escalated_at FROM escalation_states WHERE vault_id = ?1",
+        )?;
+        let row = stmt.query_row(params![vault_id as i64], |r| {
+            let tier_str: Option<String> = r.get(1)?;
+            let tier = tier_str.as_deref().and_then(|s| match s {
+                "t1" => Some(EscalationTier::T1),
+                "t2" => Some(EscalationTier::T2),
+                "t3" => Some(EscalationTier::T3),
+                _ => None,
+            });
+            let escalated_at_str: Option<String> = r.get(2)?;
+            let escalated_at = escalated_at_str.and_then(|s| {
+                chrono::DateTime::parse_from_rfc3339(&s)
+                    .ok()
+                    .map(|dt| dt.with_timezone(&chrono::Utc))
+            });
+            Ok(crate::models::EscalationState {
+                vault_id: r.get::<_, i64>(0)? as u64,
+                last_escalation_tier: tier,
+                escalated_at,
+            })
+        });
+        match row {
+            Ok(s) => Ok(Some(s)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Append a new escalation audit event.
+    pub fn insert_escalation_event(
+        &self,
+        event: &crate::models::EscalationEvent,
+    ) -> Result<(), rusqlite::Error> {
+        use crate::models::EscalationTier;
+        let tier_str = match event.tier {
+            EscalationTier::T1 => "t1",
+            EscalationTier::T2 => "t2",
+            EscalationTier::T3 => "t3",
+        };
+        let channels_json = serde_json::to_string(&event.channels).unwrap_or_default();
+        self.conn.lock().unwrap().execute(
+            r#"
+            INSERT INTO escalation_events (id, vault_id, tier, dispatched_at, channels)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            "#,
+            params![
+                event.id,
+                event.vault_id as i64,
+                tier_str,
+                event.dispatched_at.to_rfc3339(),
+                channels_json,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// List all escalation events for a vault (newest first).
+    pub fn get_escalation_events(
+        &self,
+        vault_id: u64,
+    ) -> Result<Vec<crate::models::EscalationEvent>, rusqlite::Error> {
+        use crate::models::EscalationTier;
+        let binding = self.conn.lock().unwrap();
+        let mut stmt = binding.prepare(
+            "SELECT id, vault_id, tier, dispatched_at, channels FROM escalation_events WHERE vault_id = ?1 ORDER BY dispatched_at DESC",
+        )?;
+        let iter = stmt.query_map(params![vault_id as i64], |r| {
+            let tier_str: String = r.get(2)?;
+            let tier = match tier_str.as_str() {
+                "t1" => EscalationTier::T1,
+                "t2" => EscalationTier::T2,
+                _ => EscalationTier::T3,
+            };
+            let dispatched_at_str: String = r.get(3)?;
+            let dispatched_at = chrono::DateTime::parse_from_rfc3339(&dispatched_at_str)
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+                .map_err(|e| rusqlite::Error::FromSqlConversionFailure(3, rusqlite::types::Type::Text, Box::new(e)))?;
+            let channels_str: String = r.get(4)?;
+            let channels: Vec<String> = serde_json::from_str(&channels_str).unwrap_or_default();
+            Ok(crate::models::EscalationEvent {
+                id: r.get(0)?,
+                vault_id: r.get::<_, i64>(1)? as u64,
+                tier,
+                dispatched_at,
+                channels,
+            })
+        })?;
+        let mut out = Vec::new();
+        for item in iter { out.push(item?); }
+        Ok(out)
+    }
+
+    // ── #1102: Webhook Delivery Retry ────────────────────────────────────────
+
+    /// Insert a new webhook delivery job.
+    pub fn insert_webhook_delivery(
+        &self,
+        delivery: &crate::models::WebhookDelivery,
+    ) -> Result<(), rusqlite::Error> {
+        let status_str = self.webhook_status_str(&delivery.status);
+        let attempts_json = serde_json::to_string(&delivery.attempts).unwrap_or_default();
+        let payload_json = serde_json::to_string(&delivery.payload).unwrap_or_default();
+        self.conn.lock().unwrap().execute(
+            r#"
+            INSERT INTO webhook_deliveries (
+                id, vault_id, event_type, payload, endpoint_url, status,
+                attempt_count, next_retry_at, created_at, attempts
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            "#,
+            params![
+                delivery.id,
+                delivery.vault_id,
+                delivery.event_type,
+                payload_json,
+                delivery.endpoint_url,
+                status_str,
+                delivery.attempt_count as i64,
+                delivery.next_retry_at.map(|d| d.to_rfc3339()),
+                delivery.created_at.to_rfc3339(),
+                attempts_json,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Update a webhook delivery job (status, attempt_count, next_retry_at, attempts).
+    pub fn update_webhook_delivery(
+        &self,
+        delivery: &crate::models::WebhookDelivery,
+    ) -> Result<(), rusqlite::Error> {
+        let status_str = self.webhook_status_str(&delivery.status);
+        let attempts_json = serde_json::to_string(&delivery.attempts).unwrap_or_default();
+        self.conn.lock().unwrap().execute(
+            r#"
+            UPDATE webhook_deliveries
+            SET status = ?1, attempt_count = ?2, next_retry_at = ?3, attempts = ?4
+            WHERE id = ?5
+            "#,
+            params![
+                status_str,
+                delivery.attempt_count as i64,
+                delivery.next_retry_at.map(|d| d.to_rfc3339()),
+                attempts_json,
+                delivery.id,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Retrieve all webhook deliveries due for retry (status=retrying, next_retry_at <= now).
+    pub fn get_due_webhook_retries(
+        &self,
+    ) -> Result<Vec<crate::models::WebhookDelivery>, rusqlite::Error> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let binding = self.conn.lock().unwrap();
+        let mut stmt = binding.prepare(
+            "SELECT id, vault_id, event_type, payload, endpoint_url, status, attempt_count, next_retry_at, created_at, attempts \
+             FROM webhook_deliveries \
+             WHERE status = 'retrying' AND next_retry_at <= ?1",
+        )?;
+        self.map_webhook_rows(&mut stmt, params![now])
+    }
+
+    /// Retrieve all pending webhook deliveries (not yet attempted).
+    pub fn get_pending_webhook_deliveries(
+        &self,
+    ) -> Result<Vec<crate::models::WebhookDelivery>, rusqlite::Error> {
+        let binding = self.conn.lock().unwrap();
+        let mut stmt = binding.prepare(
+            "SELECT id, vault_id, event_type, payload, endpoint_url, status, attempt_count, next_retry_at, created_at, attempts \
+             FROM webhook_deliveries WHERE status = 'pending'",
+        )?;
+        self.map_webhook_rows(&mut stmt, params![])
+    }
+
+    /// Retrieve webhook delivery log for a vault.
+    pub fn get_webhook_deliveries_for_vault(
+        &self,
+        vault_id: &str,
+    ) -> Result<Vec<crate::models::WebhookDelivery>, rusqlite::Error> {
+        let binding = self.conn.lock().unwrap();
+        let mut stmt = binding.prepare(
+            "SELECT id, vault_id, event_type, payload, endpoint_url, status, attempt_count, next_retry_at, created_at, attempts \
+             FROM webhook_deliveries WHERE vault_id = ?1 ORDER BY created_at DESC",
+        )?;
+        self.map_webhook_rows(&mut stmt, params![vault_id])
+    }
+
+    fn webhook_status_str(&self, status: &crate::models::WebhookDeliveryStatus) -> &'static str {
+        match status {
+            crate::models::WebhookDeliveryStatus::Pending => "pending",
+            crate::models::WebhookDeliveryStatus::Delivered => "delivered",
+            crate::models::WebhookDeliveryStatus::Retrying => "retrying",
+            crate::models::WebhookDeliveryStatus::DeliveryFailed => "delivery_failed",
+        }
+    }
+
+    fn map_webhook_rows(
+        &self,
+        stmt: &mut rusqlite::Statement<'_>,
+        params: impl rusqlite::Params,
+    ) -> Result<Vec<crate::models::WebhookDelivery>, rusqlite::Error> {
+        let iter = stmt.query_map(params, |r| {
+            let status_str: String = r.get(5)?;
+            let status = match status_str.as_str() {
+                "delivered" => crate::models::WebhookDeliveryStatus::Delivered,
+                "retrying" => crate::models::WebhookDeliveryStatus::Retrying,
+                "delivery_failed" => crate::models::WebhookDeliveryStatus::DeliveryFailed,
+                _ => crate::models::WebhookDeliveryStatus::Pending,
+            };
+            let payload_str: String = r.get(3)?;
+            let payload: serde_json::Value = serde_json::from_str(&payload_str).unwrap_or(serde_json::Value::Null);
+            let attempts_str: String = r.get(9)?;
+            let attempts: Vec<crate::models::WebhookAttempt> = serde_json::from_str(&attempts_str).unwrap_or_default();
+            let created_at_str: String = r.get(8)?;
+            let created_at = chrono::DateTime::parse_from_rfc3339(&created_at_str)
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+                .map_err(|e| rusqlite::Error::FromSqlConversionFailure(8, rusqlite::types::Type::Text, Box::new(e)))?;
+            let next_retry_at_str: Option<String> = r.get(7)?;
+            let next_retry_at = next_retry_at_str.and_then(|s| {
+                chrono::DateTime::parse_from_rfc3339(&s).ok().map(|dt| dt.with_timezone(&chrono::Utc))
+            });
+            Ok(crate::models::WebhookDelivery {
+                id: r.get(0)?,
+                vault_id: r.get(1)?,
+                event_type: r.get(2)?,
+                payload,
+                endpoint_url: r.get(4)?,
+                status,
+                attempt_count: r.get::<_, i64>(6)? as u32,
+                next_retry_at,
+                created_at,
+                attempts,
+            })
+        })?;
+        let mut out = Vec::new();
+        for item in iter { out.push(item?); }
+        Ok(out)
+    }
+
+    // ── #1104: Vault Timeline Events ─────────────────────────────────────────
+
+    /// Insert a timeline event.
+    pub fn insert_timeline_event(
+        &self,
+        event: &crate::models::TimelineEvent,
+    ) -> Result<(), rusqlite::Error> {
+        let kind_str = format!("{:?}", event.kind).to_lowercase();
+        let metadata_json = serde_json::to_string(&event.metadata).unwrap_or_default();
+        self.conn.lock().unwrap().execute(
+            r#"
+            INSERT INTO vault_timeline_events (id, vault_id, kind, timestamp, description, amount, metadata)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            "#,
+            params![
+                event.id,
+                event.vault_id,
+                kind_str,
+                event.timestamp.to_rfc3339(),
+                event.description,
+                event.amount.map(|a| a as i64),
+                metadata_json,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Retrieve timeline events for a vault, with optional kind filter.
+    pub fn get_timeline_events(
+        &self,
+        vault_id: &str,
+        kind_filter: Option<&str>,
+    ) -> Result<Vec<crate::models::TimelineEvent>, rusqlite::Error> {
+        let binding = self.conn.lock().unwrap();
+        let (sql, use_filter) = if kind_filter.is_some() {
+            (
+                "SELECT id, vault_id, kind, timestamp, description, amount, metadata \
+                 FROM vault_timeline_events WHERE vault_id = ?1 AND kind = ?2 ORDER BY timestamp DESC",
+                true,
+            )
+        } else {
+            (
+                "SELECT id, vault_id, kind, timestamp, description, amount, metadata \
+                 FROM vault_timeline_events WHERE vault_id = ?1 ORDER BY timestamp DESC",
+                false,
+            )
+        };
+        let mut stmt = binding.prepare(sql)?;
+
+        let map_row = |r: &rusqlite::Row<'_>| {
+            use crate::models::TimelineEventKind;
+            let kind_str: String = r.get(2)?;
+            let kind = match kind_str.as_str() {
+                "created" => TimelineEventKind::Created,
+                "deposited" => TimelineEventKind::Deposited,
+                "checkedin" | "checked_in" => TimelineEventKind::CheckedIn,
+                "hibernated" => TimelineEventKind::Hibernated,
+                "released" => TimelineEventKind::Released,
+                "escalationsent" | "escalation_sent" => TimelineEventKind::EscalationSent,
+                "webhookdelivered" | "webhook_delivered" => TimelineEventKind::WebhookDelivered,
+                "webhookfailed" | "webhook_failed" => TimelineEventKind::WebhookFailed,
+                _ => TimelineEventKind::Created,
+            };
+            let timestamp_str: String = r.get(3)?;
+            let timestamp = chrono::DateTime::parse_from_rfc3339(&timestamp_str)
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+                .map_err(|e| rusqlite::Error::FromSqlConversionFailure(3, rusqlite::types::Type::Text, Box::new(e)))?;
+            let amount: Option<i64> = r.get(5)?;
+            let metadata_str: String = r.get(6)?;
+            let metadata: serde_json::Value = serde_json::from_str(&metadata_str).unwrap_or(serde_json::Value::Null);
+            Ok(crate::models::TimelineEvent {
+                id: r.get(0)?,
+                vault_id: r.get(1)?,
+                kind,
+                timestamp,
+                description: r.get(4)?,
+                amount: amount.map(|a| a as i128),
+                metadata,
+            })
+        };
+
+        let iter = if use_filter {
+            stmt.query_map(params![vault_id, kind_filter.unwrap()], map_row)?
+        } else {
+            stmt.query_map(params![vault_id], map_row)?
+        };
+
+        let mut out = Vec::new();
+        for item in iter { out.push(item?); }
+        Ok(out)
     }
 
 }

--- a/backend/src/escalation.rs
+++ b/backend/src/escalation.rs
@@ -1,0 +1,290 @@
+/// #1101: Reminder Escalation for Unresponsive Vault Owners
+///
+/// Escalation tiers:
+///   T1 — 7 days (168 h) before expiry: email
+///   T2 — 3 days  (72 h) before expiry: email + SMS
+///   T3 — 24 h            before expiry: all channels + emergency contact
+///
+/// Rules:
+///   - A tier is only dispatched once within a 24-hour window (deduplication).
+///   - The scheduler promotes to the next tier when TTL crosses the threshold.
+///   - Every dispatch is written to the escalation_events audit table.
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use uuid::Uuid;
+
+use crate::{
+    db::Db,
+    models::{EscalationEvent, EscalationState, EscalationTier, TimelineEvent, TimelineEventKind},
+};
+
+/// How long (seconds) to wait before re-dispatching the same tier.
+/// Prevents duplicate alerts within a 24-hour window.
+const TIER_DEDUP_WINDOW_SECS: i64 = 86_400; // 24 h
+
+/// Evaluate all vaults with reminder preferences and dispatch escalation
+/// notifications as necessary. Called from the scheduler loop.
+#[tracing::instrument(skip(db))]
+pub async fn run_escalation_check(db: &Arc<Db>) {
+    let prefs = match db.all() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(error = %e, "escalation: failed to fetch reminder preferences");
+            return;
+        }
+    };
+
+    for pref in prefs {
+        let ttl_hours = fetch_ttl_hours(pref.vault_id).await;
+        evaluate_vault(db, pref.vault_id, ttl_hours).await;
+    }
+}
+
+/// Determine whether a new escalation tier should be dispatched for a single
+/// vault, and if so, dispatch it.
+pub async fn evaluate_vault(db: &Arc<Db>, vault_id: u64, ttl_hours: u32) {
+    // Determine which tier the current TTL falls into.
+    let required_tier = tier_for_ttl(ttl_hours);
+    let Some(required_tier) = required_tier else {
+        // TTL is still far enough away — no escalation needed.
+        return;
+    };
+
+    // Load existing state.
+    let state = match db.get_escalation_state(vault_id) {
+        Ok(s) => s.unwrap_or(EscalationState {
+            vault_id,
+            last_escalation_tier: None,
+            escalated_at: None,
+        }),
+        Err(e) => {
+            tracing::error!(vault_id, error = %e, "escalation: failed to load state");
+            return;
+        }
+    };
+
+    // Check if this tier (or higher) was already dispatched.
+    if let Some(last_tier) = state.last_escalation_tier {
+        if last_tier >= required_tier {
+            // Check deduplication window — don't re-send within 24 h.
+            if let Some(escalated_at) = state.escalated_at {
+                let age = Utc::now().signed_duration_since(escalated_at).num_seconds();
+                if age < TIER_DEDUP_WINDOW_SECS {
+                    tracing::debug!(
+                        vault_id,
+                        ?last_tier,
+                        age_secs = age,
+                        "escalation: skipping, within dedup window"
+                    );
+                    return;
+                }
+            } else {
+                // Last tier was dispatched, no timestamp — skip to avoid double-send.
+                return;
+            }
+        }
+    }
+
+    // Dispatch the escalation.
+    dispatch_escalation(db, vault_id, required_tier).await;
+}
+
+/// Return the highest escalation tier triggered by the remaining TTL (hours).
+/// Returns None if no escalation is warranted yet.
+pub fn tier_for_ttl(ttl_hours: u32) -> Option<EscalationTier> {
+    if ttl_hours <= EscalationTier::T3.hours_before_expiry() {
+        Some(EscalationTier::T3)
+    } else if ttl_hours <= EscalationTier::T2.hours_before_expiry() {
+        Some(EscalationTier::T2)
+    } else if ttl_hours <= EscalationTier::T1.hours_before_expiry() {
+        Some(EscalationTier::T1)
+    } else {
+        None
+    }
+}
+
+/// Channels used per tier.
+fn channels_for_tier(tier: EscalationTier) -> Vec<&'static str> {
+    match tier {
+        EscalationTier::T1 => vec!["email"],
+        EscalationTier::T2 => vec!["email", "sms"],
+        EscalationTier::T3 => vec!["email", "sms", "emergency_contact"],
+    }
+}
+
+/// Actually dispatch the escalation: log the event, update state, and record
+/// a timeline entry.
+async fn dispatch_escalation(db: &Arc<Db>, vault_id: u64, tier: EscalationTier) {
+    let channels: Vec<String> = channels_for_tier(tier)
+        .into_iter()
+        .map(String::from)
+        .collect();
+    let now = Utc::now();
+    let event_id = Uuid::new_v4().to_string();
+
+    tracing::info!(
+        vault_id,
+        ?tier,
+        ?channels,
+        "escalation: dispatching tier"
+    );
+
+    // Stub: in production, call email/SMS/emergency-contact providers here.
+    send_escalation_notifications(vault_id, tier, &channels).await;
+
+    // Persist the escalation event for the audit trail.
+    let event = EscalationEvent {
+        id: event_id.clone(),
+        vault_id,
+        tier,
+        dispatched_at: now,
+        channels: channels.clone(),
+    };
+    if let Err(e) = db.insert_escalation_event(&event) {
+        tracing::error!(vault_id, error = %e, "escalation: failed to insert event");
+    }
+
+    // Update escalation state.
+    let new_state = EscalationState {
+        vault_id,
+        last_escalation_tier: Some(tier),
+        escalated_at: Some(now),
+    };
+    if let Err(e) = db.upsert_escalation_state(&new_state) {
+        tracing::error!(vault_id, error = %e, "escalation: failed to upsert state");
+    }
+
+    // Record in vault timeline.
+    let timeline_event = TimelineEvent {
+        id: Uuid::new_v4().to_string(),
+        vault_id: vault_id.to_string(),
+        kind: TimelineEventKind::EscalationSent,
+        timestamp: now,
+        description: format!("Escalation {:?} sent via: {}", tier, channels.join(", ")),
+        amount: None,
+        metadata: serde_json::json!({
+            "tier": format!("{:?}", tier).to_lowercase(),
+            "channels": channels,
+        }),
+    };
+    if let Err(e) = db.insert_timeline_event(&timeline_event) {
+        tracing::error!(vault_id, error = %e, "escalation: failed to insert timeline event");
+    }
+}
+
+/// Stub: dispatches notifications via the configured channels.
+/// Replace with real email/SMS/emergency-contact integrations in production.
+async fn send_escalation_notifications(vault_id: u64, tier: EscalationTier, channels: &[String]) {
+    for channel in channels {
+        tracing::info!(
+            vault_id,
+            ?tier,
+            channel,
+            "escalation: sending notification"
+        );
+    }
+}
+
+/// Stub: returns hours remaining until TTL expiry for a vault.
+/// Replace with a real Stellar RPC call in production.
+async fn fetch_ttl_hours(_vault_id: u64) -> u32 {
+    u32::MAX
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tier_for_ttl_no_escalation() {
+        // 200 h remaining — beyond T1 threshold (168 h)
+        assert_eq!(tier_for_ttl(200), None);
+    }
+
+    #[test]
+    fn test_tier_for_ttl_t1() {
+        // Between T1 (168 h) and T2 (72 h) thresholds
+        assert_eq!(tier_for_ttl(168), Some(EscalationTier::T1));
+        assert_eq!(tier_for_ttl(100), Some(EscalationTier::T1));
+        assert_eq!(tier_for_ttl(73), Some(EscalationTier::T1));
+    }
+
+    #[test]
+    fn test_tier_for_ttl_t2() {
+        // Between T2 (72 h) and T3 (24 h) thresholds
+        assert_eq!(tier_for_ttl(72), Some(EscalationTier::T2));
+        assert_eq!(tier_for_ttl(48), Some(EscalationTier::T2));
+        assert_eq!(tier_for_ttl(25), Some(EscalationTier::T2));
+    }
+
+    #[test]
+    fn test_tier_for_ttl_t3() {
+        // Within T3 threshold (24 h)
+        assert_eq!(tier_for_ttl(24), Some(EscalationTier::T3));
+        assert_eq!(tier_for_ttl(1), Some(EscalationTier::T3));
+        assert_eq!(tier_for_ttl(0), Some(EscalationTier::T3));
+    }
+
+    #[test]
+    fn test_channels_for_tier() {
+        assert_eq!(channels_for_tier(EscalationTier::T1), vec!["email"]);
+        assert_eq!(channels_for_tier(EscalationTier::T2), vec!["email", "sms"]);
+        assert_eq!(
+            channels_for_tier(EscalationTier::T3),
+            vec!["email", "sms", "emergency_contact"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_vault_no_escalation_needed() {
+        let db = Arc::new(Db::open(":memory:").unwrap());
+        db.migrate().unwrap();
+        // TTL far from expiry — no escalation should be written.
+        evaluate_vault(&db, 1, 300).await;
+        let events = db.get_escalation_events(1).unwrap();
+        assert!(events.is_empty(), "no escalation expected for TTL=300h");
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_vault_dispatches_t1() {
+        let db = Arc::new(Db::open(":memory:").unwrap());
+        db.migrate().unwrap();
+        // TTL at T1 threshold.
+        evaluate_vault(&db, 42, 100).await;
+        let events = db.get_escalation_events(42).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].tier, EscalationTier::T1);
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_vault_deduplication() {
+        let db = Arc::new(Db::open(":memory:").unwrap());
+        db.migrate().unwrap();
+        // First evaluation dispatches T1.
+        evaluate_vault(&db, 99, 100).await;
+        // Second evaluation within the dedup window should NOT dispatch again.
+        evaluate_vault(&db, 99, 100).await;
+        let events = db.get_escalation_events(99).unwrap();
+        assert_eq!(events.len(), 1, "deduplication: only one event expected");
+    }
+
+    #[tokio::test]
+    async fn test_evaluate_vault_promotes_to_higher_tier() {
+        let db = Arc::new(Db::open(":memory:").unwrap());
+        db.migrate().unwrap();
+        // T1 is dispatched first.
+        evaluate_vault(&db, 7, 100).await;
+        // Force-expire the dedup window by manipulating the state timestamp.
+        let mut state = db.get_escalation_state(7).unwrap().unwrap();
+        state.escalated_at = Some(Utc::now() - chrono::Duration::hours(25));
+        db.upsert_escalation_state(&state).unwrap();
+        // Now TTL drops to T2 threshold — should promote.
+        evaluate_vault(&db, 7, 48).await;
+        let events = db.get_escalation_events(7).unwrap();
+        assert_eq!(events.len(), 2, "two escalation events expected (T1 then T2)");
+        // The most recent event should be T2.
+        assert_eq!(events[0].tier, EscalationTier::T2);
+    }
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -9,6 +9,13 @@ pub mod error;
 pub mod routes;
 pub mod otel;
 pub mod fee_sponsorship;
+pub mod escalation;
+pub mod webhook_retry;
+pub mod cache;
+pub mod consensus;
+pub mod contract_version_check;
+pub mod metrics;
+pub mod two_factor;
 
 pub use models::*;
 pub use handlers::*;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -19,6 +19,8 @@ mod otel;
 mod routes;
 mod scheduler;
 mod two_factor;
+mod escalation;
+mod webhook_retry;
 
 #[cfg(test)]
 mod tests;
@@ -190,6 +192,26 @@ async fn main() {
             "/api/vaults/:vault_id/sponsored-release",
             post(routes::create_sponsored_release)
                 .get(routes::get_sponsored_releases),
+        )
+        // #1101: Escalation
+        .route(
+            "/api/vaults/:vault_id/escalation-state",
+            get(routes::get_escalation_state),
+        )
+        .route(
+            "/api/vaults/:vault_id/escalation-events",
+            get(routes::list_escalation_events),
+        )
+        // #1102: Webhook delivery
+        .route(
+            "/api/vaults/:vault_id/webhooks",
+            post(routes::register_webhook)
+                .get(routes::list_webhook_deliveries),
+        )
+        // #1104: Vault timeline
+        .route(
+            "/api/vaults/:vault_id/events",
+            get(routes::list_vault_timeline),
         )
         .layer(build_cors_layer())
         .with_state(state);

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -680,3 +680,135 @@ pub struct SimulateReleaseResponse {
     pub simulated_at: DateTime<Utc>,
 }
 
+
+// ── #1101: Reminder Escalation ───────────────────────────────────────────────
+
+/// Escalation tier for unresponsive vault owners.
+/// T1: 7 days before expiry  → email
+/// T2: 3 days before expiry  → email + SMS
+/// T3: 24 h  before expiry   → all channels + emergency contact
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum EscalationTier {
+    T1,
+    T2,
+    T3,
+}
+
+impl EscalationTier {
+    /// Hours before TTL expiry at which this tier fires.
+    pub fn hours_before_expiry(self) -> u32 {
+        match self {
+            EscalationTier::T1 => 168, // 7 days
+            EscalationTier::T2 => 72,  // 3 days
+            EscalationTier::T3 => 24,  // 24 hours
+        }
+    }
+}
+
+/// Persisted escalation state for a single vault.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EscalationState {
+    pub vault_id: u64,
+    /// Highest tier already dispatched (None = no escalation yet).
+    pub last_escalation_tier: Option<EscalationTier>,
+    /// When the last escalation was dispatched.
+    pub escalated_at: Option<DateTime<Utc>>,
+}
+
+/// A single escalation audit event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EscalationEvent {
+    pub id: String,
+    pub vault_id: u64,
+    pub tier: EscalationTier,
+    pub dispatched_at: DateTime<Utc>,
+    /// Channels actually used for this escalation.
+    pub channels: Vec<String>,
+}
+
+// ── #1102: Webhook Delivery Retry ────────────────────────────────────────────
+
+/// Delivery status of a single webhook event.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WebhookDeliveryStatus {
+    Pending,
+    Delivered,
+    Retrying,
+    DeliveryFailed,
+}
+
+/// A single webhook delivery attempt log entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookAttempt {
+    pub attempted_at: DateTime<Utc>,
+    pub http_status: Option<u16>,
+    pub response_body: String,
+    pub error: Option<String>,
+}
+
+/// Persisted webhook delivery job.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookDelivery {
+    pub id: String,
+    pub vault_id: String,
+    pub event_type: String,
+    pub payload: serde_json::Value,
+    pub endpoint_url: String,
+    pub status: WebhookDeliveryStatus,
+    pub attempt_count: u32,
+    /// When the next retry should fire.
+    pub next_retry_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub attempts: Vec<WebhookAttempt>,
+}
+
+/// Request to register a webhook endpoint for a vault.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisterWebhookRequest {
+    pub vault_id: String,
+    pub endpoint_url: String,
+    pub event_types: Vec<String>,
+}
+
+/// Registered webhook subscription.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookSubscription {
+    pub id: String,
+    pub vault_id: String,
+    pub endpoint_url: String,
+    pub event_types: Vec<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+// ── #1104: Vault Timeline event types ────────────────────────────────────────
+
+/// Timeline event displayed in the vault status history.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TimelineEventKind {
+    Created,
+    Deposited,
+    CheckedIn,
+    Hibernated,
+    Released,
+    EscalationSent,
+    WebhookDelivered,
+    WebhookFailed,
+}
+
+/// A single vault timeline entry returned by GET /api/vaults/{id}/events.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimelineEvent {
+    pub id: String,
+    pub vault_id: String,
+    pub kind: TimelineEventKind,
+    pub timestamp: DateTime<Utc>,
+    /// Human-readable description.
+    pub description: String,
+    /// Optional amount (deposits, withdrawals).
+    pub amount: Option<i128>,
+    /// Any extra metadata.
+    pub metadata: serde_json::Value,
+}

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -14,6 +14,7 @@ use crate::{
     error::AppError,
     handlers::{parse_scenario_types, simulate_release_handler},
     models::{ReminderPreferences, SetPreferencesRequest, SimulateReleaseQuery, SimulateReleaseResponse},
+    AppState,
 };
 
 #[derive(Deserialize)]
@@ -192,4 +193,88 @@ pub async fn get_sponsored_releases(
         .map_err(|e| AppError::InvalidInput(e))?;
 
     Ok(Json(result))
+}
+
+// ── #1101: Escalation endpoints ──────────────────────────────────────────────
+
+/// GET /api/vaults/:vault_id/escalation-state
+/// Retrieve the current escalation state for a vault.
+pub async fn get_escalation_state(
+    State(state): State<Arc<AppState>>,
+    Path(vault_id): Path<u64>,
+) -> Result<Json<crate::models::EscalationState>, AppError> {
+    match state.db.get_escalation_state(vault_id)? {
+        Some(s) => Ok(Json(s)),
+        None => Ok(Json(crate::models::EscalationState {
+            vault_id,
+            last_escalation_tier: None,
+            escalated_at: None,
+        })),
+    }
+}
+
+/// GET /api/vaults/:vault_id/escalation-events
+/// List escalation audit events for a vault.
+pub async fn list_escalation_events(
+    State(state): State<Arc<AppState>>,
+    Path(vault_id): Path<u64>,
+) -> Result<Json<Vec<crate::models::EscalationEvent>>, AppError> {
+    let events = state.db.get_escalation_events(vault_id)?;
+    Ok(Json(events))
+}
+
+// ── #1102: Webhook delivery endpoints ────────────────────────────────────────
+
+/// POST /api/vaults/:vault_id/webhooks
+/// Register a webhook endpoint and enqueue an initial test delivery.
+pub async fn register_webhook(
+    State(state): State<Arc<AppState>>,
+    Path(vault_id): Path<String>,
+    Json(req): Json<crate::models::RegisterWebhookRequest>,
+) -> Result<(StatusCode, Json<crate::models::WebhookDelivery>), AppError> {
+    let payload = serde_json::json!({
+        "event": "webhook_registered",
+        "vault_id": vault_id,
+        "endpoint_url": req.endpoint_url,
+    });
+    let delivery = crate::webhook_retry::enqueue(
+        &state.db,
+        &vault_id,
+        "webhook_registered",
+        payload,
+        &req.endpoint_url,
+    )
+    .map_err(AppError::InvalidInput)?;
+    Ok((StatusCode::CREATED, Json(delivery)))
+}
+
+/// GET /api/vaults/:vault_id/webhooks
+/// Retrieve the webhook delivery log for a vault.
+pub async fn list_webhook_deliveries(
+    State(state): State<Arc<AppState>>,
+    Path(vault_id): Path<String>,
+) -> Result<Json<Vec<crate::models::WebhookDelivery>>, AppError> {
+    let log = crate::webhook_retry::get_delivery_log(&state.db, &vault_id)
+        .map_err(AppError::InvalidInput)?;
+    Ok(Json(log))
+}
+
+// ── #1104: Vault Timeline endpoints ──────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct TimelineQuery {
+    pub kind: Option<String>,
+}
+
+/// GET /api/vaults/:vault_id/events
+/// Returns the vault status timeline, optionally filtered by event kind.
+pub async fn list_vault_timeline(
+    State(state): State<Arc<AppState>>,
+    Path(vault_id): Path<String>,
+    Query(query): Query<TimelineQuery>,
+) -> Result<Json<Vec<crate::models::TimelineEvent>>, AppError> {
+    let events = state
+        .db
+        .get_timeline_events(&vault_id, query.kind.as_deref())?;
+    Ok(Json(events))
 }

--- a/backend/src/scheduler.rs
+++ b/backend/src/scheduler.rs
@@ -72,6 +72,12 @@ pub async fn run(db: Arc<Db>) {
 
         // 2) TTL insurance scheduler.
         extend_ttl_for_inactive_owners(&db).await;
+
+        // 3) #1101: Reminder escalation for unresponsive vault owners.
+        crate::escalation::run_escalation_check(&db).await;
+
+        // 4) #1102: Webhook delivery retry with exponential backoff.
+        crate::webhook_retry::flush(&db).await;
     }
 }
 

--- a/backend/src/webhook_retry.rs
+++ b/backend/src/webhook_retry.rs
@@ -1,0 +1,377 @@
+/// #1102: Webhook Delivery Retry with Exponential Backoff
+///
+/// Retry schedule (max 5 attempts after the first):
+///   Attempt 1: immediate
+///   Retry  1: +1  min
+///   Retry  2: +5  min
+///   Retry  3: +15 min
+///   Retry  4: +1  h
+///   Retry  5: +4  h
+///
+/// After all retries are exhausted, status → DeliveryFailed and the vault
+/// owner is notified via email (stub; replace with real email integration).
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use uuid::Uuid;
+
+use crate::{
+    db::Db,
+    models::{
+        TimelineEvent, TimelineEventKind, WebhookAttempt, WebhookDelivery,
+        WebhookDeliveryStatus,
+    },
+};
+
+/// Exponential backoff delays in seconds: 1 min, 5 min, 15 min, 1 h, 4 h.
+pub const RETRY_DELAYS_SECS: [u64; 5] = [60, 300, 900, 3_600, 14_400];
+
+/// Maximum number of attempts (including the first delivery attempt).
+pub const MAX_ATTEMPTS: u32 = 6; // 1 initial + 5 retries
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Queue a new webhook delivery job for a vault event. This should be called
+/// whenever a significant vault event occurs (release, low TTL, etc.).
+pub fn enqueue(
+    db: &Arc<Db>,
+    vault_id: &str,
+    event_type: &str,
+    payload: serde_json::Value,
+    endpoint_url: &str,
+) -> Result<WebhookDelivery, String> {
+    let delivery = WebhookDelivery {
+        id: Uuid::new_v4().to_string(),
+        vault_id: vault_id.to_string(),
+        event_type: event_type.to_string(),
+        payload,
+        endpoint_url: endpoint_url.to_string(),
+        status: WebhookDeliveryStatus::Pending,
+        attempt_count: 0,
+        next_retry_at: None,
+        created_at: Utc::now(),
+        attempts: Vec::new(),
+    };
+    db.insert_webhook_delivery(&delivery)
+        .map_err(|e| e.to_string())?;
+    Ok(delivery)
+}
+
+/// Process all pending and due-retry webhook deliveries. Called from the
+/// scheduler loop.
+#[tracing::instrument(skip(db))]
+pub async fn flush(db: &Arc<Db>) {
+    // First, attempt pending deliveries.
+    match db.get_pending_webhook_deliveries() {
+        Ok(pending) => {
+            for delivery in pending {
+                attempt_delivery(db, delivery).await;
+            }
+        }
+        Err(e) => tracing::error!(error = %e, "webhook_retry: failed to fetch pending deliveries"),
+    }
+
+    // Then, retry any Retrying deliveries that are due.
+    match db.get_due_webhook_retries() {
+        Ok(due) => {
+            for delivery in due {
+                attempt_delivery(db, delivery).await;
+            }
+        }
+        Err(e) => tracing::error!(error = %e, "webhook_retry: failed to fetch due retries"),
+    }
+}
+
+/// Get webhook delivery log for a vault.
+pub fn get_delivery_log(
+    db: &Arc<Db>,
+    vault_id: &str,
+) -> Result<Vec<WebhookDelivery>, String> {
+    db.get_webhook_deliveries_for_vault(vault_id)
+        .map_err(|e| e.to_string())
+}
+
+// ── Internal delivery logic ──────────────────────────────────────────────────
+
+async fn attempt_delivery(db: &Arc<Db>, mut delivery: WebhookDelivery) {
+    let attempt_number = delivery.attempt_count + 1;
+
+    tracing::info!(
+        delivery_id = %delivery.id,
+        vault_id = %delivery.vault_id,
+        endpoint = %delivery.endpoint_url,
+        attempt = attempt_number,
+        "webhook_retry: attempting delivery"
+    );
+
+    let (http_status, response_body, error) =
+        send_webhook(&delivery.endpoint_url, &delivery.payload).await;
+
+    let now = Utc::now();
+    let attempt_log = WebhookAttempt {
+        attempted_at: now,
+        http_status,
+        response_body: response_body.clone(),
+        error: error.clone(),
+    };
+    delivery.attempts.push(attempt_log);
+    delivery.attempt_count = attempt_number;
+
+    let success = http_status.map_or(false, |s| (200..300).contains(&s));
+
+    if success {
+        delivery.status = WebhookDeliveryStatus::Delivered;
+        delivery.next_retry_at = None;
+        tracing::info!(
+            delivery_id = %delivery.id,
+            vault_id = %delivery.vault_id,
+            attempt = attempt_number,
+            "webhook_retry: delivered successfully"
+        );
+
+        record_timeline_event(db, &delivery, true).await;
+    } else {
+        let retry_index = (attempt_number - 1) as usize; // 0-based index into RETRY_DELAYS_SECS
+        if retry_index < RETRY_DELAYS_SECS.len() {
+            // Schedule a retry.
+            let delay = RETRY_DELAYS_SECS[retry_index];
+            delivery.status = WebhookDeliveryStatus::Retrying;
+            delivery.next_retry_at =
+                Some(now + chrono::Duration::seconds(delay as i64));
+            tracing::warn!(
+                delivery_id = %delivery.id,
+                vault_id = %delivery.vault_id,
+                attempt = attempt_number,
+                retry_in_secs = delay,
+                error = ?error,
+                "webhook_retry: delivery failed, scheduling retry"
+            );
+        } else {
+            // All retries exhausted.
+            delivery.status = WebhookDeliveryStatus::DeliveryFailed;
+            delivery.next_retry_at = None;
+            tracing::error!(
+                delivery_id = %delivery.id,
+                vault_id = %delivery.vault_id,
+                total_attempts = attempt_number,
+                "webhook_retry: all retries exhausted — delivery permanently failed"
+            );
+
+            // Notify vault owner via email (stub).
+            notify_owner_delivery_failed(&delivery).await;
+            record_timeline_event(db, &delivery, false).await;
+        }
+    }
+
+    if let Err(e) = db.update_webhook_delivery(&delivery) {
+        tracing::error!(
+            delivery_id = %delivery.id,
+            error = %e,
+            "webhook_retry: failed to persist delivery update"
+        );
+    }
+}
+
+/// HTTP POST to the endpoint. Returns (http_status, response_body, error).
+async fn send_webhook(
+    url: &str,
+    payload: &serde_json::Value,
+) -> (Option<u16>, String, Option<String>) {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .unwrap_or_default();
+
+    match client.post(url).json(payload).send().await {
+        Ok(resp) => {
+            let status = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            if (200..300).contains(&status) {
+                (Some(status), body, None)
+            } else {
+                (
+                    Some(status),
+                    body.clone(),
+                    Some(format!("HTTP {status}: {body}")),
+                )
+            }
+        }
+        Err(e) => (None, String::new(), Some(e.to_string())),
+    }
+}
+
+/// Record the delivery outcome as a vault timeline event.
+async fn record_timeline_event(db: &Arc<Db>, delivery: &WebhookDelivery, success: bool) {
+    let kind = if success {
+        TimelineEventKind::WebhookDelivered
+    } else {
+        TimelineEventKind::WebhookFailed
+    };
+    let description = if success {
+        format!(
+            "Webhook '{}' delivered to {}",
+            delivery.event_type, delivery.endpoint_url
+        )
+    } else {
+        format!(
+            "Webhook '{}' permanently failed after {} attempts",
+            delivery.event_type, delivery.attempt_count
+        )
+    };
+    let event = TimelineEvent {
+        id: Uuid::new_v4().to_string(),
+        vault_id: delivery.vault_id.clone(),
+        kind,
+        timestamp: Utc::now(),
+        description,
+        amount: None,
+        metadata: serde_json::json!({
+            "delivery_id": delivery.id,
+            "event_type": delivery.event_type,
+            "endpoint_url": delivery.endpoint_url,
+            "attempt_count": delivery.attempt_count,
+        }),
+    };
+    if let Err(e) = db.insert_timeline_event(&event) {
+        tracing::error!(error = %e, "webhook_retry: failed to insert timeline event");
+    }
+}
+
+/// Stub: sends a failure notification email to the vault owner.
+async fn notify_owner_delivery_failed(delivery: &WebhookDelivery) {
+    tracing::warn!(
+        vault_id = %delivery.vault_id,
+        event_type = %delivery.event_type,
+        endpoint = %delivery.endpoint_url,
+        "webhook_retry: notifying owner of permanent delivery failure (stub)"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Db;
+    use std::sync::Arc;
+
+    fn test_db() -> Arc<Db> {
+        let db = Arc::new(Db::open(":memory:").unwrap());
+        db.migrate().unwrap();
+        db
+    }
+
+    #[test]
+    fn test_enqueue_creates_pending_delivery() {
+        let db = test_db();
+        let payload = serde_json::json!({"event": "vault_released", "vault_id": "v1"});
+        let delivery = enqueue(&db, "v1", "vault_released", payload, "https://example.com/hook")
+            .expect("enqueue should succeed");
+
+        assert_eq!(delivery.vault_id, "v1");
+        assert_eq!(delivery.event_type, "vault_released");
+        assert_eq!(delivery.status, WebhookDeliveryStatus::Pending);
+        assert_eq!(delivery.attempt_count, 0);
+        assert!(delivery.attempts.is_empty());
+    }
+
+    #[test]
+    fn test_retry_delays_sequence() {
+        // Verify the backoff schedule matches the spec: 1m, 5m, 15m, 1h, 4h.
+        assert_eq!(RETRY_DELAYS_SECS[0], 60);
+        assert_eq!(RETRY_DELAYS_SECS[1], 300);
+        assert_eq!(RETRY_DELAYS_SECS[2], 900);
+        assert_eq!(RETRY_DELAYS_SECS[3], 3_600);
+        assert_eq!(RETRY_DELAYS_SECS[4], 14_400);
+        assert_eq!(RETRY_DELAYS_SECS.len(), 5, "exactly 5 retry intervals");
+    }
+
+    #[test]
+    fn test_max_attempts_is_six() {
+        assert_eq!(MAX_ATTEMPTS, 6, "1 initial + 5 retries = 6 total");
+    }
+
+    #[tokio::test]
+    async fn test_exhaustion_marks_delivery_failed() {
+        let db = test_db();
+        // Insert a delivery already at MAX_ATTEMPTS - 1 retries, with a bad URL.
+        let delivery = WebhookDelivery {
+            id: "d-exhaust".to_string(),
+            vault_id: "v99".to_string(),
+            event_type: "test".to_string(),
+            payload: serde_json::json!({}),
+            endpoint_url: "http://127.0.0.1:0/nonexistent".to_string(),
+            status: WebhookDeliveryStatus::Retrying,
+            // Set attempt_count to 5 (last retry slot) so next attempt exhausts.
+            attempt_count: 5,
+            next_retry_at: Some(Utc::now() - chrono::Duration::seconds(1)),
+            created_at: Utc::now(),
+            attempts: Vec::new(),
+        };
+        db.insert_webhook_delivery(&delivery).unwrap();
+
+        // Flush retries — the single delivery should be marked DeliveryFailed.
+        flush(&db).await;
+
+        let log = db.get_webhook_deliveries_for_vault("v99").unwrap();
+        assert_eq!(log.len(), 1);
+        assert_eq!(
+            log[0].status,
+            WebhookDeliveryStatus::DeliveryFailed,
+            "status should be DeliveryFailed after exhaustion"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_successful_delivery_clears_retries() {
+        // We can't easily mock HTTP in unit tests, so we verify the enqueue +
+        // state-machine logic directly without a live HTTP call.
+        let db = test_db();
+
+        // Simulate a delivery that "succeeded" by manually updating it.
+        let payload = serde_json::json!({"ok": true});
+        let mut delivery = enqueue(&db, "v2", "check_in", payload, "https://example.com/ok")
+            .expect("enqueue");
+
+        // Manually drive it to Delivered state (as the send_webhook mock would).
+        delivery.status = WebhookDeliveryStatus::Delivered;
+        delivery.attempt_count = 1;
+        delivery.next_retry_at = None;
+        db.update_webhook_delivery(&delivery).unwrap();
+
+        let log = db.get_webhook_deliveries_for_vault("v2").unwrap();
+        assert_eq!(log[0].status, WebhookDeliveryStatus::Delivered);
+        assert!(log[0].next_retry_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_retry_scheduling_after_failure() {
+        let db = test_db();
+        // Insert a pending delivery pointing to an unreachable endpoint.
+        let delivery = WebhookDelivery {
+            id: "d-retry-test".to_string(),
+            vault_id: "v10".to_string(),
+            event_type: "vault_released".to_string(),
+            payload: serde_json::json!({}),
+            endpoint_url: "http://127.0.0.1:0/bad".to_string(),
+            status: WebhookDeliveryStatus::Pending,
+            attempt_count: 0,
+            next_retry_at: None,
+            created_at: Utc::now(),
+            attempts: Vec::new(),
+        };
+        db.insert_webhook_delivery(&delivery).unwrap();
+
+        // Flush pending — should fail and move to Retrying with a next_retry_at.
+        flush(&db).await;
+
+        let log = db.get_webhook_deliveries_for_vault("v10").unwrap();
+        assert_eq!(log.len(), 1);
+        // After first failure, status must be Retrying (not DeliveryFailed).
+        assert_eq!(log[0].status, WebhookDeliveryStatus::Retrying);
+        assert!(
+            log[0].next_retry_at.is_some(),
+            "next_retry_at must be set after first failure"
+        );
+        assert_eq!(log[0].attempt_count, 1);
+    }
+}


### PR DESCRIPTION
## Summary

Implements four enhancements in a single PR.

---

### #1101 — Reminder Escalation for Unresponsive Vault Owners

**New file:** `backend/src/escalation.rs`

Multi-tier escalation triggered by remaining TTL:

| Tier | Threshold | Channels |
|------|-----------|----------|
| T1   | 7 days    | Email |
| T2   | 3 days    | Email + SMS |
| T3   | 24 hours  | Email + SMS + Emergency contact |

- `EscalationTier`, `EscalationState`, `EscalationEvent` models added to `models.rs`
- `tier_for_ttl()` maps remaining hours → required tier
- `evaluate_vault()` applies a 24-hour deduplication window; promotes tier when TTL drops further
- Every dispatch is persisted to `escalation_events` for audit trail
- Scheduler loop calls `run_escalation_check()` every minute
- New API endpoints: `GET /api/vaults/:id/escalation-state` and `GET /api/vaults/:id/escalation-events`
- Tests: no-escalation path, T1 dispatch, deduplication guard, tier promotion

---

### #1102 — Webhook Delivery Retry with Exponential Backoff

**New file:** `backend/src/webhook_retry.rs`

Retry schedule (max 5 retries after first attempt):

```
Attempt 1: immediate
Retry  1: +1  min
Retry  2: +5  min
Retry  3: +15 min
Retry  4: +1  h
Retry  5: +4  h
```

- `WebhookDelivery`, `WebhookAttempt`, `WebhookDeliveryStatus`, `RegisterWebhookRequest` models
- Per-attempt log stores timestamp, HTTP status, response body, error
- Status → `DeliveryFailed` after all retries exhausted; owner notified via stub email call
- Scheduler calls `flush()` every minute for pending and due-retry deliveries
- New API endpoints: `POST /api/vaults/:id/webhooks` (register + enqueue test ping), `GET /api/vaults/:id/webhooks` (delivery log)
- Tests: enqueue, backoff sequence, exhaustion → DeliveryFailed, success clears retries, retry scheduling

---

### #1103 — Dark Mode Theme Support

**Modified:** `backend/simulator.html`

- CSS custom properties for all colour tokens (`--bg`, `--surface`, `--border`, `--text`, `--muted`, `--accent`, `--danger`, `--warn`, `--success`)
- Dark theme is the default; light theme via `:root[data-theme="light"]`
- System preference auto-detected via `prefers-color-scheme: dark` media query (no override needed)
- Manual toggle button in the nav bar labelled ☀️ Light / 🌙 Dark
- Preference persisted in `localStorage` under key `ttl-theme`
- OS theme change events update the button label in real time

---

### #1104 — Vault Status Timeline Visualization

**Modified:** `backend/simulator.html`, `backend/src/db.rs`, `backend/src/models.rs`, `backend/src/routes.rs`

- `TimelineEvent` + `TimelineEventKind` models (Created, Deposited, CheckedIn, Hibernated, Released, EscalationSent, WebhookDelivered, WebhookFailed)
- `GET /api/vaults/:id/events?kind=<filter>` endpoint — returns timeline newest-first
- Frontend vertical timeline with per-kind icons, timestamps, optional amounts
- Filter dropdown (all events or by type); Refresh button
- Loading skeletons (4 rows) shown while fetching; empty state with friendly copy for new vaults
- Timeline auto-loads after every simulation run

---

### Migration 5 (new tables)

`escalation_states`, `escalation_events`, `webhook_deliveries`, `webhook_subscriptions`, `vault_timeline_events`, `vault_subscriptions` (was previously referenced but never created)

---

### Housekeeping

- Added `AppState` import to `routes.rs` (fixed pre-existing 'not in scope' errors)
- Added missing modules to `lib.rs`: `cache`, `consensus`, `contract_version_check`, `metrics`, `two_factor`
- Soroban contract (`contracts/`) is untouched; CI test target unaffected

Closes #1101
Closes #1102
Closes #1103
Closes #1104