### PR TITLE
feat(vault): add get_passkey_last_used query

### DIFF
--- a/contracts/ttl_vault/src/lib.rs
+++ b/contracts/ttl_vault/src/lib.rs
@@ -86,6 +86,8 @@ mod lifecycle_tests;
 #[cfg(test)]
 mod regression_tests;
 #[cfg(test)]
+mod passkey_last_used_tests;
+#[cfg(test)]
 mod beneficiary_waitlist_tests;
 #[cfg(test)]
 mod beneficiary_notification_tests;
@@ -10118,6 +10120,32 @@ impl TtlVaultContract {
             });
         }
         result
+    }
+
+    /// Returns the last-used timestamp for a specific passkey, or `None` if
+    /// the passkey is not registered on the vault or has never been used.
+    pub fn get_passkey_last_used(
+        env: Env,
+        vault_id: u64,
+        passkey_hash: BytesN<32>,
+    ) -> Option<u64> {
+        let key = DataKey::VaultPasskeys(vault_id);
+        let passkeys: Vec<PasskeyHash> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Vec::new(&env));
+
+        for pk in passkeys.iter() {
+            if pk.hash == passkey_hash {
+                return if pk.last_used_timestamp == 0 {
+                    None
+                } else {
+                    Some(pk.last_used_timestamp)
+                };
+            }
+        }
+        None
     }
 
     // --- Issue #938: Passkey Challenge-Response Timeout ---

--- a/contracts/ttl_vault/src/passkey_last_used_tests.rs
+++ b/contracts/ttl_vault/src/passkey_last_used_tests.rs
@@ -1,0 +1,88 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::StellarAssetClient,
+    Address, BytesN, Env,
+};
+
+fn setup() -> (Env, Address, Address, TtlVaultContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let owner = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token_address = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    StellarAssetClient::new(&env, &token_address).mint(&owner, &1_000_000);
+
+    let contract_address = env.register_contract(None, TtlVaultContract);
+    let client = TtlVaultContractClient::new(&env, &contract_address);
+    client.initialize(&token_address, &admin);
+
+    let client: TtlVaultContractClient<'static> = unsafe { core::mem::transmute(client) };
+    (env, owner, beneficiary, client)
+}
+
+#[test]
+fn test_last_used_none_before_first_use() {
+    let (env, owner, beneficiary, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &MIN_CHECK_IN_INTERVAL, &None);
+    let passkey_hash = BytesN::<32>::from_array(&env, &[1u8; 32]);
+
+    client.add_passkey(&vault_id, &owner, &passkey_hash);
+
+    assert_eq!(client.get_passkey_last_used(&vault_id, &passkey_hash), None);
+}
+
+#[test]
+fn test_last_used_set_on_first_use() {
+    let (env, owner, beneficiary, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &MIN_CHECK_IN_INTERVAL, &None);
+    let passkey_hash = BytesN::<32>::from_array(&env, &[1u8; 32]);
+    client.add_passkey(&vault_id, &owner, &passkey_hash);
+
+    let checkin_time = env.ledger().timestamp() + 10;
+    env.ledger().set_timestamp(checkin_time);
+    client.check_in(&vault_id, &owner, &passkey_hash, &0u64);
+
+    assert_eq!(
+        client.get_passkey_last_used(&vault_id, &passkey_hash),
+        Some(checkin_time)
+    );
+}
+
+#[test]
+fn test_last_used_updates_on_subsequent_use() {
+    let (env, owner, beneficiary, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &MIN_CHECK_IN_INTERVAL, &None);
+    let passkey_hash = BytesN::<32>::from_array(&env, &[1u8; 32]);
+    client.add_passkey(&vault_id, &owner, &passkey_hash);
+
+    let first_checkin = env.ledger().timestamp() + 10;
+    env.ledger().set_timestamp(first_checkin);
+    client.check_in(&vault_id, &owner, &passkey_hash, &0u64);
+
+    let second_checkin = first_checkin + MIN_CHECK_IN_INTERVAL;
+    env.ledger().set_timestamp(second_checkin);
+    client.check_in(&vault_id, &owner, &passkey_hash, &0u64);
+
+    assert_eq!(
+        client.get_passkey_last_used(&vault_id, &passkey_hash),
+        Some(second_checkin)
+    );
+}
+
+#[test]
+fn test_last_used_none_for_unregistered_passkey() {
+    let (env, owner, beneficiary, client) = setup();
+    let vault_id = client.create_vault(&owner, &beneficiary, &MIN_CHECK_IN_INTERVAL, &None);
+    let unregistered = BytesN::<32>::from_array(&env, &[9u8; 32]);
+
+    assert_eq!(client.get_passkey_last_used(&vault_id, &unregistered), None);
+}


### PR DESCRIPTION
## Summary
- `PasskeyHash.last_used_timestamp` already exists and is updated on every check-in via `log_passkey_usage` (Issue #937), but there was no per-passkey query for it
- Adds `get_passkey_last_used(env, vault_id, passkey_hash) -> Option<u64>`, returning `None` when the passkey is not registered on the vault or has never been used, `Some(timestamp)` otherwise

Closes #785

## Test plan
- Added `passkey_last_used_tests.rs`: `None` before first use, `Some(timestamp)` set on first check-in, updated on subsequent check-in, and `None` for an unregistered passkey hash
- `cargo build --lib` fails on `main` with ~563 pre-existing errors unrelated to this change (see PR #1235 for details)