### PR TITLE
feat(vault): expose get_release_conditions as a public typed query

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -86,6 +86,8 @@ mod lifecycle_tests;
 #[cfg(test)]
 mod regression_tests;
 #[cfg(test)]
+mod release_conditions_query_tests;
+#[cfg(test)]
 mod beneficiary_waitlist_tests;
 #[cfg(test)]
 mod beneficiary_notification_tests;
@@ -2721,7 +2723,7 @@ impl TtlVaultContract {
         }
 
         // Load release conditions
-        let conditions = Self::get_release_conditions(&env, vault_id);
+        let conditions = Self::get_release_conditions(env.clone(), vault_id);
         let mut condition_met = false;
         for cond in conditions.iter() {
             match cond {
@@ -7512,12 +7514,13 @@ impl TtlVaultContract {
         Ok(())
     }
 
-    /// Helper to retrieve stored release conditions.
-    fn get_release_conditions(env: &Env, vault_id: u64) -> Vec<ReleaseCondition> {
+    /// Returns the release conditions attached to a vault.
+    /// Returns an empty vector if none have been set.
+    pub fn get_release_conditions(env: Env, vault_id: u64) -> Vec<ReleaseCondition> {
         env.storage()
             .persistent()
             .get(&DataKey::ReleaseConditions(vault_id))
-            .unwrap_or_else(|| Vec::new(env))
+            .unwrap_or_else(|| Vec::new(&env))
     }
 
     /// Owner‑initiated panic release.

--- a/contracts/ttl_vault/src/release_conditions_query_tests.rs
+++ b/contracts/ttl_vault/src/release_conditions_query_tests.rs
@@ -1,0 +1,63 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, vec, Address, Env};
+
+fn setup() -> (Env, Address, Address, TtlVaultContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let owner = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token_address = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    StellarAssetClient::new(&env, &token_address).mint(&owner, &1_000_000);
+
+    let contract_address = env.register_contract(None, TtlVaultContract);
+    let client = TtlVaultContractClient::new(&env, &contract_address);
+    client.initialize(&token_address, &admin);
+
+    let client: TtlVaultContractClient<'static> = unsafe { core::mem::transmute(client) };
+    (env, owner, beneficiary, client)
+}
+
+#[test]
+fn test_get_release_conditions_empty_by_default() {
+    let (env, owner, beneficiary, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &MIN_CHECK_IN_INTERVAL, &None);
+
+    let conditions = client.get_release_conditions(&vault_id);
+    assert_eq!(conditions, vec![&env]);
+}
+
+#[test]
+fn test_get_release_conditions_single() {
+    let (env, owner, beneficiary, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &MIN_CHECK_IN_INTERVAL, &None);
+
+    let expected = vec![&env, ReleaseCondition::TTLExpiry];
+    client.set_release_conditions(&vault_id, &owner, &expected);
+
+    assert_eq!(client.get_release_conditions(&vault_id), expected);
+}
+
+#[test]
+fn test_get_release_conditions_multiple() {
+    let (env, owner, beneficiary, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &MIN_CHECK_IN_INTERVAL, &None);
+    let oracle = Address::generate(&env);
+
+    let expected = vec![
+        &env,
+        ReleaseCondition::TTLExpiry,
+        ReleaseCondition::OwnerInitiated,
+        ReleaseCondition::Oracle(oracle),
+    ];
+    client.set_release_conditions(&vault_id, &owner, &expected);
+
+    assert_eq!(client.get_release_conditions(&vault_id), expected);
+}


### PR DESCRIPTION
## Summary
- Promotes the internal `get_release_conditions` helper to a `pub fn get_release_conditions(env: Env, vault_id: u64) -> Vec<ReleaseCondition>` contract query
- Returns an empty vector when no conditions have been set (unchanged behavior, now reachable without reading raw storage)

Closes #789

## Test plan
- Added `release_conditions_query_tests.rs` covering zero, one, and multiple conditions (including an `Oracle` condition)
- `cargo build --lib` fails on `main` with ~563 pre-existing errors unrelated to this change (see PR #1235 for details)