### PR TITLE
feat(vault): add set_release_memo for on-chain inheritance notes

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -36,7 +36,8 @@ use types::{
     DISPUTE_RESOLVED_TOPIC, DUPLICATE_VAULT_TOPIC, EXPIRY_WARNING_THRESHOLD,
     HIBERNATION_ENTERED_TOPIC, HIBERNATION_EXITED_TOPIC, INACTIVITY_PENALTY_TOPIC,
     INHERITANCE_TOPIC, INTEGRITY_TOPIC, MAX_CUSTOM_METADATA_LEN, MAX_DESCRIPTION_LEN,
-    MAX_METADATA_LEN, MAX_NAME_LEN, MAX_NOTES_LEN, META_REVERT_TOPIC, META_VERSION_TOPIC,
+    MAX_METADATA_LEN, MAX_NAME_LEN, MAX_NOTES_LEN, MAX_RELEASE_MEMO_LEN, META_REVERT_TOPIC,
+    META_VERSION_TOPIC,
     MIN_THRESHOLD_REDISTRIBUTE_TOPIC, MIN_THRESHOLD_SET_TOPIC, MIN_THRESHOLD_SKIP_TOPIC,
     MULTISIG_APPROVED_TOPIC, MULTISIG_CONFIG_TOPIC, MULTISIG_EXECUTED_TOPIC,
     MULTISIG_PROPOSAL_EXPIRY, MULTISIG_PROPOSED_TOPIC, MULTISIG_REJECTED_TOPIC,
@@ -85,6 +86,8 @@ mod bps_invariant_tests;
 mod lifecycle_tests;
 #[cfg(test)]
 mod regression_tests;
+#[cfg(test)]
+mod release_memo_tests;
 #[cfg(test)]
 mod beneficiary_waitlist_tests;
 #[cfg(test)]
@@ -2699,6 +2702,13 @@ impl TtlVaultContract {
         );
     }
 
+    fn load_release_memo(env: &Env, vault_id: u64) -> Bytes {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ReleaseMemo(vault_id))
+            .unwrap_or_else(|| Bytes::new(env))
+    }
+
     fn trigger_release_internal(env: Env, vault_id: u64, mode: ReleaseTrigger) {
         Self::assert_not_paused(&env);
         // Attempt to restore archived vault state before proceeding - Issue #443
@@ -2945,6 +2955,7 @@ impl TtlVaultContract {
         }
 
         Self::mark_release_attempted(&env, vault_id);
+        let release_memo = Self::load_release_memo(&env, vault_id);
 
         if has_vesting || has_milestone_vesting {
             // Vesting schedule exists: mark as Released but keep balance intact
@@ -2966,6 +2977,7 @@ impl TtlVaultContract {
                     vault_id,
                     beneficiary: vault.beneficiary.clone(),
                     amount: 0,
+                    memo: release_memo.clone(),
                 },
             );
         } else {
@@ -2997,6 +3009,7 @@ impl TtlVaultContract {
                         vault_id,
                         beneficiary: vault.beneficiary.clone(),
                         amount: release_amount,
+                        memo: release_memo.clone(),
                     },
                 );
             } else {
@@ -7259,6 +7272,44 @@ impl TtlVaultContract {
         env.events()
             .publish((SET_METADATA_TOPIC, vault_id), metadata);
         Ok(())
+    }
+
+    /// Sets (or updates) the owner-supplied release memo for a vault.
+    /// The memo is included in the `RELEASE_TOPIC` event emitted when the
+    /// vault's funds are released. Owner-only; up to `MAX_RELEASE_MEMO_LEN`
+    /// bytes. Passing an empty `Bytes` clears the memo.
+    pub fn set_release_memo(
+        env: Env,
+        vault_id: u64,
+        caller: Address,
+        memo: Bytes,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        if memo.len() > MAX_RELEASE_MEMO_LEN {
+            return Err(ContractError::InvalidAmount);
+        }
+        let vault = Self::load_vault(&env, vault_id);
+        if caller != vault.owner {
+            return Err(ContractError::NotOwner);
+        }
+        if vault.status != ReleaseStatus::Locked {
+            return Err(ContractError::AlreadyReleased);
+        }
+        let key = DataKey::ReleaseMemo(vault_id);
+        let ttl = vault_ttl_ledgers(vault.check_in_interval);
+        env.storage().persistent().set(&key, &memo);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, VAULT_TTL_THRESHOLD, ttl);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_LEDGERS);
+        Ok(())
+    }
+
+    /// Returns the owner-supplied release memo for a vault, if any.
+    pub fn get_release_memo(env: Env, vault_id: u64) -> Bytes {
+        Self::load_release_memo(&env, vault_id)
     }
 
     /// Returns the custom metadata history (bytes + timestamp) for a vault.
@@ -13356,6 +13407,7 @@ impl TtlVaultContract {
         mode: ReleaseTrigger,
     ) {
         let token_client = token::Client::new(env, &vault.token_address);
+        let release_memo = Self::load_release_memo(env, vault_id);
 
         let triggers_map: Vec<(Address, Vec<ReleaseTrigger>)> = env
             .storage()
@@ -13461,6 +13513,7 @@ impl TtlVaultContract {
                     vault_id,
                     beneficiary: vault.owner.clone(),
                     amount: release_amount,
+                    memo: release_memo.clone(),
                 },
             );
             return;
@@ -13492,6 +13545,7 @@ impl TtlVaultContract {
                         vault_id,
                         beneficiary: entry.address.clone(),
                         amount: share,
+                        memo: release_memo.clone(),
                     },
                 );
             }

