### PR TITLE
fix(vault): block trigger_release when vault-level pause is active

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -86,6 +86,8 @@ mod lifecycle_tests;
 #[cfg(test)]
 mod regression_tests;
 #[cfg(test)]
+mod vault_pause_release_tests;
+#[cfg(test)]
 mod beneficiary_waitlist_tests;
 #[cfg(test)]
 mod beneficiary_notification_tests;
@@ -277,6 +279,7 @@ pub enum ContractError {
     UpgradeTimelocked = 93,        // Issue #1120: Upgrade not yet executable
     UpgradeInvalidWasm = 94,       // Issue #1120: Invalid WASM hash
     TokenNotAllowed = 95,          // Issue #1118: Token not in allowlist
+    VaultPaused = 96,              // Issue #790: vault-level pause blocks trigger_release
 }
 
 #[contract]
@@ -2704,6 +2707,9 @@ impl TtlVaultContract {
         // Attempt to restore archived vault state before proceeding - Issue #443
         Self::try_restore_archived_vault(&env, vault_id);
         let mut vault = Self::load_vault(&env, vault_id);
+        if vault.is_paused {
+            panic_with_error!(&env, ContractError::VaultPaused);
+        }
         if Self::check_vault_frozen(&env, vault_id) {
             panic_with_error!(&env, ContractError::VaultFrozen);
         }

--- a/contracts/ttl_vault/src/vault_pause_release_tests.rs
+++ b/contracts/ttl_vault/src/vault_pause_release_tests.rs
@@ -1,0 +1,66 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::StellarAssetClient,
+    Address, Env,
+};
+
+fn setup() -> (Env, Address, Address, TtlVaultContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let owner = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token_address = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    StellarAssetClient::new(&env, &token_address).mint(&owner, &1_000_000);
+
+    let contract_address = env.register_contract(None, TtlVaultContract);
+    let client = TtlVaultContractClient::new(&env, &contract_address);
+    client.initialize(&token_address, &admin);
+
+    let client: TtlVaultContractClient<'static> = unsafe { core::mem::transmute(client) };
+    (env, owner, beneficiary, client)
+}
+
+#[test]
+#[should_panic(expected = "VaultPaused")]
+fn test_trigger_release_blocked_when_vault_paused() {
+    let (env, owner, beneficiary, client) = setup();
+    let interval = MIN_CHECK_IN_INTERVAL;
+    let vault_id = client.create_vault(&owner, &beneficiary, &interval, &None);
+    client.deposit(&vault_id, &owner, &100_000i128);
+
+    client.pause_vault(&vault_id, &owner);
+
+    // Expire the vault's TTL
+    let expired_at = env.ledger().timestamp() + interval + 1;
+    env.ledger().set_timestamp(expired_at);
+
+    // Vault-level pause must block release even though the contract-wide
+    // pause flag is untouched and the vault has expired.
+    client.trigger_release(&vault_id);
+}
+
+#[test]
+fn test_trigger_release_succeeds_after_resume() {
+    let (env, owner, beneficiary, client) = setup();
+    let interval = MIN_CHECK_IN_INTERVAL;
+    let vault_id = client.create_vault(&owner, &beneficiary, &interval, &None);
+    client.deposit(&vault_id, &owner, &100_000i128);
+
+    client.pause_vault(&vault_id, &owner);
+    client.resume_vault(&vault_id, &owner);
+
+    let expired_at = env.ledger().timestamp() + interval + 1;
+    env.ledger().set_timestamp(expired_at);
+
+    client.trigger_release(&vault_id);
+    assert_eq!(client.get_vault(&vault_id).status, ReleaseStatus::Released);
+}


### PR DESCRIPTION
## Summary
- `trigger_release_internal` now checks `vault.is_paused` and panics with the new `ContractError::VaultPaused` (96) before proceeding, in addition to the existing global contract pause check
- Previously only the global pause flag was checked, so a vault paused via `pause_vault` could still be released once its TTL expired

Closes #790

## Test plan
- Added `vault_pause_release_tests.rs`: pauses a vault, fast-forwards past TTL expiry, asserts `trigger_release` panics with `VaultPaused`; also verifies release succeeds normally after `resume_vault`
- `cargo build --lib` fails on `main` with ~563 pre-existing errors unrelated to this change (see PR #1235 for details); verified via `git stash` that these errors predate this diff