--- a/contracts/ttl_vault/src/release_memo_tests.rs
+++ b/contracts/ttl_vault/src/release_memo_tests.rs
@@ -1,0 +1,89 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Bytes, Env};
+
+fn setup_release_memo_test() -> (Env, Address, Address, TtlVaultContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let owner = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token_address = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    StellarAssetClient::new(&env, &token_address).mint(&owner, &10_000_000);
+
+    let contract_address = env.register_contract(None, TtlVaultContract);
+    let client = TtlVaultContractClient::new(&env, &contract_address);
+    client.initialize(&token_address, &admin);
+
+    let client: TtlVaultContractClient<'static> = unsafe { core::mem::transmute(client) };
+    (env, owner, beneficiary, client)
+}
+
+#[test]
+fn test_set_release_memo_succeeds() {
+    let (env, owner, beneficiary, client) = setup_release_memo_test();
+    let vault_id = client.create_vault(&owner, &beneficiary, &1_000u64, &None);
+
+    let memo = Bytes::from_slice(&env, b"For my family");
+    client.set_release_memo(&vault_id, &owner, &memo);
+
+    assert_eq!(client.get_release_memo(&vault_id), memo);
+}
+
+#[test]
+fn test_update_release_memo_overwrites_previous() {
+    let (env, owner, beneficiary, client) = setup_release_memo_test();
+    let vault_id = client.create_vault(&owner, &beneficiary, &1_000u64, &None);
+
+    let first = Bytes::from_slice(&env, b"Old memo");
+    let second = Bytes::from_slice(&env, b"New memo");
+    client.set_release_memo(&vault_id, &owner, &first);
+    client.set_release_memo(&vault_id, &owner, &second);
+
+    assert_eq!(client.get_release_memo(&vault_id), second);
+}
+
+#[test]
+fn test_release_memo_defaults_to_empty() {
+    let (_env, owner, beneficiary, client) = setup_release_memo_test();
+    let vault_id = client.create_vault(&owner, &beneficiary, &1_000u64, &None);
+
+    assert_eq!(client.get_release_memo(&vault_id).len(), 0);
+}
+
+#[test]
+fn test_set_release_memo_nil_clears_memo() {
+    let (env, owner, beneficiary, client) = setup_release_memo_test();
+    let vault_id = client.create_vault(&owner, &beneficiary, &1_000u64, &None);
+
+    client.set_release_memo(&vault_id, &owner, &Bytes::from_slice(&env, b"Something"));
+    client.set_release_memo(&vault_id, &owner, &Bytes::new(&env));
+
+    assert_eq!(client.get_release_memo(&vault_id).len(), 0);
+}
+
+#[test]
+#[should_panic(expected = "NotOwner")]
+fn test_set_release_memo_requires_owner() {
+    let (env, owner, beneficiary, client) = setup_release_memo_test();
+    let vault_id = client.create_vault(&owner, &beneficiary, &1_000u64, &None);
+    let stranger = Address::generate(&env);
+
+    client.set_release_memo(&vault_id, &stranger, &Bytes::from_slice(&env, b"Nope"));
+}
+
+#[test]
+#[should_panic(expected = "InvalidAmount")]
+fn test_set_release_memo_rejects_oversized_memo() {
+    let (env, owner, beneficiary, client) = setup_release_memo_test();
+    let vault_id = client.create_vault(&owner, &beneficiary, &1_000u64, &None);
+
+    let too_long = Bytes::from_slice(&env, &[0u8; 257]);
+    client.set_release_memo(&vault_id, &owner, &too_long);
+}

--- a/contracts/ttl_vault/src/types.rs
+++ b/contracts/ttl_vault/src/types.rs
@@ -341,6 +341,8 @@ pub const MAX_NOTES_LEN: u32 = 1024;
 
 /// Maximum length for custom metadata bytes (2KB) - Issue #378
 pub const MAX_CUSTOM_METADATA_LEN: u32 = 2048;
+/// Maximum length, in bytes, of a vault's release memo (Issue #791).
+pub const MAX_RELEASE_MEMO_LEN: u32 = 256;
 
 #[contracttype(export = false)]
 #[derive(Clone)]
@@ -405,6 +407,8 @@ pub enum DataKey {
     CheckInEntry(u64, u32),
     // Issue #873: ring buffer head pointer for check-in history
     CheckInHistoryHead(u64),
+    // Issue #791: owner-supplied release memo, emitted with the release event
+    ReleaseMemo(u64),
     // Issue #873: number of check-in history entries
     CheckInHistoryLen(u64),
     CheckInStreak(u64),
@@ -630,6 +634,7 @@ pub struct ReleaseEvent {
     pub vault_id: u64,
     pub beneficiary: Address,
     pub amount: i128,
+    pub memo: Bytes,
 }
 
 /// A single beneficiary entry: (address, basis_points, minimum_threshold).


### PR DESCRIPTION
## Summary
- Adds `DataKey::ReleaseMemo(u64)` persistent storage for an owner-supplied, up-to-256-byte release memo
- Adds owner-only `set_release_memo(env, vault_id, caller, memo)` and `get_release_memo(env, vault_id)`
- Includes the memo bytes in the `RELEASE_TOPIC` event (`ReleaseEvent.memo`) emitted on vault release

Closes #791

## Test plan
- Added `release_memo_tests.rs` covering set, update, default-empty, nil/clear, owner-only auth, and oversized-memo rejection
- `cargo build --lib` currently fails on `main` with ~563 pre-existing errors (duplicate const/enum definitions in `types.rs`, mismatched fn signatures) unrelated to this change — verified via `git stash` that the same errors exist without this diff. None of the errors reference this change's new symbols.